### PR TITLE
Company Query by User Manager and Combined User and Invite Query

### DIFF
--- a/cla-backend-go/cmd/root.go
+++ b/cla-backend-go/cmd/root.go
@@ -33,6 +33,8 @@ func init() {
 
 		// should we validate the user's GitHub organizations?
 		"GH_ORG_VALIDATION": "true",
+		// should we validate company API queries against the current authenticated user?
+		"COMPANY_USER_VALIDATION": "true",
 	}
 
 	for key, value := range defaults {

--- a/cla-backend-go/cmd/server.go
+++ b/cla-backend-go/cmd/server.go
@@ -78,22 +78,28 @@ func server(localMode bool) http.Handler {
 	if err != nil {
 		log.Fatalf("GH_ORG_VALIDATION value must be a boolean string. Error: %v", err)
 	}
+	// Grab a couple of configuration settings
+	companyUserValidation, err := strconv.ParseBool(viper.GetString("COMPANY_USER_VALIDATION"))
+	if err != nil {
+		log.Fatalf("COMPANY_USER_VALIDATION value must be a boolean string. Error: %v", err)
+	}
 	stage := viper.GetString("STAGE")
 
 	log.Infof("Service %s starting...", ini.ServiceName)
 
 	// Show the version and build info
-	log.Infof("Name                  : %s", ini.ServiceName)
-	log.Infof("Version               : %s", Version)
-	log.Infof("Git commit hash       : %s", Commit)
-	log.Infof("Branch                : %s", Branch)
-	log.Infof("Build date            : %s", BuildDate)
-	log.Infof("Golang OS             : %s", runtime.GOOS)
-	log.Infof("Golang Arch           : %s", runtime.GOARCH)
-	log.Infof("GH_ORG_VALIDATION     : %t", githubOrgValidation)
-	log.Infof("STAGE                 : %s", stage)
-	log.Infof("Service Host          : %s", host)
-	log.Infof("Service Port          : %d", *portFlag)
+	log.Infof("Name                    : %s", ini.ServiceName)
+	log.Infof("Version                 : %s", Version)
+	log.Infof("Git commit hash         : %s", Commit)
+	log.Infof("Branch                  : %s", Branch)
+	log.Infof("Build date              : %s", BuildDate)
+	log.Infof("Golang OS               : %s", runtime.GOOS)
+	log.Infof("Golang Arch             : %s", runtime.GOARCH)
+	log.Infof("GH_ORG_VALIDATION       : %t", githubOrgValidation)
+	log.Infof("COMPANY_USER_VALIDATION : %t", companyUserValidation)
+	log.Infof("STAGE                   : %s", stage)
+	log.Infof("Service Host            : %s", host)
+	log.Infof("Service Port            : %d", *portFlag)
 
 	awsSession, err := ini.GetAWSSession()
 	if err != nil {
@@ -154,7 +160,7 @@ func server(localMode bool) http.Handler {
 	signatures.Configure(api, signaturesService, sessionStore)
 	docs.Configure(api)
 
-	company.Configure(api, companyService)
+	company.Configure(api, companyService, companyUserValidation)
 
 	// For local mode - we allow anything, otherwise we use the value specified in the config (e.g. AWS SSM)
 	var apiHandler http.Handler

--- a/cla-backend-go/swagger/cla.yaml
+++ b/cla-backend-go/swagger/cla.yaml
@@ -657,6 +657,64 @@ paths:
       tags:
         - company
 
+  /company/user/{userID}:
+    get:
+      summary: API to retrieve a list of companies where the user is the manager
+      security:
+        - OauthSecurity:
+            - company
+      operationId: getCompaniesByUserManager
+      parameters:
+        - name: userID
+          description: the user ID of the user manager
+          in: path
+          type: string
+          required: true
+      responses:
+        '200':
+          description: 'Success'
+          schema:
+            $ref: '#/definitions/companies'
+        '400':
+          $ref: '#/responses/invalid-request'
+        '401':
+          $ref: '#/responses/unauthorized'
+        '403':
+          $ref: '#/responses/forbidden'
+        '404':
+          $ref: '#/responses/not-found'
+      tags:
+        - company
+
+  /company/user/{userID}/invites:
+    get:
+      summary: API to retrieve a list of companies where the user is the manager (approved) and in the invite list
+      security:
+        - OauthSecurity:
+            - company
+      operationId: getCompaniesByUserManagerWithInvites
+      parameters:
+        - name: userID
+          description: the user ID of the user manager
+          in: path
+          type: string
+          required: true
+      responses:
+        '200':
+          description: 'Success'
+          schema:
+            $ref: '#/definitions/companies-with-invites'
+        '400':
+          $ref: '#/responses/invalid-request'
+        '401':
+          $ref: '#/responses/unauthorized'
+        '403':
+          $ref: '#/responses/forbidden'
+        '404':
+          $ref: '#/responses/not-found'
+      tags:
+        - company
+
   /company/search:
     get:
       summary: Search companies
@@ -1109,6 +1167,8 @@ definitions:
         type: string
       status:
         type: string
+      companyName:
+        type: string
 
   access-list-user:
     type: object
@@ -1306,6 +1366,28 @@ definitions:
         items:
           $ref: '#/definitions/company'
 
+  companies-with-invites:
+    type: object
+    x-nullable: false
+    title: Companies
+    description: A list of companies with invitation status
+    properties:
+      resultCount:
+        type: integer
+        format: int64
+        x-omitempty: false
+      totalCount:
+        type: integer
+        format: int64
+        x-omitempty: false
+      lastKeyScanned:
+        type: string
+      companies-with-invites:
+        type: array
+        x-omitempty: false
+        items:
+          $ref: '#/definitions/company-with-invite'
+
   company:
     type: object
     x-nullable: false
@@ -1325,6 +1407,37 @@ definitions:
         description: A list of user ID's authorized to make changes to the company
         items:
           type: string
+      created:
+        type: string
+        description: The company record created date/time
+        format: date-time
+      updated:
+        type: string
+        description: The company record update date/time
+        format: date-time
+
+  company-with-invite:
+    type: object
+    x-nullable: false
+    title: Company
+    description: Company Model with Invitation status
+    properties:
+      companyID:
+        description: The company unique ID
+        example: 13f79a8f-734d-44c1-ab03-ab98c2a1b64a
+        type: string
+      companyName:
+        description: The company name
+        example: Acme, Inc.
+        type: string
+      companyACL:
+        type: array
+        description: A list of user ID's authorized to make changes to the company
+        items:
+          type: string
+      status:
+        type: string
+        description: The user's invitation status
       created:
         type: string
         description: The company record created date/time


### PR DESCRIPTION
- Added query company by user manager v3 go endpoint - replaces v1/v2 python
- Added new company by user manager plus invites query v3 go endpoint - useful
  to return a list of companies and pending invites for a given user -
  in support of the UX
- added UI endpoints for UI team to leverage

Signed-off-by: David Deal <dealako@gmail.com>