### PR TITLE
Removed sign_url hyperlink for badge and added lfcla.com for detail link

### DIFF
--- a/cla-backend/cla/models/github_models.py
+++ b/cla-backend/cla/models/github_models.py
@@ -647,7 +647,8 @@ def update_pull_request(installation_id, github_repository_id, pull_request, sig
             context, body = cla.utils.assemble_cla_status(author_name, signed=True)
             # sign_url = cla.utils.get_full_sign_url('github', installation_id, github_repository_id, pull_request.number)
             cla.log.info('Creating new CLA status on commit %s: %s', commit, state)
-            create_commit_status(pull_request, last_commit.sha, state, None, body, context)
+            sign_url = "https://lfcla.com" # Remove this once signature detail page ready.
+            create_commit_status(pull_request, last_commit.sha, state, sign_url, body, context)
 
 
 def create_commit_status(pull_request, commit_hash, state, sign_url, body, context):

--- a/cla-backend/cla/utils.py
+++ b/cla-backend/cla/utils.py
@@ -570,7 +570,7 @@ def get_comment_badge(repository_type, all_signed, sign_url):
         badge_url += '?signed=1'
     else:
         badge_url += '?signed=0'
-    return '[![CLA Check](' + badge_url + ')](' + sign_url + ')'
+    return '[![CLA Check](' + badge_url + ')]()'
 
 def assemble_cla_status(author_name, signed=False):
     """


### PR DESCRIPTION
1. Removes hyperlink for cla-sign status badge.
2. Adds https://lfcla.com as hyperlink for `detail` link for successful signs.

Signed-off-by: manikantanr <manikantanr@biarca.com>