### PR TITLE
CLA-907: Help for PMs to get access to Projects

### DIFF
--- a/cla-frontend-project-console/src/ionic/pages/all-projects/all-projects.html
+++ b/cla-frontend-project-console/src/ionic/pages/all-projects/all-projects.html
@@ -23,7 +23,13 @@
       <ion-row>
         <ion-col>
           <ion-item no-lines class="transparent">
-            <h2>All Projects</h2>
+            <h2 class="all-projects-title"><b>All Projects</b></h2>
+          </ion-item>
+        </ion-col>
+        <ion-col>
+          <ion-item no-lines class="transparent text-right">
+            <p class="get-access-label">Don't see all your projects here?</p>
+            <button class="transparent get-access-button" (click)="openAccessPage()">Get Access</button>
           </ion-item>
         </ion-col>
       </ion-row>

--- a/cla-frontend-project-console/src/ionic/pages/all-projects/all-projects.scss
+++ b/cla-frontend-project-console/src/ionic/pages/all-projects/all-projects.scss
@@ -4,6 +4,20 @@ all-projects {
   -ms-user-select: text;
   user-select: text;
 
+  .all-projects-title {
+    color: color($colors, dark) !important;
+  }
+
+  .get-access-button {
+    color: color($colors, secondary) !important;
+    font-size: 14px;
+    padding: 1rem;
+  }
+
+  .get-access-label {
+    color: color($colors, dark) !important;
+  }
+
   .navbar-logo {
     width: 100px;
     position: absolute;

--- a/cla-frontend-project-console/src/ionic/pages/all-projects/all-projects.ts
+++ b/cla-frontend-project-console/src/ionic/pages/all-projects/all-projects.ts
@@ -94,4 +94,8 @@ export class AllProjectsPage {
       );
     }
   }
+
+  openAccessPage() {
+    window.open("https://docs.linuxfoundation.org/pages/viewpage.action?pageId=7411265", "_blank");
+  }
 }


### PR DESCRIPTION
Given the projects page on the project manager console
When the page loads
Then the following text appears with "Get Access" linked to: https://docs.linuxfoundation.org/x/QRZx [NOTE: Currently internal LF doc only]:
"Don't see your projects here?
Get Access"

<img width="1276" alt="Screen Shot 2019-08-08 at 5 21 01 PM" src="https://user-images.githubusercontent.com/11598255/62720055-203b4680-ba01-11e9-9b20-3f2e88151fc4.png">


Signed-off-by: ngozi-ekekwe <rose.ekekwe@gmail.com>