### PR TITLE
Use Node12 for serverless deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -504,6 +504,7 @@ jobs:
             pushd $PROJECT_DIR/edge
             yarn build
             popd
+      - *install-node-12
       - run:
           name: Deploy
           command: |
@@ -697,7 +698,6 @@ jobs:
             echo "Node version is: $(node --version)"
             echo "Running top level install..."
             yarn install
-      - *install-node-8
       - run:
           name: Deploy
           command: |


### PR DESCRIPTION
- Updated to node12 for serverless deployment to fix the recent error
  messages are showing up:

An error occurred: ClientEdgeLambdaFunction - The runtime parameter of nodejs8.10 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs12.x) while creating or updating functions. (Service: AWSLambdaInternal; Status Code: 400; Error Code: InvalidParameterValueException; Request ID: c334b1cc-d348-4a45-a5fd-c1b854c06932).

Signed-off-by: David Deal <dealako@gmail.com>