### PR TITLE
Solved issue of long text with no space

### DIFF
--- a/cla-frontend-project-console/src/ionic/pages/project/project-cla/project-cla.html
+++ b/cla-frontend-project-console/src/ionic/pages/project/project-cla/project-cla.html
@@ -122,7 +122,7 @@
                     </button>
                   </ion-buttons>
                 </ion-col>
-                <ion-col col-auto class="project-title">
+                <ion-col col-4 class="project-title">
                   <h2>
                     {{ project.projectName }}
                   </h2>

--- a/cla-frontend-project-console/src/ionic/pages/project/project-cla/project-cla.scss
+++ b/cla-frontend-project-console/src/ionic/pages/project/project-cla/project-cla.scss
@@ -89,7 +89,7 @@ project-cla {
     .project-title {
       display: flex;
       align-items: center;
-
+      word-break: break-all;
       h2 {
         margin: 0;
         color: #7b7b7b;


### PR DESCRIPTION
Issue was when group name having long single word (without space). Ideally it should not be present but I have added solution.

![Screenshot from 2020-04-10 11-39-33](https://user-images.githubusercontent.com/56335654/78967902-29952980-7b21-11ea-8f42-5ef16adae626.png)

Signed-off-by: Amol Sontakke <amols@proximabiz.com>