### PR TITLE
load badge icons from s3 instead of lambda

### DIFF
--- a/cla-backend/cla/controllers/repository_service.py
+++ b/cla-backend/cla/controllers/repository_service.py
@@ -19,13 +19,6 @@ def received_activity(provider, data):
     return result
 
 
-def change_icon(provider, signed=False):
-    """
-    Properly triages the change icon request to the appropriate provider.
-    """
-    return cla.utils.change_icon(provider, signed)
-
-
 def oauth2_redirect(provider, state, code, installation_id, github_repository_id, change_request_id, request): # pylint: disable=too-many-arguments
     """
     Properly triages the OAuth2 redirect to the appropriate provider.

--- a/cla-backend/cla/routes.py
+++ b/cla-backend/cla/routes.py
@@ -1391,49 +1391,6 @@ def sign_request(provider: hug.types.one_of(get_supported_repository_providers()
                                                            request)
 
 
-@hug.get('/repository-provider/{provider}/icon.png', versions=2,
-         output=hug.output_format.png_image)  # pylint: disable=no-member
-def change_icon(provider: hug.types.one_of(get_supported_repository_providers().keys()),
-                signed: hug.types.smart_boolean):
-    """
-    GET: /repository-provider/{provider}/icon.png
-
-    TODO: This should probably be cached and web-accessible outside of the CLA.
-
-    Returns the CLA status image for the provider requested.
-    """
-    cla.log.debug('GET /v2/repository-provider/' + str(provider) + '/icon.png')
-    return cla.controllers.repository_service.change_icon(provider, signed)
-
-
-@hug.get('/repository-provider/{provider}/cla-notsigned.png', versions=2,
-         output=hug.output_format.png_image)  # pylint: disable=no-member
-def cla_notsigned_icon(provider: hug.types.one_of(get_supported_repository_providers().keys())):
-    """
-    GET: /repository-provider/{provider}/cla-notsigned.png
-
-    TODO: This should probably be cached and web-accessible outside of the CLA.
-
-    Returns the CLA status image for the provider requested.
-    """
-    cla.log.debug('GET /v2/repository-provider/' + str(provider) + '/cla-notsigned.png')
-    return 'cla/resources/cla-notsigned.png'
-
-
-@hug.get('/repository-provider/{provider}/cla-signed.png', versions=2,
-         output=hug.output_format.png_image)  # pylint: disable=no-member
-def cla_signed_icon(provider: hug.types.one_of(get_supported_repository_providers().keys())):
-    """
-    GET: /repository-provider/{provider}/icon.png
-
-    TODO: This should probably be cached and web-accessible outside of the CLA.
-
-    Returns the CLA status image for the provider requested.
-    """
-    cla.log.debug('GET /v2/repository-provider/' + str(provider) + '/cla-signed.png')
-    return 'cla/resources/cla-signed.png'
-
-
 @hug.get('/repository-provider/{provider}/oauth2_redirect', versions=2)
 def oauth2_redirect(auth_user: check_auth,  # pylint: disable=too-many-arguments
                     provider: hug.types.one_of(get_supported_repository_providers().keys()),

--- a/cla-backend/cla/utils.py
+++ b/cla-backend/cla/utils.py
@@ -19,6 +19,7 @@ from hug.store import InMemoryStore as Store
 import cla
 
 api_base_url = os.environ.get('CLA_API_BASE', '')
+cla_logo_url = os.environ.get('CLA_BUCKET_LOGO_URL', '')
 
 def get_cla_path():
     """Returns the CLA code root directory on the current system."""
@@ -567,10 +568,10 @@ def get_comment_badge(repository_type, all_signed, sign_url):
     """
 
     if all_signed:
-        badge_url = '{}/v2/repository-provider/{}/cla-signed.png'.format(cla.conf['API_BASE_URL'], repository_type)
+        badge_url = '{}/cla-signed.png'.format(cla_logo_url)
         badge_hyperlink = 'https://lfcla.com'
     else:
-        badge_url = '{}/v2/repository-provider/{}/cla-notsigned.png'.format(cla.conf['API_BASE_URL'], repository_type)
+        badge_url = '{}/cla-notsigned.png'.format(cla_logo_url)
         badge_hyperlink = sign_url
     return '[![CLA Check](' + badge_url + ')](' + badge_hyperlink + ')'
 
@@ -932,25 +933,6 @@ def request_individual_signature(installation_id, github_repository_id, user, ch
                   'to return_url instead')
     raise falcon.HTTPFound(return_url)
 
-def change_icon(provider, signed=False): # pylint: disable=unused-argument
-    """
-    Function called when the code chagne image/icon is requested.
-
-    This will be a badge for GitHub and GitLab providers.
-
-    TODO: Fire a hook here with the provider and signed variables as parameters. This will allow
-    customizeable change icon images.
-
-    :param provider: The repository service provider asking for the change icon image.
-    :type provider: string
-    :param signed: Whether this image is for a signed or unsigned CLA.
-    :type signed: boolean
-    :return: Anything compatible with hug's output_format.svg_xml_image.
-    :rtype: file path | file handler | Pillow Image
-    """
-    if signed:
-        return 'cla/resources/cla-signed.png'
-    return 'cla/resources/cla-notsigned.png'
 
 def get_oauth_client():
     return OAuth2Session(os.environ['GH_OAUTH_CLIENT_ID'])


### PR DESCRIPTION
- Load PR badge icons from S3.
- Removed the functions which serves badges from lambda


Signed-off-by: manikantanr <manikantanr@biarca.com>