### PR TITLE
Allow Bots to be Whitelisted and Affiliated Automatically

### DIFF
--- a/cla-backend-go/signatures/repository.go
+++ b/cla-backend-go/signatures/repository.go
@@ -873,7 +873,7 @@ func (repo repository) buildProjectSignatureModels(results *dynamodb.QueryOutput
 
 			if dbSignature.SignatureReferenceType == "user" {
 				userModel, userErr := repo.usersRepo.GetUser(dbSignature.SignatureReferenceID)
-				if userErr != nil {
+				if userErr != nil || userModel == nil {
 					log.Warnf("unable to lookup user using id: %s, error: %v", dbSignature.SignatureReferenceID, userErr)
 				} else {
 					userName = userModel.Username
@@ -903,11 +903,14 @@ func (repo repository) buildProjectSignatureModels(results *dynamodb.QueryOutput
 				SignatureCreated:       dbSignature.DateCreated,
 				SignatureModified:      dbSignature.DateModified,
 				SignatureType:          dbSignature.SignatureType,
+				SignatureReferenceID:   dbSignature.SignatureReferenceID,
 				SignatureSigned:        dbSignature.SignatureSigned,
 				SignatureApproved:      dbSignature.SignatureApproved,
 				Version:                dbSignature.SignatureDocumentMajorVersion + "." + dbSignature.SignatureDocumentMinorVersion,
 				SignatureReferenceType: dbSignature.SignatureReferenceType,
 				ProjectID:              dbSignature.SignatureProjectID,
+				Created:                dbSignature.DateCreated,
+				Modified:               dbSignature.DateModified,
 				UserName:               userName,
 				UserLFID:               userLFID,
 				UserGHID:               userGHID,

--- a/cla-backend-go/swagger/cla.yaml
+++ b/cla-backend-go/swagger/cla.yaml
@@ -1566,6 +1566,8 @@ definitions:
         type: boolean
       signatureReferenceType:
         type: string
+      signatureReferenceID:
+        type: string
       signatureType:
         type: string
       userName:
@@ -1579,6 +1581,10 @@ definitions:
       userLFID:
         type: string
       version:
+        type: string
+      created:
+        type: string
+      modified:
         type: string
       emailWhitelist:
         type: array

--- a/cla-backend/cla/config.py
+++ b/cla-backend/cla/config.py
@@ -18,7 +18,7 @@ stage = os.environ.get('STAGE', '')
 
 LOG_LEVEL = logging.DEBUG  #: Logging level.
 #: Logging format.
-LOG_FORMAT = logging.Formatter('%(asctime)s %(levelname)-8s %(name)s: %(message)s')
+LOG_FORMAT = logging.Formatter(fmt='%(asctime)s %(levelname)s %(name)s: %(message)s', datefmt='%Y-%m-%dT%H:%M:%S')
 
 DEBUG = False  #: Debug off in production
 

--- a/cla-backend/cla/test_utils.py
+++ b/cla-backend/cla/test_utils.py
@@ -1,0 +1,88 @@
+# Copyright The Linux Foundation and each contributor to CommunityBridge.
+# SPDX-License-Identifier: MIT
+import logging
+import unittest
+
+import cla
+from cla import utils
+from cla.models.dynamo_models import User
+
+
+class TestUtils(unittest.TestCase):
+    tests_enabled = False
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        pass
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        pass
+
+    def setUp(self) -> None:
+        # Only show critical logging stuff
+        cla.log.level = logging.CRITICAL
+
+    def tearDown(self) -> None:
+        pass
+
+    def test_user_get_user_by_username(self) -> None:
+        """
+        Test that we can get a user by username
+        """
+        # TODO - should use mock data - disable tests for now :-(
+        if self.tests_enabled:
+            user_instance = utils.get_user_instance()
+            users = user_instance.get_user_by_username('ddeal')
+            self.assertIsNotNone(users, 'User lookup by username is not None')
+            self.assertEqual(len(users), 1, 'User lookup by username found 1')
+
+            # some invalid username
+            users = user_instance.get_user_by_username('foo')
+            self.assertIsNone(users, 'User lookup by username is None')
+
+    def test_user_get_user_by_email(self) -> None:
+        """
+        Test that we can get a user by email
+        """
+        # TODO - should use mock data - disable tests for now :-(
+        if self.tests_enabled:
+            users = User().get_user_by_email('ddeal@linuxfoundation.org')
+            self.assertIsNotNone(users, 'User lookup by email is not None')
+            self.assertEqual(len(users), 1, 'User lookup by email found 1')
+
+            # some invalid email
+            users = User().get_user_by_email('foo@bar.org')
+            self.assertIsNone(users, 'User lookup by email is None')
+
+    def test_user_get_user_by_github_id(self) -> None:
+        """
+        Test that we can get a user by github id
+        """
+        # TODO - should use mock data - disable tests for now :-(
+        if self.tests_enabled:
+            users = User().get_user_by_github_id(519609)
+            self.assertIsNotNone(users, 'User lookup by github id is not None')
+            self.assertEqual(len(users), 2, 'User lookup by github id found 2')
+
+            # some invalid number
+            users = User().get_user_by_github_id(9999999)
+            self.assertIsNone(users, 'User lookup by github id is None')
+
+    def test_user_get_user_by_github_username(self) -> None:
+        """
+        Test that we can get a user by github username
+        """
+        # TODO - should use mock data - disable tests for now :-(
+        if self.tests_enabled:
+            users = User().get_user_by_github_username('dealako')
+            self.assertIsNotNone(users, 'User lookup by github username is not None')
+            self.assertEqual(len(users), 1, 'User lookup by github username found 1')
+
+            # some invalid username
+            users = User().get_user_by_github_username('foooooo')
+            self.assertIsNone(users, 'User lookup by github username is None')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/cla-frontend-corporate-console/src/ionic/modals/whitelist-modal/whitelist-modal.html
+++ b/cla-frontend-corporate-console/src/ionic/modals/whitelist-modal/whitelist-modal.html
@@ -1,7 +1,7 @@
 <ion-header>
   <ion-toolbar>
     <ion-title>
-      <span>Edit {{type | titlecase}} Whitelist</span>
+      <span>Edit {{type | titlecase}} Whitelist for {{ companyName | titlecase }}</span>
     </ion-title>
     <ion-buttons start>
       <button ion-button (click)="dismiss()">
@@ -21,7 +21,8 @@
       </ion-row>
       <ion-row>
         <ion-col col-12>
-          <button type="button" ion-button class="clickable" (click)="addNewWhitelistItem()">Add {{type}}</button  >
+          <button type="button" ion-button class="clickable" (click)="addNewWhitelistItem()">Add {{type}}</button>
+          <p *ngIf="type === 'github'">Note: Any GitHub bots you whitelist will be automatically affiliated to {{companyName}} on {{projectName}}.</p>
         </ion-col>
       </ion-row>
       <ion-row *ngFor="let item of form.controls.whitelist.controls; let i = index" [formGroupName]="i">

--- a/cla-frontend-corporate-console/src/ionic/modals/whitelist-modal/whitelist-modal.ts
+++ b/cla-frontend-corporate-console/src/ionic/modals/whitelist-modal/whitelist-modal.ts
@@ -20,6 +20,10 @@ export class WhitelistModal {
   currentlySubmitting: boolean;
 
   type: string;
+  companyName: string;
+  projectName: string;
+  projectId: string;
+  companyId: string;
   signatureId: string;
   whitelist: string[];
 
@@ -34,6 +38,10 @@ export class WhitelistModal {
 
   getDefaults() {
     this.type = this.navParams.get("type"); // ['email' | 'domain' | 'github']
+    this.companyName = this.navParams.get('companyName');
+    this.projectName = this.navParams.get('projectName');
+    this.projectId = this.navParams.get('projectId');
+    this.companyId = this.navParams.get('companyId');
     this.signatureId = this.navParams.get('signatureId');
     this.whitelist = this.navParams.get('whitelist') || [];
 
@@ -129,15 +137,21 @@ export class WhitelistModal {
     }
 
     let signature = new ClaSignatureModel();
+    signature.signature_project_id = this.projectId;
+    signature.signature_reference_id = this.companyId; // CCLA, so signature_reference_id is the company id
     signature.signature_id = this.signatureId;
 
+    // ['email' | 'domain' | 'github']
     if (this.type === "domain") {
+      // TODO: apply filter to remove duplicates
       signature.domain_whitelist = this.extractWhitelist();
     } else if (this.type === "email") {
       //email
+      // TODO: apply filter to remove duplicates
       signature.email_whitelist = this.extractWhitelist();
     } else {
       //github username
+      // TODO: apply filter to remove duplicates
       signature.github_whitelist = this.extractWhitelist();
     }
 

--- a/cla-frontend-corporate-console/src/ionic/pages/project-page/project-page.html
+++ b/cla-frontend-corporate-console/src/ionic/pages/project-page/project-page.html
@@ -3,7 +3,7 @@
     <button ion-button menuToggle>
       <ion-icon name="menu"></ion-icon>
     </button>
-    <ion-title>Project Signatures</ion-title>
+    <ion-title>{{ cclaSignature.companyName || titlecase }} Project Signatures</ion-title>
     <img class="navbar-logo" src="/assets/logo/cp_app_easycla.svg" alt="">
   </ion-navbar>
 </ion-header>
@@ -110,7 +110,7 @@
       </ion-col>
       <ion-col col-12 col-md-8>
         <div class="table-responsive-vertical">
-          <h2>Employee Acknowledgements</h2>
+          <h2>{{ cclaSignature.companyName | titlecase }} Employee Acknowledgements</h2>
           <table class="table table-hover">
             <thead>
               <tr>
@@ -129,13 +129,13 @@
             <tbody>
               <tr *ngFor="let signature of employeeSignatures">
                 <td data-title="Name">
-                  <span *ngIf="users[signature.signature_reference_id]">{{ users[signature.signature_reference_id].user_name }}</span>
+                  <span *ngIf="users[signature.signatureReferenceID]">{{ users[signature.signatureReferenceID].user_name }}</span>
                 </td>
                 <td data-title="Agreement">
-                  v{{ signature.signature_document_major_version}}.{{signature.signature_document_minor_version }}
+                  v{{ signature.version}}
                 </td>
                 <td data-title="Date">
-                  {{ signature.date_modified | date:'medium' }}
+                  {{ signature.modified | date:'medium' }}
                 </td>
               </tr>
             </tbody>

--- a/cla-frontend-corporate-console/src/ionic/pages/project-page/project-page.ts
+++ b/cla-frontend-corporate-console/src/ionic/pages/project-page/project-page.ts
@@ -90,8 +90,8 @@ export class ProjectPage {
   getProject() {
     // console.log('Loading project: ' + this.projectId);
     this.claService.getProject(this.projectId).subscribe(response => {
-      // console.log('Project response:');
-      // console.log(response);
+      console.log('Project response:');
+      console.log(response);
       this.project = response;
       this.getProjectSignatures();
     });
@@ -166,12 +166,12 @@ export class ProjectPage {
     // get employee signatures
     this.claService.getEmployeeProjectSignatures(this.companyId, this.projectId)
       .subscribe(response => {
-          // console.log('Employee signatures:');
-          // console.log(response);
+          console.log('Employee signatures:');
+          console.log(response);
           if (response.signatures) {
-            this.employeeSignatures = response;
+            this.employeeSignatures = response.signatures || [];
             for (let signature of this.employeeSignatures) {
-              this.getUser(signature.signatureReferenceType);
+              this.loadUser(signature.signatureReferenceID);
             }
           }
         },
@@ -184,14 +184,18 @@ export class ProjectPage {
   }
 
   getManager(userId) {
+    console.log('Looking up manager: ' + userId);
     this.claService.getUser(userId).subscribe(response => {
       this.manager = response;
     });
   }
 
-  getUser(userId) {
+  loadUser(userId) {
+    console.log('Looking up user: ' + userId);
     if (!this.users[userId]) {
       this.claService.getUser(userId).subscribe(response => {
+        console.log('Loaded user:');
+        console.log(response);
         this.users[userId] = response;
       });
     }
@@ -200,6 +204,10 @@ export class ProjectPage {
   openWhitelistEmailModal() {
     let modal = this.modalCtrl.create("WhitelistModal", {
       type: "email",
+      projectName: this.project.project_name,
+      companyName: this.cclaSignature.companyName,
+      projectId: this.cclaSignature.projectID,
+      companyId: this.companyId,
       signatureId: this.cclaSignature.signatureID,
       whitelist: this.cclaSignature.emailWhitelist
     });
@@ -213,6 +221,9 @@ export class ProjectPage {
   openWhitelistDomainModal() {
     let modal = this.modalCtrl.create("WhitelistModal", {
       type: "domain",
+      projectName: this.project.project_name,
+      companyName: this.cclaSignature.companyName,
+      projectId: this.cclaSignature.projectID,
       signatureId: this.cclaSignature.signatureID,
       whitelist: this.cclaSignature.domainWhitelist
     });
@@ -226,6 +237,9 @@ export class ProjectPage {
   openWhitelistGithubModal() {
     let modal = this.modalCtrl.create("WhitelistModal", {
       type: "github",
+      projectName: this.project.project_name,
+      companyName: this.cclaSignature.companyName,
+      projectId: this.cclaSignature.projectID,
       signatureId: this.cclaSignature.signatureID,
       whitelist: this.cclaSignature.githubWhitelist
     });
@@ -289,11 +303,16 @@ export class ProjectPage {
             let cclaSignatures = response.filter(sig => sig.signatureType === 'ccla');
             if (cclaSignatures.length) {
               this.cclaSignature = cclaSignatures[0];
+              console.log('CCLA Signature:');
+              console.log(this.cclaSignature);
               this.getCLAManagers();
               this.getGitHubOrgWhitelist();
 
               // Ok to open the modal now that we have signatures loaded
               let modal = this.modalCtrl.create("GithubOrgWhitelistModal", {
+                projectName: this.project.project_name,
+                companyName: this.cclaSignature.companyName,
+                projectId: this.cclaSignature.projectID,
                 companyId: this.companyId,
                 corporateClaId: this.projectId,
                 signatureId: this.cclaSignature.signatureID
@@ -312,6 +331,9 @@ export class ProjectPage {
           });
     } else {
       let modal = this.modalCtrl.create("GithubOrgWhitelistModal", {
+        projectName: this.project.project_name,
+        companyName: this.cclaSignature.companyName,
+        projectId: this.cclaSignature.projectID,
         companyId: this.companyId,
         corporateClaId: this.projectId,
         signatureId: this.cclaSignature.signatureID

--- a/cla-frontend-corporate-console/src/ionic/services/cla.service.ts
+++ b/cla-frontend-corporate-console/src/ionic/services/cla.service.ts
@@ -1303,10 +1303,14 @@ export class ClaService {
     if (error.status && error._body && error.status === 500 && error._body.includes('Token is expired')) {
       console.log(error._body + ' - redirecting to login page');
       this.authService.logout();
+      window.location.hash = '#/login';
+      window.location.reload(true);
       return Observable.throw(error);
     } else if (error.status && error.status === 401) {
       console.log(error._body + ' - redirecting to login page');
       this.authService.logout();
+      window.location.hash = '#/login';
+      window.location.reload(true);
       return Observable.throw(error);
     }
 


### PR DESCRIPTION
- Updated logic to detect when bots are added to the GitHub whitelist
- Auto-creates a bot user in the EasyCLA system when a bot is added to the GitHub whitelist
- Auto-creates a bot signature in the EasyClA system when a bot is added to the GitHub whitelist
- Added database node column support for users and signatures tables
- Attempted to clean up logging config
- Added defensive code to Go backend when looking up signatures
- Updated project/signatures response model to include the signature reference id, version and created/modified date/time values
- Added company name to whitelist modals
- Added GitHub bot note to the GitHub whitelist modal
- Provided company and project name details to whitelist modal parameters
- Added company name to corporate console company page

Resolves: #284
Signed-off-by: David Deal <dealako@gmail.com>