### PR TITLE
Visual Cue: Loading: Project Console: Add Repo to CLA Check

### DIFF
--- a/cla-frontend-project-console/src/ionic/modals/cla-configure-github-repositories-modal/cla-configure-github-repositories-modal.html
+++ b/cla-frontend-project-console/src/ionic/modals/cla-configure-github-repositories-modal/cla-configure-github-repositories-modal.html
@@ -1,10 +1,16 @@
 <ion-header>
   <modal-header>
-    Configure Github Repositories
+    <ion-row class="align-items-center">
+      <div>Configure Github Repositories</div>
+      <div class="active-spinner">
+        <loading-spinner [loading]="loading.activateSpinner"></loading-spinner>
+      </div>
+    </ion-row>
   </modal-header>
 </ion-header>
 
 <ion-content>
+  <loading-spinner [loading]="loading.repositories"></loading-spinner>
   <ion-grid>
     <ion-row *ngFor="let organization of orgAndRepositories">
       <ion-col col-12 class="github-organization">
@@ -14,21 +20,15 @@
               {{ organization.organization_name }}
             </div>
             <div class="repositories">
-              <h4 class="repository"
-                  [ngClass]="{
+              <h4 class="repository" [ngClass]="{
                     'disabled': repository.status === 'taken',
                     'assigned': repository.status === 'assigned'
-                  }"
-                  *ngFor="let repository of organization.repositories">
+                  }" *ngFor="let repository of organization.repositories">
                 {{ repository.repository_name }}
-                <button type="button" ion-button color="light" size="small"
-                        *ngIf="repository.status === 'free'"
-                        (click)="assignRepository(repository)">
+                <button type="button" ion-button color="light" size="small" *ngIf="repository.status === 'free'" (click)="assignRepository(repository)">
                   Add
                 </button>
-                <button type="button" ion-button color="light" size="small" class="remove"
-                        *ngIf="repository.status === 'assigned'"
-                        (click)="removeRepository(repository)">
+                <button type="button" ion-button color="light" size="small" class="remove" *ngIf="repository.status === 'assigned'" (click)="removeRepository(repository)">
                   Remove
                 </button>
                 <button type="button" ion-button color="light" size="small" *ngIf="repository.status === 'taken'">Disabled</button>

--- a/cla-frontend-project-console/src/ionic/modals/cla-configure-github-repositories-modal/cla-configure-github-repositories-modal.scss
+++ b/cla-frontend-project-console/src/ionic/modals/cla-configure-github-repositories-modal/cla-configure-github-repositories-modal.scss
@@ -1,8 +1,12 @@
 cla-configure-github-repositories-modal {
 
-  .org-name {
-    font-size: 18px;
-    color: #7b7b7b;
+  .org-group {
+    display: flex;
+    align-items: center;
+  }
+
+  .active-spinner {
+    margin-left: 2rem;
   }
 
   .github-organization {

--- a/cla-frontend-project-console/src/ionic/modals/cla-configure-github-repositories-modal/cla-configure-github-repositories-modal.ts
+++ b/cla-frontend-project-console/src/ionic/modals/cla-configure-github-repositories-modal/cla-configure-github-repositories-modal.ts
@@ -1,9 +1,9 @@
 // Copyright The Linux Foundation and each contributor to CommunityBridge.
 // SPDX-License-Identifier: MIT
 
-import {Component} from '@angular/core';
-import {NavParams, ViewController, IonicPage, Events} from 'ionic-angular';
-import {ClaService} from '../../services/cla.service';
+import { Component } from '@angular/core';
+import { NavParams, ViewController, IonicPage, Events } from 'ionic-angular';
+import { ClaService } from '../../services/cla.service';
 
 @IonicPage({
   segment: 'cla-configure-github-repositories-modal'
@@ -13,6 +13,7 @@ import {ClaService} from '../../services/cla.service';
   templateUrl: 'cla-configure-github-repositories-modal.html'
 })
 export class ClaConfigureGithubRepositoriesModal {
+  loading: any;
   responseErrors: string[] = [];
   claProjectId: any;
   orgAndRepositories: any[];
@@ -25,10 +26,18 @@ export class ClaConfigureGithubRepositoriesModal {
     public events: Events
   ) {
     this.claProjectId = this.navParams.get('claProjectId');
+    this.getDefaults();
 
     events.subscribe('modal:close', () => {
       this.dismiss();
     });
+  }
+
+  getDefaults() {
+    this.loading = {
+      repositories: true,
+      activateSpinner: false
+    }
   }
 
   ngOnInit() {
@@ -44,6 +53,7 @@ export class ClaConfigureGithubRepositoriesModal {
     this.assignedRepositories = data['repositories'];
     this.orgAndRepositories = data['orgs_and_repos']
       .map(organization => {
+        this.loading.activateSpinner = false
         organization.repositories.map(repository => {
           repository.status = 'free';
           repository.repository_organization_name = organization.organization_name;
@@ -61,6 +71,7 @@ export class ClaConfigureGithubRepositoriesModal {
 
         return organization;
       });
+    this.loading.repositories = false
   }
 
   dismiss() {
@@ -85,8 +96,9 @@ export class ClaConfigureGithubRepositoriesModal {
   }
 
   assignRepository(repository) {
-    const payload = {...repository};
+    const payload = { ...repository };
     delete payload.status;
+    this.loading.activateSpinner = true
 
     payload.repository_project_id = this.claProjectId;
     payload.repository_external_id = payload.repository_github_id;
@@ -97,6 +109,7 @@ export class ClaConfigureGithubRepositoriesModal {
   }
 
   removeRepository(repository) {
+    this.loading.activateSpinner = true
     this.claService.removeProjectRepository(repository.repository_id)
       .subscribe(() => this.getOrgRepositories())
   }


### PR DESCRIPTION
Given a user of the project console (project.*.lfcla.com)
When the user clicks the "CONFIGURE GITHUB REPOSITORIES" button associated with a CLA group of a project, and clicks on one of the projects to "ADD" them
Then a loading animation (spinner) appears next to the repo name until added
Then display "REMOVE"

Given the load times out
Then an error message displays to the user within the context of the "View signatures" Modal
<img width="771" alt="Screen Shot 2019-08-01 at 2 45 20 PM" src="https://user-images.githubusercontent.com/11598255/62298610-3b3f1100-b46b-11e9-8345-fc426e1bf26a.png">



Signed-off-by: ngozi-ekekwe <rose.ekekwe@gmail.com>