### PR TITLE
Add link badge

### DIFF
--- a/cla-backend/cla/routes.py
+++ b/cla-backend/cla/routes.py
@@ -1390,18 +1390,18 @@ def sign_request(provider: hug.types.one_of(get_supported_repository_providers()
                                                            request)
 
 
-@hug.get('/repository-provider/{provider}/icon.svg', versions=2,
+@hug.get('/repository-provider/{provider}/icon.png', versions=2,
          output=hug.output_format.svg_xml_image)  # pylint: disable=no-member
 def change_icon(provider: hug.types.one_of(get_supported_repository_providers().keys()),
                 signed: hug.types.smart_boolean):
     """
-    GET: /repository-provider/{provider}/icon.svg
+    GET: /repository-provider/{provider}/icon.png
 
     TODO: This should probably be cached and web-accessible outside of the CLA.
 
     Returns the CLA status image for the provider requested.
     """
-    cla.log.debug('GET /v2/repository-provider/' + str(provider) + '/icon.svg')
+    cla.log.debug('GET /v2/repository-provider/' + str(provider) + '/icon.png')
     return cla.controllers.repository_service.change_icon(provider, signed)
 
 

--- a/cla-backend/cla/utils.py
+++ b/cla-backend/cla/utils.py
@@ -570,7 +570,7 @@ def get_comment_badge(repository_type, all_signed, sign_url):
         badge_url += '?signed=1'
     else:
         badge_url += '?signed=0'
-    return '[![CLA Check](' + badge_url + ')]()'
+    return '[![CLA Check](' + badge_url + ')](https://lfcla.com)'
 
 def assemble_cla_status(author_name, signed=False):
     """

--- a/cla-backend/cla/utils.py
+++ b/cla-backend/cla/utils.py
@@ -565,7 +565,7 @@ def get_comment_badge(repository_type, all_signed, sign_url):
     :param sign_url: The URL for the user to click in order to initiate signing.
     :type sign_url: string
     """
-    badge_url = '{}/v2/repository-provider/{}/icon.svg'.format(cla.conf['API_BASE_URL'], repository_type)
+    badge_url = '{}/v2/repository-provider/{}/icon.png'.format(cla.conf['API_BASE_URL'], repository_type)
     if all_signed:
         badge_url += '?signed=1'
     else:

--- a/cla-backend/cla/utils.py
+++ b/cla-backend/cla/utils.py
@@ -568,9 +568,11 @@ def get_comment_badge(repository_type, all_signed, sign_url):
     badge_url = '{}/v2/repository-provider/{}/icon.png'.format(cla.conf['API_BASE_URL'], repository_type)
     if all_signed:
         badge_url += '?signed=1'
+        badge_hyperlink = 'https://lfcla.com'
     else:
         badge_url += '?signed=0'
-    return '[![CLA Check](' + badge_url + ')](https://lfcla.com)'
+        badge_hyperlink = sign_url
+    return '[![CLA Check](' + badge_url + ')](' + badge_hyperlink + ')'
 
 def assemble_cla_status(author_name, signed=False):
     """


### PR DESCRIPTION
- Show lfcla.com if all commits are signed else show sign url if there are few unsigned, like detail link
- Changed SVG to PNG in routes, related to PR [94](https://github.com/communitybridge/easycla/pull/94l)