### PR TITLE
Updated CloudFront Cache Control Settings

### DIFF
--- a/cla-frontend-contributor-console/serverless.yml
+++ b/cla-frontend-contributor-console/serverless.yml
@@ -152,9 +152,11 @@ resources:
                 # We use the serverless-lambda-version plugin to automatically update this every time there is a change.
                 LambdaFunctionARN: ClientEdgeLambdaFunction
             Compress: true # Turns on gzipping
-            MaxTTL: 31536000 # Can keep the file in the cloudfront cache for a maximum of a year.
+            #DefaultTTL: 86400 # Defaults to a day if no Cache-Control header is set.
+            DefaultTTL: 600 # 10 minutes only due to users seeing a lot of stale cache issues after release (even after invalidating
             MinTTL: 0
-            DefaultTTL: 86400 # Defaults to a day if no Cache-Control header is set.
+            #MaxTTL: 31536000 # Can keep the file in the cloudfront cache for a maximum of a year.
+            MaxTTL: 600 # 10 minutes only due to users seeing a lot of stale cache issues after release (even after invalidating
             TargetOriginId:
               Ref: WebsiteDeploymentBucket
             ForwardedValues:

--- a/cla-frontend-corporate-console/serverless.yml
+++ b/cla-frontend-corporate-console/serverless.yml
@@ -150,9 +150,11 @@ resources:
                 # We use the serverless-lambda-version plugin to automatically update this every time there is a change.
                 LambdaFunctionARN: ClientEdgeLambdaFunction
             Compress: true # Turns on gzipping
-            MaxTTL: 31536000 # Can keep the file in the cloudfront cache for a maximum of a year.
+            #DefaultTTL: 86400 # Defaults to a day if no Cache-Control header is set.
+            DefaultTTL: 600 # 10 minutes only due to users seeing a lot of stale cache issues after release (even after invalidating
             MinTTL: 0
-            DefaultTTL: 86400 # Defaults to a day if no Cache-Control header is set.
+            #MaxTTL: 31536000 # Can keep the file in the cloudfront cache for a maximum of a year.
+            MaxTTL: 600 # 10 minutes only due to users seeing a lot of stale cache issues after release (even after invalidating
             TargetOriginId:
               Ref: WebsiteDeploymentBucket
             ForwardedValues:

--- a/cla-frontend-project-console/serverless.yml
+++ b/cla-frontend-project-console/serverless.yml
@@ -152,9 +152,11 @@ resources:
                 # We use the serverless-lambda-version plugin to automatically update this every time there is a change.
                 LambdaFunctionARN: ClientEdgeLambdaFunction
             Compress: true # Turns on gzipping
-            MaxTTL: 31536000 # Can keep the file in the cloudfront cache for a maximum of a year.
+            #DefaultTTL: 86400 # Defaults to a day if no Cache-Control header is set.
+            DefaultTTL: 600 # 10 minutes only due to users seeing a lot of stale cache issues after release (even after invalidating
             MinTTL: 0
-            DefaultTTL: 86400 # Defaults to a day if no Cache-Control header is set.
+            #MaxTTL: 31536000 # Can keep the file in the cloudfront cache for a maximum of a year.
+            MaxTTL: 600 # 10 minutes only due to users seeing a lot of stale cache issues after release (even after invalidating
             TargetOriginId:
               Ref: WebsiteDeploymentBucket
             ForwardedValues:


### PR DESCRIPTION
- updated configuration to reduce Default and Max Cache times (TTL) in an
  attempt to address user/UI issues related to problems after a release

Resolves: #526

Signed-off-by: David Deal <dealako@gmail.com>