### PR TITLE
Add Go Services API Documentation Endpoint

### DIFF
--- a/cla-backend-go/cmd/server.go
+++ b/cla-backend-go/cmd/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/communitybridge/easycla/cla-backend-go/company"
 	"github.com/communitybridge/easycla/cla-backend-go/config"
 	"github.com/communitybridge/easycla/cla-backend-go/docraptor"
+	"github.com/communitybridge/easycla/cla-backend-go/docs"
 	"github.com/communitybridge/easycla/cla-backend-go/gen/restapi"
 	"github.com/communitybridge/easycla/cla-backend-go/gen/restapi/operations"
 	"github.com/communitybridge/easycla/cla-backend-go/github"
@@ -132,6 +133,7 @@ func server(localMode bool) http.Handler {
 	template.Configure(api, templateService)
 	github.Configure(api, configFile.Github.ClientID, configFile.Github.ClientSecret, sessionStore)
 	whitelist.Configure(api, whitelistService, sessionStore)
+	docs.Configure(api)
 
 	company.Configure(api, companyService)
 

--- a/cla-backend-go/docs/doc.go
+++ b/cla-backend-go/docs/doc.go
@@ -1,0 +1,54 @@
+// Copyright The Linux Foundation and each contributor to CommunityBridge.
+// SPDX-License-Identifier: MIT
+
+package docs
+
+import (
+	"net/http"
+
+	"github.com/go-openapi/runtime"
+)
+
+// GetDocOK Success
+type GetDocOK struct {
+}
+
+// NewGetDocOK creates GetDocOK with default headers values
+func NewGetDocOK() *GetDocOK {
+	return &GetDocOK{}
+}
+
+// WriteResponse to the client
+func (o *GetDocOK) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+	html := `<!DOCTYPE html>
+	<html>
+	  <head>
+		<title>CLA Service Doc</title>
+		<!-- needed for adaptive design -->
+		<meta charset="utf-8"/>
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<link rel="shortcut icon" href="https://www.linuxfoundation.org/wp-content/uploads/2017/08/favicon.png">
+		<link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+
+		<!--
+		ReDoc doesn't change outer page styles
+		-->
+		<style>
+		  body {
+			margin: 0;
+			padding: 0;
+		  }
+		</style>
+	  </head>
+	  <body>
+		<redoc spec-url='/v3/swagger.json'></redoc>
+		<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+	  </body>
+	</html>`
+
+	rw.Header().Set("Content-Type", "text/html")
+	_, err := rw.Write([]byte(html))
+	if err != nil {
+		panic(err)
+	}
+}

--- a/cla-backend-go/docs/handlers.go
+++ b/cla-backend-go/docs/handlers.go
@@ -1,0 +1,17 @@
+// Copyright The Linux Foundation and each contributor to CommunityBridge.
+// SPDX-License-Identifier: MIT
+
+package docs
+
+import (
+	"github.com/communitybridge/easycla/cla-backend-go/gen/restapi/operations"
+	"github.com/communitybridge/easycla/cla-backend-go/gen/restapi/operations/docs"
+	"github.com/go-openapi/runtime/middleware"
+)
+
+// Configure setups handlers on api with Service
+func Configure(api *operations.ClaAPI) {
+	api.DocsGetDocHandler = docs.GetDocHandlerFunc(func(params docs.GetDocParams) middleware.Responder {
+		return NewGetDocOK()
+	})
+}

--- a/cla-backend-go/swagger/cla.yaml
+++ b/cla-backend-go/swagger/cla.yaml
@@ -43,6 +43,19 @@ paths:
           $ref: '#/responses/unauthorized'
         '403':
           $ref: '#/responses/forbidden'
+  /api-docs:
+    get:
+      security: []
+      summary: Get swagger documentation
+      operationId: getDoc
+      produces:
+        - text/html
+      responses:
+        200:
+          description: Success
+      tags:
+        - docs
+
   /project:
     get:
       summary: Get Project IDs based on PM


### PR DESCRIPTION
- Added /api-docs endpoint for the API documentation

Signed-off-by: David Deal <dealako@gmail.com>