### PR TITLE
Corporate Console - Tool tip is not displayed for + icon to add cla manager in Manage White list page

### DIFF
--- a/cla-frontend-corporate-console/src/ionic/pages/project-page/project-page.html
+++ b/cla-frontend-corporate-console/src/ionic/pages/project-page/project-page.html
@@ -210,7 +210,7 @@
                   </div>
                 </ion-item>
               </ion-list>
-              <button bottom right ion-fab mini class="add-manager-btn" *ngIf="!managersRestricted" (click)="openManagerModal()">
+              <button title="Add CLA Manager" bottom right ion-fab mini class="add-manager-btn" *ngIf="!managersRestricted" (click)="openManagerModal()">
                 <ion-icon name="add"></ion-icon>
               </button>
             </ion-card-content>


### PR DESCRIPTION

![Screenshot from 2020-04-01 19-47-21](https://user-images.githubusercontent.com/56335654/78147984-e4526700-7451-11ea-84bc-f35202493b04.png)

Signed-off-by: Amol Sontakke <amols@proximabiz.com>