### PR TITLE
/recent/events will return events only when event is associated with project

### DIFF
--- a/cla-backend-go/events/repository.go
+++ b/cla-backend-go/events/repository.go
@@ -372,9 +372,10 @@ func (repo repository) getEventByDay(day string, containsPII bool, pageSize int6
 
 	indexName := "event-date-and-contains-pii-event-time-epoch-index"
 	eventDateAndContainsPII := fmt.Sprintf("%s#%t", day, containsPII)
+	filter := expression.Name("event_project_id").AttributeExists()
 	condition = expression.Key("event_date_and_contains_pii").Equal(expression.Value(eventDateAndContainsPII))
 
-	builder = builder.WithKeyCondition(condition)
+	builder = builder.WithKeyCondition(condition).WithFilter(filter)
 	// Use the nice builder to create the expression
 	expr, err := builder.Build()
 	if err != nil {


### PR DESCRIPTION
- /recent/evetns will return events where project_id is present and contains_pii = false