### PR TITLE
Missing data and Overlap issues when Project name is too long

### DIFF
--- a/cla-frontend-corporate-console/src/ionic/modals/view-cla-managers-modal/view-cla-managers-modal.html
+++ b/cla-frontend-corporate-console/src/ionic/modals/view-cla-managers-modal/view-cla-managers-modal.html
@@ -1,7 +1,7 @@
 <ion-header>
   <ion-toolbar>
     <ion-title>
-      <span>View CLA Manager For {{ ProjectName }}</span>
+      View CLA Manager For <span class="project-name" [title]="ProjectName">{{ trimCharacter(ProjectName,25) }}</span>
     </ion-title>
     <ion-buttons start>
       <button ion-button (click)="dismiss()">

--- a/cla-frontend-corporate-console/src/ionic/modals/view-cla-managers-modal/view-cla-managers-modal.scss
+++ b/cla-frontend-corporate-console/src/ionic/modals/view-cla-managers-modal/view-cla-managers-modal.scss
@@ -5,3 +5,7 @@ ion-label {
     white-space: normal;
   }
 }
+
+.project-name {
+  color: #4c79b6;
+}

--- a/cla-frontend-corporate-console/src/ionic/modals/view-cla-managers-modal/view-cla-managers-modal.ts
+++ b/cla-frontend-corporate-console/src/ionic/modals/view-cla-managers-modal/view-cla-managers-modal.ts
@@ -38,6 +38,10 @@ export class ViewCLAManagerModal {
     this.ProjectName = this.navParams.get('ProjectName');
   }
 
+  trimCharacter(text, length) {
+    return text.length > length ? text.substring(0, length) + '...' : text;
+  }
+
   dismiss(data = false) {
     this.viewCtrl.dismiss(data);
   }

--- a/cla-frontend-corporate-console/src/ionic/pages/company-page/company-page.html
+++ b/cla-frontend-corporate-console/src/ionic/pages/company-page/company-page.html
@@ -86,7 +86,7 @@
                           <tbody>
   
                             <tr *ngFor="let row of rows">
-                              <td data-title="Project Name">
+                              <td class="wrap-word" data-title="Project Name">
                                 <span>{{ row.ProjectName}}</span>
                               </td>
   
@@ -167,7 +167,7 @@
                     </thead>
                     <tbody>
                       <tr *ngFor="let invite of invites">
-                        <td data-title="Name">
+                        <td class="wrap-word" data-title="Name">
                           <span>{{ invite.userName }}</span>
                         </td>
                         <td data-title="Email">

--- a/cla-frontend-corporate-console/src/ionic/pages/company-page/company-page.scss
+++ b/cla-frontend-corporate-console/src/ionic/pages/company-page/company-page.scss
@@ -64,13 +64,12 @@ company-page {
     }
   }
 
-
   ul {
     list-style: none; /* Remove default bullets */
   }
 
   ul li::before {
-    content: '\2022'; /* Add content: \2022 is the CSS Code/unicode for a bullet */
+    content: "\2022"; /* Add content: \2022 is the CSS Code/unicode for a bullet */
     color: #4c79b6; /* Change the color */
     font-weight: bold; /* If you want it to be bold */
     display: inline-block; /* Needed to add space between the bullet and the text */
@@ -95,17 +94,17 @@ company-page {
     position: relative;
   }
 
-  span[title='CLA Manager'] {
+  span[title="CLA Manager"] {
     color: green;
     font-weight: bold;
   }
-  
-  span[title='Pending'] {
+
+  span[title="Pending"] {
     color: #4c79b6;
     font-weight: bold;
   }
-  
-  span[title='Request Access'] {
+
+  span[title="Request Access"] {
     color: #4c79b6;
     font-weight: bold;
     text-decoration: underline;
@@ -113,5 +112,8 @@ company-page {
 
   td {
     vertical-align: text-bottom !important;
+    &.wrap-word {
+      word-break: break-all;
+    }
   }
 }


### PR DESCRIPTION
Added below points.
1. wrap word in table view.
2. Trim project name to 25 characters in dialog.
3. Added tooltip for trimmed content. 

![Screenshot from 2020-03-30 14-43-27](https://user-images.githubusercontent.com/56335654/77896011-35692c00-7295-11ea-9aca-07ddb03295ed.png)
![Screenshot from 2020-03-30 14-42-20](https://user-images.githubusercontent.com/56335654/77896014-3732ef80-7295-11ea-8afe-850f6aa44e7b.png)
