### PR TITLE
Add release version to website

### DIFF
--- a/cla-frontend-contributor-console/src/ionic/layout/cla-footer/cla-footer.html
+++ b/cla-frontend-contributor-console/src/ionic/layout/cla-footer/cla-footer.html
@@ -25,6 +25,18 @@
           <small>
             DocuSign is a registered trademark of DocuSign, Inc
           </small>
+          <small>
+            <p>
+              <b>Version</b>
+              <span>{{ version }}</span>
+            </p>
+            <p>
+              <span>
+                <b>Release Date:</b>
+              </span> {{ releaseDate }}
+            </p>
+          </small>
+
         </ion-col>
         <ion-col text-sm-right>
           <small>

--- a/cla-frontend-contributor-console/src/ionic/layout/cla-footer/cla-footer.ts
+++ b/cla-frontend-contributor-console/src/ionic/layout/cla-footer/cla-footer.ts
@@ -2,11 +2,30 @@
 // SPDX-License-Identifier: MIT
 
 import { Component } from '@angular/core';
+import { ClaService } from '../../services/cla.service';
 
 @Component({
   selector: 'cla-footer',
   templateUrl: 'cla-footer.html'
 })
 export class ClaFooter {
-  constructor() {}
+  version: any;
+  releaseDate: any;
+
+  constructor(
+    public claService: ClaService,
+  ) {
+    this.getDefaults();
+  }
+
+  getDefaults() {
+    this.getReleaseVersion()
+  }
+
+  getReleaseVersion() {
+    this.claService.getReleaseVersion().subscribe((data) => {
+      this.version = data.version;
+      this.releaseDate = data.buildDate;
+    })
+  }
 }

--- a/cla-frontend-contributor-console/src/ionic/services/cla.service.ts
+++ b/cla-frontend-contributor-console/src/ionic/services/cla.service.ts
@@ -882,5 +882,11 @@ export class ClaService {
     return this.http.securedGet(this.claApiUrl + '/v1/project/' + projectId + '/gerrits').map((res) => res.json());
   }
 
+  getReleaseVersion() {
+    const url: URL = this.getV3Endpoint('/v3/ops/version');
+    return this.http.get(url).map((res) => res.json());
+  }
+
+
   //////////////////////////////////////////////////////////////////////////////
 }

--- a/cla-frontend-corporate-console/src/ionic/layout/cla-footer/cla-footer.html
+++ b/cla-frontend-corporate-console/src/ionic/layout/cla-footer/cla-footer.html
@@ -23,6 +23,19 @@
           <small>
             DocuSign is a registered trademark of DocuSign, Inc
           </small>
+          <small>
+            <p>
+              <b>Version</b>
+              <span>{{ version }}</span>
+            </p>
+            <p>
+              <span>
+                <b>Release Date:</b>
+              </span> {{ releaseDate }}
+            </p>
+          </small>
+
+
         </ion-col>
         <ion-col text-sm-right>
           <small>

--- a/cla-frontend-corporate-console/src/ionic/layout/cla-footer/cla-footer.ts
+++ b/cla-frontend-corporate-console/src/ionic/layout/cla-footer/cla-footer.ts
@@ -2,11 +2,31 @@
 // SPDX-License-Identifier: MIT
 
 import { Component } from '@angular/core';
+import { ClaService } from '../../services/cla.service';
 
 @Component({
   selector: 'cla-footer',
   templateUrl: 'cla-footer.html'
 })
 export class ClaFooter {
-  constructor() {}
+  version: any;
+  releaseDate: any;
+  constructor(
+    public claService: ClaService,
+  ) {
+    this.getDefaults();
+  }
+
+  getDefaults() {
+    this.getReleaseVersion()
+  }
+
+  getReleaseVersion() {
+    this.claService.getReleaseVersion().subscribe((data) => {
+      this.version = data.version;
+      this.releaseDate = data.buildDate;
+    })
+  }
+
+  
 }

--- a/cla-frontend-corporate-console/src/ionic/services/cla.service.ts
+++ b/cla-frontend-corporate-console/src/ionic/services/cla.service.ts
@@ -1490,5 +1490,10 @@ export class ClaService {
     return Observable.throw(error);
   }
 
+  getReleaseVersion() {
+    const url: URL = this.getV3Endpoint('/v3/ops/version');
+    return this.http.get(url).map((res) => res.json());
+  }
+
   //////////////////////////////////////////////////////////////////////////////
 }

--- a/cla-frontend-project-console/src/ionic/layout/cla-footer/cla-footer.html
+++ b/cla-frontend-project-console/src/ionic/layout/cla-footer/cla-footer.html
@@ -25,6 +25,17 @@
           <small>
             DocuSign is a registered trademark of DocuSign, Inc
           </small>
+          <small>
+            <p>
+              <b>Version</b>
+              <span>{{ version }}</span>
+            </p>
+            <p>
+              <span>
+                <b>Release Date:</b>
+              </span> {{ releaseDate }}
+            </p>
+          </small>
         </ion-col>
         <ion-col text-sm-right>
           <small>

--- a/cla-frontend-project-console/src/ionic/layout/cla-footer/cla-footer.ts
+++ b/cla-frontend-project-console/src/ionic/layout/cla-footer/cla-footer.ts
@@ -1,9 +1,31 @@
 import { Component } from '@angular/core';
+import { ClaService } from '../../services/cla.service';
+
 
 @Component({
   selector: 'cla-footer',
   templateUrl: 'cla-footer.html'
 })
 export class ClaFooter {
-  constructor() {}
+  version: any;
+  releaseDate: any;
+  constructor(
+    public claService: ClaService,
+  ) {
+    this.getDefaults();
+  }
+
+  getDefaults() {
+    this.getReleaseVersion()
+  }
+
+  getReleaseVersion() {
+    this.claService.getReleaseVersion().subscribe((data) => {
+      this.version = data.version;
+      this.releaseDate = data.buildDate;
+    })
+  }
+
 }
+
+

--- a/cla-frontend-project-console/src/ionic/services/cla.service.ts
+++ b/cla-frontend-project-console/src/ionic/services/cla.service.ts
@@ -980,5 +980,10 @@ export class ClaService {
     }
   }
 
+  getReleaseVersion() {
+    const url: URL = this.getV3Endpoint('/v3/ops/version');
+    return this.http.get(url).map((res) => res.json());
+  }
+
   //////////////////////////////////////////////////////////////////////////////
 }


### PR DESCRIPTION
Add release version somewhere on the website, probably the footer so we know what version of EasyCLA is deployed.