### PR TITLE
Project Console - Support Email Incorrect

### DIFF
--- a/cla-frontend-project-console/src/ionic/pages/login/login.html
+++ b/cla-frontend-project-console/src/ionic/pages/login/login.html
@@ -95,8 +95,6 @@
                     in.
                   </span>
                 </li>
-                <p class="cla-list-paragraph">If you do not have your LF ID, email
-                  <a>support@linuxfoundation.org</a> to request it.</p>
               </ul>
             </ion-card-content>
           </ion-card>


### PR DESCRIPTION
- Per discussions with the support team, removed the invalid support email on the login page

Signed-off-by: David Deal <dealako@gmail.com>