### PR TITLE
GitHub Org Whitelist: Allow freeform input

### DIFF
--- a/cla-backend/cla/controllers/signature.py
+++ b/cla-backend/cla/controllers/signature.py
@@ -140,7 +140,8 @@ def update_signature(signature_id,  # pylint: disable=too-many-arguments,too-man
                      signature_sign_url=None,
                      domain_whitelist=None,
                      email_whitelist=None,
-                     github_whitelist=None):
+                     github_whitelist=None,
+                     github_org_whitelist=None):
     """
     Updates an signature and returns the newly updated signature in dict format.
     A value of None means the field should not be updated.
@@ -163,6 +164,10 @@ def update_signature(signature_id,  # pylint: disable=too-many-arguments,too-man
     :type signature_return_url: string | None
     :param signature_sign_url: The URL the user must visit to sign the signature.
     :type signature_sign_url: string | None
+    :param domain_whitelist:  the domain whitelist
+    :param email_whitelist:  the email whitelist
+    :param github_whitelist:  the github username whitelist
+    :param github_org_whitelist:  the github org whitelist
     :return: dict representation of the signature object.
     :rtype: dict
     """
@@ -250,6 +255,15 @@ def update_signature(signature_id,  # pylint: disable=too-many-arguments,too-man
         except KeyError as err:
             return {'errors': {
                 'github_whitelist': 'Invalid value passed in for the github whitelist'
+            }}
+
+    if github_org_whitelist is not None:
+        try:
+            github_org_whitelist = hug.types.multiple(github_org_whitelist)
+            signature.set_github_org_whitelist(github_org_whitelist)
+        except KeyError as err:
+            return {'errors': {
+                'github_org_whitelist': 'Invalid value passed in for the github org whitelist'
             }}
 
     signature.save()

--- a/cla-backend/cla/routes.py
+++ b/cla-backend/cla/routes.py
@@ -415,7 +415,8 @@ def put_signature(auth_user: check_auth,  # pylint: disable=too-many-arguments
                   signature_sign_url=None,
                   domain_whitelist=None,
                   email_whitelist=None,
-                  github_whitelist=None):
+                  github_whitelist=None,
+                  github_org_whitelist=None):
     """
     PUT: /signature
 
@@ -438,7 +439,8 @@ def put_signature(auth_user: check_auth,  # pylint: disable=too-many-arguments
         signature_sign_url=signature_sign_url,
         domain_whitelist=domain_whitelist,
         email_whitelist=email_whitelist,
-        github_whitelist=github_whitelist)
+        github_whitelist=github_whitelist,
+        github_org_whitelist=github_org_whitelist)
 
 
 @hug.delete('/signature/{signature_id}', versions=1)

--- a/cla-frontend-corporate-console/src/ionic/app/app.scss
+++ b/cla-frontend-corporate-console/src/ionic/app/app.scss
@@ -1,5 +1,4 @@
 // http://ionicframework.com/docs/v2/theming/
-
 // App Global Sass
 // --------------------------------------------------
 // Put style rules here that you want to apply globally. These
@@ -13,7 +12,6 @@
 // To declare rules for a specific mode, create a child rule
 // for the .md, .ios, or .wp mode classes. The mode class is
 // automatically applied to the <body> element in the app.
-
 //@import url('https://fonts.googleapis.com/css?family=Lato');
 @import "../assets/fonts/lato-font.scss";
 @import "../assets/fonts/open-sans-font.scss";
@@ -42,14 +40,15 @@ body ion-app.wp {
   padding-right: 0;
 }
 
-.item.item-md{
+.item.item-md {
   padding-left: 0;
+
   .checkbox-md {
     margin: 6px 15px 9px 0px;
   }
 }
 
-.item-md.item-block .item-inner{
+.item-md.item-block .item-inner {
   padding-right: 0;
 }
 
@@ -57,17 +56,50 @@ body ion-app.wp {
   padding: 0;
 }
 
-.md ion-footer .toolbar:last-child{
+.md ion-footer .toolbar:last-child {
   padding-bottom: 1rem;
 }
 
 .bar-buttons-md[end] {
   margin-right: 0;
+
   .button:last-child {
     margin-right: 0;
   }
 }
 
 .row .col .card {
-  min-height: calc( 100% - 20px )
+  min-height: calc(100% - 20px)
+}
+
+.isa_info, .isa_success, .isa_warning, .isa_error {
+  margin: 10px 0px;
+  padding: 12px;
+}
+
+.isa_info {
+  color: #00529B;
+  background-color: #BDE5F8;
+}
+
+.isa_success {
+  color: #4F8A10;
+  background-color: #DFF2BF;
+}
+
+//color: #9F6000;
+.isa_warning {
+  color: #9f4c00;
+  background-color: #FEEFB3;
+}
+
+.isa_error {
+  color: #D8000C;
+  background-color: #FFD2D2;
+}
+
+.isa_info i, .isa_success i, .isa_warning i, .isa_error i {
+  margin: 10px 22px;
+  font-size: 2em;
+  vertical-align: middle;
 }

--- a/cla-frontend-corporate-console/src/ionic/modals/whitelist-modal/whitelist-modal.html
+++ b/cla-frontend-corporate-console/src/ionic/modals/whitelist-modal/whitelist-modal.html
@@ -1,7 +1,7 @@
 <ion-header>
   <ion-toolbar>
     <ion-title>
-      <span>Edit {{type | titlecase}} Whitelist for {{ companyName | titlecase }}</span>
+      <span>Edit {{  getTitleType() }} Whitelist for {{ companyName }}</span>
     </ion-title>
     <ion-buttons start>
       <button ion-button (click)="dismiss()">
@@ -16,14 +16,15 @@
     <ion-grid formArrayName="whitelist">
       <ion-row>
         <ion-col col-12>
-          <button type="button" ion-button class="clickable" (click)="addNewWhitelistItem()">Add {{type}}</button>
+          <button type="button" ion-button class="clickable" (click)="addNewWhitelistItem()">Add New Line</button>
           <p *ngIf="type === 'github'">Note: Any GitHub bots you whitelist will be automatically affiliated
             to {{companyName}} on {{projectName}}.</p>
         </ion-col>
       </ion-row>
-      <ion-row *ngIf="submitAttempt && !form.valid">
+      <ion-row *ngIf="message.error != null && message.error.trim() !== ''">
         <ion-col col-12>
-          <p class="form-message red">Please check the fields below for errors. {{errorMessage}}</p>
+          <div class="isa_warning">
+            Please check the fields below for errors. {{message.error}}</div>
         </ion-col>
       </ion-row>
       <ion-row *ngFor="let item of form.controls.whitelist.controls; let i = index" [formGroupName]="i">
@@ -48,11 +49,12 @@
   <ion-toolbar>
     <ion-buttons end>
       <loading-spinner [loading]="currentlySubmitting"></loading-spinner>
-      <button ion-button icon-right (click)="dismiss()" [color]="cancelButton()" [disabled]="currentlySubmitting">
+      <button type="button" ion-button icon-left (click)="dismiss()" color="primary" [disabled]="currentlySubmitting">
+<!--        <button ion-button icon-left (click)="dismiss()" [color]="cancelButton()" [disabled]="currentlySubmitting">-->
         Cancel
       </button>
       <button form="form" type="submit" ion-button icon-right [color]="saveButton()" [disabled]="currentlySubmitting">
-        Save
+        Save Whitelist
       </button>
     </ion-buttons>
   </ion-toolbar>

--- a/cla-frontend-corporate-console/src/ionic/models/cla-signature.ts
+++ b/cla-frontend-corporate-console/src/ionic/models/cla-signature.ts
@@ -24,6 +24,7 @@ export class ClaSignatureModel {
   domain_whitelist: Array<string>;
   email_whitelist: Array<string>;
   github_whitelist: Array<string>;
+  github_org_whitelist: Array<string>;
 
   constructor() {
   }

--- a/cla-frontend-corporate-console/src/ionic/pages/project-page/project-page.html
+++ b/cla-frontend-corporate-console/src/ionic/pages/project-page/project-page.html
@@ -57,12 +57,12 @@
         <ion-col col-12 col-md-3>
           <h3>
             GitHub Org Whitelist
-            <ion-icon class="clickable" name="md-create" item-right (click)="openGithubOrgWhitelistModal()"></ion-icon>
+            <ion-icon class="clickable" name="md-create" item-right (click)="openWhitelistGithubOrgModal()"></ion-icon>
           </h3>
           <div class="list-container">
             <ion-list>
-              <ion-item *ngFor="let organization of githubEnabledWhitelist">
-                <span>{{ organization.id }}</span>
+              <ion-item *ngFor="let org of cclaSignature.githubOrgWhitelist">
+                {{ org }}
               </ion-item>
             </ion-list>
           </div>
@@ -113,31 +113,31 @@
           <h2>{{ cclaSignature.companyName | titlecase }} Employee Acknowledgements</h2>
           <table class="table table-hover">
             <thead>
-              <tr>
-                <th class="clickable">
-                  Name
-                </th>
-                <th class="clickable">
-                  Agreement
-                </th>
-                <th class="clickable" (click)="sortMembers('date')">
-                  Date
-                  <sorting-display [sorting]='sort.date.sort'></sorting-display>
-                </th>
-              </tr>
+            <tr>
+              <th class="clickable">
+                Name
+              </th>
+              <th class="clickable">
+                Agreement
+              </th>
+              <th class="clickable" (click)="sortMembers('date')">
+                Date
+                <sorting-display [sorting]='sort.date.sort'></sorting-display>
+              </th>
+            </tr>
             </thead>
             <tbody>
-              <tr *ngFor="let signature of employeeSignatures">
-                <td data-title="Name">
-                  {{ signature.userName }}
-                </td>
-                <td data-title="Agreement">
-                  v{{ signature.version}}
-                </td>
-                <td data-title="Date">
-                  {{ signature.modified | date:'medium' }}
-                </td>
-              </tr>
+            <tr *ngFor="let signature of employeeSignatures">
+              <td data-title="Name">
+                {{ signature.userName }}
+              </td>
+              <td data-title="Agreement">
+                v{{ signature.version}}
+              </td>
+              <td data-title="Date">
+                {{ signature.modified | date:'medium' }}
+              </td>
+            </tr>
             </tbody>
           </table>
         </div>

--- a/cla-frontend-corporate-console/src/ionic/pages/project-page/project-page.ts
+++ b/cla-frontend-corporate-console/src/ionic/pages/project-page/project-page.ts
@@ -26,8 +26,8 @@ import {WhitelistModal} from "../../modals/whitelist-modal/whitelist-modal";
 export class ProjectPage {
   cclaSignature: any;
   employeeSignatures: any[];
-  githubOrgWhitelist: any[] = [];
-  githubEnabledWhitelist: any[] = [];
+  //githubOrgWhitelist: any[] = [];
+  //githubEnabledWhitelist: any[] = [];
   loading: any;
   companyId: string;
   projectId: string;
@@ -54,9 +54,9 @@ export class ProjectPage {
     this.projectId = navParams.get("projectId");
     this.showModal = navParams.get("modal");
 
-    if (this.showModal === 'orgwhitelist') {
-      this.openGithubOrgWhitelistModal();
-    }
+    // if (this.showModal === 'orgwhitelist') {
+    //   this.openGithubOrgWhitelistModal();
+    // }
 
     this.getDefaults();
   }
@@ -97,6 +97,7 @@ export class ProjectPage {
     });
   }
 
+  /*
   getGitHubOrgWhitelist() {
     this.claService.getGithubOrganizationWhitelistEntries(this.cclaSignature.signatureID).subscribe(organizations => {
       this.githubOrgWhitelist = organizations;
@@ -107,6 +108,7 @@ export class ProjectPage {
   githubOrgWhitelistEnabled() {
     this.githubEnabledWhitelist = this.githubOrgWhitelist.filter((org) => org.selected);
   }
+   */
 
   getCLAManagers() {
     this.claService.getCLAManagers(this.cclaSignature.signatureID).subscribe(response => {
@@ -156,7 +158,7 @@ export class ProjectPage {
                 this.cclaSignature.githubOrgWhitelist = Array.from(new Set(sortedList));
               }
               this.getCLAManagers();
-              this.getGitHubOrgWhitelist();
+              //this.getGitHubOrgWhitelist();
             }
           }
         },
@@ -196,6 +198,22 @@ export class ProjectPage {
     });
   }
 
+  openWhitelistDomainModal() {
+    let modal = this.modalCtrl.create("WhitelistModal", {
+      type: "domain",
+      projectName: this.project.project_name,
+      companyName: this.cclaSignature.companyName,
+      projectId: this.cclaSignature.projectID,
+      signatureId: this.cclaSignature.signatureID,
+      whitelist: this.cclaSignature.domainWhitelist
+    });
+    modal.onDidDismiss(data => {
+      // A refresh of data anytime the modal is dismissed
+      this.getProjectSignatures();
+    });
+    modal.present();
+  }
+
   openWhitelistEmailModal() {
     let modal = this.modalCtrl.create("WhitelistModal", {
       type: "email",
@@ -205,22 +223,6 @@ export class ProjectPage {
       companyId: this.companyId,
       signatureId: this.cclaSignature.signatureID,
       whitelist: this.cclaSignature.emailWhitelist
-    });
-    modal.onDidDismiss(data => {
-      // A refresh of data anytime the modal is dismissed
-      this.getProjectSignatures();
-    });
-    modal.present();
-  }
-
-  openWhitelistDomainModal() {
-    let modal = this.modalCtrl.create("WhitelistModal", {
-      type: "domain",
-      projectName: this.project.project_name,
-      companyName: this.cclaSignature.companyName,
-      projectId: this.cclaSignature.projectID,
-      signatureId: this.cclaSignature.signatureID,
-      whitelist: this.cclaSignature.domainWhitelist
     });
     modal.onDidDismiss(data => {
       // A refresh of data anytime the modal is dismissed
@@ -243,7 +245,22 @@ export class ProjectPage {
       this.getProjectSignatures();
     });
     modal.present();
+  }
 
+  openWhitelistGithubOrgModal() {
+    let modal = this.modalCtrl.create("WhitelistModal", {
+      type: "githubOrg",
+      projectName: this.project.project_name,
+      companyName: this.cclaSignature.companyName,
+      projectId: this.cclaSignature.projectID,
+      signatureId: this.cclaSignature.signatureID,
+      whitelist: this.cclaSignature.githubOrgWhitelist
+    });
+    modal.onDidDismiss(data => {
+      // A refresh of data anytime the modal is dismissed
+      this.getProjectSignatures();
+    });
+    modal.present();
   }
 
   sortMembers(prop) {
@@ -290,6 +307,7 @@ export class ProjectPage {
     modal.present();
   }
 
+  /*
   openGithubOrgWhitelistModal() {
     // Maybe this happens if we authorize GH and come back after the flow and we haven't fully loaded...
     if (this.cclaSignature == null) {
@@ -340,4 +358,5 @@ export class ProjectPage {
       modal.present();
     }
   }
+   */
 }

--- a/cla-frontend-corporate-console/src/ionic/services/cla.service.ts
+++ b/cla-frontend-corporate-console/src/ionic/services/cla.service.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import {Injectable} from "@angular/core";
-import {Http} from "@angular/http";
+import {Headers, Http} from "@angular/http";
 import {AuthService} from "./auth.service"
 
 import "rxjs/Rx";
@@ -1271,7 +1271,6 @@ export class ClaService {
   /**
    * Handle service error is a common routine to handle HTTP response errors
    * @param error the error
-   * @param caught the error that was caught
    */
   private handleServiceError(error: any) {
     /*


### PR DESCRIPTION
- refactored github org whitelist to allow freeform input
- added regex validator for github org whitelist
- removed specialization logic for github org whitelist to check based on users github permissions
- updated python service handler to accept github_org_whitelist values (like the other whitelists)
- added info/warning message for form validation errors
- updated whitelist title and button labels

Resolves: #293

Signed-off-by: David Deal <dealako@gmail.com>