### PR TITLE
Prevent Duplicate CLA Groups

### DIFF
--- a/cla-backend-go/project/service.go
+++ b/cla-backend-go/project/service.go
@@ -13,6 +13,7 @@ type Service interface {
 	CreateProject(project *models.Project) (*models.Project, error)
 	GetProjects(params *project.GetProjectsParams) (*models.Projects, error)
 	GetProjectByID(projectID string) (*models.Project, error)
+	GetProjectByName(projectName string) (*models.Project, error)
 	DeleteProject(projectID string) error
 	UpdateProject(projectModel *models.Project) (*models.Project, error)
 	GetMetrics() (*models.ProjectMetrics, error)
@@ -42,7 +43,12 @@ func (s service) GetProjects(params *project.GetProjectsParams) (*models.Project
 
 // GetProjectByID service method
 func (s service) GetProjectByID(projectID string) (*models.Project, error) {
-	return s.repo.GetProject(projectID)
+	return s.repo.GetProjectByID(projectID)
+}
+
+// GetProjectByName service method
+func (s service) GetProjectByName(projectName string) (*models.Project, error) {
+	return s.repo.GetProjectByName(projectName)
 }
 
 // DeleteProject service method

--- a/cla-backend-go/swagger/cla.yaml
+++ b/cla-backend-go/swagger/cla.yaml
@@ -744,6 +744,8 @@ paths:
           $ref: '#/responses/unauthorized'
         '403':
           $ref: '#/responses/forbidden'
+        '409':
+          $ref: '#/responses/conflict'
       tags:
         - project
     put:
@@ -852,6 +854,34 @@ paths:
           description: 'Success'
           schema:
             $ref: '#/definitions/project-metrics'
+        '400':
+          $ref: '#/responses/invalid-request'
+        '401':
+          $ref: '#/responses/unauthorized'
+        '403':
+          $ref: '#/responses/forbidden'
+        '404':
+          $ref: '#/responses/not-found'
+      tags:
+        - project
+
+  /project/name/{projectName}:
+    get:
+      summary: Get Project By Name
+      description: Returns the project object when provided the project name - exact match
+      parameters:
+        - name: projectName
+          in: path
+          type: string
+          required: true
+      security:
+        - OauthSecurity: []
+      operationId: getProjectByName
+      responses:
+        '200':
+          description: 'Success'
+          schema:
+            $ref: '#/definitions/project'
         '400':
           $ref: '#/responses/invalid-request'
         '401':

--- a/cla-backend-go/whitelist/service.go
+++ b/cla-backend-go/whitelist/service.go
@@ -159,22 +159,22 @@ func (s service) AddCclaWhitelistRequest(companyID string, projectID string, arg
 	if len(list.List) > 0 {
 		return "", ErrCclaWhitelistRequestAlreadyExists
 	}
-	company, err := s.companyRepo.GetCompany(companyID)
+	companyModel, err := s.companyRepo.GetCompany(companyID)
 	if err != nil {
 		return "", err
 	}
-	project, err := s.projectRepo.GetProject(projectID)
+	projectModel, err := s.projectRepo.GetProjectByID(projectID)
 	if err != nil {
 		return "", err
 	}
-	user, err := s.userRepo.GetUser(args.UserID)
+	userModel, err := s.userRepo.GetUser(args.UserID)
 	if err != nil {
 		return "", err
 	}
-	if user == nil {
+	if userModel == nil {
 		return "", errors.New("invalid user")
 	}
-	return s.repo.AddCclaWhitelistRequest(company, project, user)
+	return s.repo.AddCclaWhitelistRequest(companyModel, projectModel, userModel)
 }
 
 // DeleteCclaWhitelistRequest is the handler for the Delete CLA Whitelist request

--- a/cla-backend/serverless.yml
+++ b/cla-backend/serverless.yml
@@ -129,6 +129,7 @@ provider:
         - "arn:aws:dynamodb:#{AWS::Region}:#{AWS::AccountId}:table/cla-${opt:stage}-signatures/index/signature-company-initial-manager-index"
         - "arn:aws:dynamodb:#{AWS::Region}:#{AWS::AccountId}:table/cla-${opt:stage}-companies/index/external-company-index"
         - "arn:aws:dynamodb:#{AWS::Region}:#{AWS::AccountId}:table/cla-${opt:stage}-projects/index/external-project-index"
+        - "arn:aws:dynamodb:#{AWS::Region}:#{AWS::AccountId}:table/cla-${opt:stage}-projects/index/project-name-search-index"
         - "arn:aws:dynamodb:#{AWS::Region}:#{AWS::AccountId}:table/cla-${opt:stage}-repositories/index/project-repository-index"
         - "arn:aws:dynamodb:#{AWS::Region}:#{AWS::AccountId}:table/cla-${opt:stage}-repositories/index/external-repository-index"
         - "arn:aws:dynamodb:#{AWS::Region}:#{AWS::AccountId}:table/cla-${opt:stage}-repositories/index/sfdc-repository-index"

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -150,6 +150,7 @@ function buildProjectsTable(importResources: boolean): aws.dynamodb.Table {
       attributes: [
         { name: 'project_id', type: 'S' },
         { name: 'project_external_id', type: 'S' },
+        { name: 'project_name', type: 'S' },
       ],
       hashKey: 'project_id',
       billingMode: 'PAY_PER_REQUEST',
@@ -157,6 +158,11 @@ function buildProjectsTable(importResources: boolean): aws.dynamodb.Table {
         {
           name: 'external-project-index',
           hashKey: 'project_external_id',
+          projectionType: 'ALL',
+        },
+        {
+          name: 'project-name-search-index',
+          hashKey: 'project_name',
           projectionType: 'ALL',
         },
       ],

--- a/tests/rest/test_v3_project_api.tavern.yaml
+++ b/tests/rest/test_v3_project_api.tavern.yaml
@@ -127,7 +127,43 @@ stages:
                 type: str
                 required: true
 
-  - name: Project get request with auth
+  - name: Project create request with auth with name conflict
+    request:
+      url: "{api_url}/v3/project"
+      method: POST
+      headers:
+        Authorization: "Bearer {auth0_token:s}"
+        Content-Type: "application/json"
+        Accept: "application/json"
+      json:
+        projectName: "dd test project"
+        projectExternalID: "abc123456"
+        projectACL: ["ddeal", "hwillson"]
+        projectICLAEnabled: true
+        projectCCLAEnabled: true
+        projectCCLARequiresICLA: true
+    response:
+      status_code: 409
+
+  - name: Project create request with auth with External ID conflict
+    request:
+      url: "{api_url}/v3/project"
+      method: POST
+      headers:
+        Authorization: "Bearer {auth0_token:s}"
+        Content-Type: "application/json"
+        Accept: "application/json"
+      json:
+        projectName: "dd test project not matching"
+        projectExternalID: "abc123"
+        projectACL: ["ddeal", "hwillson"]
+        projectICLAEnabled: true
+        projectCCLAEnabled: true
+        projectCCLARequiresICLA: true
+    response:
+      status_code: 409
+
+  - name: Project get by ID request with auth
     request:
       url: "{api_url}/v3/project/{projectID:s}"
       method: GET
@@ -190,6 +226,131 @@ stages:
                 type: str
                 required: true
 
+  - name: Project get by External ID request with auth
+    request:
+      url: "{api_url}/v3/project/{projectExternalID:s}"
+      method: GET
+      headers:
+        Authorization: "Bearer {auth0_token:s}"
+        Content-Type: "application/json"
+        Accept: "application/json"
+    response:
+      status_code: 200
+      headers:
+        content-type: application/json
+      body:
+        projectID: "{projectID:s}"
+        projectName: "dd test project"
+        projectExternalID: "abc123"
+        projectACL: ["ddeal", "hwillson"]
+        projectICLAEnabled: true
+        projectCCLAEnabled: true
+        projectCCLARequiresICLA: true
+        dateCreated: "{dateCreated:s}"
+        dateModified: "{dateModified:s}"
+      verify_response_with:
+        function: tavern.testutils.helpers:validate_pykwalify
+        extra_kwargs:
+          schema:
+            type: map
+            required: true
+            mapping:
+              projectID:
+                type: str
+                required: true
+              projectExternalID:
+                type: str
+                required: true
+              projectName:
+                type: str
+                required: true
+              projectACL:
+                type: seq
+                required: true
+                sequence:
+                  - type: str
+                    required: true
+              projectICLAEnabled:
+                type: bool
+                required: true
+              projectCCLAEnabled:
+                type: bool
+                required: true
+              projectCCLARequiresICLA:
+                type: bool
+                required: true
+              dateCreated:
+                type: str
+                required: true
+              dateModified:
+                type: str
+                required: true
+              version:
+                type: str
+                required: true
+
+  - name: Project get by name request with auth
+    request:
+      url: "{api_url}/v3/project/name/{projectName:s}"
+      method: GET
+      headers:
+        Authorization: "Bearer {auth0_token:s}"
+        Content-Type: "application/json"
+        Accept: "application/json"
+    response:
+      status_code: 200
+      headers:
+        content-type: application/json
+      body:
+        projectID: "{projectID:s}"
+        projectName: "dd test project"
+        projectExternalID: "abc123"
+        projectACL: ["ddeal", "hwillson"]
+        projectICLAEnabled: true
+        projectCCLAEnabled: true
+        projectCCLARequiresICLA: true
+        dateCreated: "{dateCreated:s}"
+        dateModified: "{dateModified:s}"
+      verify_response_with:
+        function: tavern.testutils.helpers:validate_pykwalify
+        extra_kwargs:
+          schema:
+            type: map
+            required: true
+            mapping:
+              projectID:
+                type: str
+                required: true
+              projectExternalID:
+                type: str
+                required: true
+              projectName:
+                type: str
+                required: true
+              projectACL:
+                type: seq
+                required: true
+                sequence:
+                  - type: str
+                    required: true
+              projectICLAEnabled:
+                type: bool
+                required: true
+              projectCCLAEnabled:
+                type: bool
+                required: true
+              projectCCLARequiresICLA:
+                type: bool
+                required: true
+              dateCreated:
+                type: str
+                required: true
+              dateModified:
+                type: str
+                required: true
+              version:
+                type: str
+                required: true
   - name: Project update request with auth
     request:
       url: "{api_url}/v3/project"


### PR DESCRIPTION
- Added logic to prevent duplicate CLA groups from being created
- Added new GSI for DynamoDB for project_name
- Added GetProjectByName API endpoint and implementation
- Updated Create logic to check if project name or external ID exists
- Fixed lint issue in whitelist
- Renamed GetProject to GetProjectByID to be more clear
- Added functional tests

Resolves #610

Signed-off-by: David Deal <dealako@gmail.com>