### PR TITLE
Added Serverless Prune Script Target

### DIFF
--- a/cla-backend-go/package.json
+++ b/cla-backend-go/package.json
@@ -6,7 +6,14 @@
   "scripts": {
     "sls": "./node_modules/serverless/bin/serverless",
     "deploy:dev": "SLS_DEBUG=* ./node_modules/serverless/bin/serverless deploy -s dev -r us-east-2 --verbose",
-    "package:dev": "SLS_DEBUG=* ./node_modules/serverless/bin/serverless package -s dev -r us-east-2 --verbose"
+    "package:dev": "SLS_DEBUG=* ./node_modules/serverless/bin/serverless package -s dev -r us-east-2 --verbose",
+    "prune:dev": "SLS_DEBUG=* time ./node_modules/serverless/bin/serverless prune -n 10 -s dev -r us-east-2 --verbose",
+    "deploy:staging": "SLS_DEBUG=* ./node_modules/serverless/bin/serverless deploy -s staging -r us-east-2 --verbose",
+    "package:staging": "SLS_DEBUG=* ./node_modules/serverless/bin/serverless package -s staging -r us-east-2 --verbose",
+    "prune:staging": "SLS_DEBUG=* time ./node_modules/serverless/bin/serverless prune -n 10 -s staging -r us-east-2 --verbose",
+    "deploy:prod": "SLS_DEBUG=* ./node_modules/serverless/bin/serverless deploy -s prod -r us-east-2 --verbose",
+    "package:prod": "SLS_DEBUG=* ./node_modules/serverless/bin/serverless package -s prod -r us-east-2 --verbose",
+    "prune:prod": "SLS_DEBUG=* time ./node_modules/serverless/bin/serverless prune -n 10 -s prod -r us-east-2 --verbose"
   },
   "dependencies": {
     "install": "^0.13.0",

--- a/cla-backend/package.json
+++ b/cla-backend/package.json
@@ -6,15 +6,18 @@
   "scripts": {
     "sls": "./node_modules/serverless/bin/serverless",
     "serve:dev": "./node_modules/serverless/bin/serverless wsgi serve -s 'dev'",
+    "deploy:dev": "SLS_DEBUG=* ./node_modules/serverless/bin/serverless deploy -s dev -r us-east-1 --verbose",
+    "prune:dev": "SLS_DEBUG=* time ./node_modules/serverless/bin/serverless prune -n 10 -s dev -r us-east-1 --verbose",
+    "package": "SLS_DEBUG=* ./node_modules/serverless/bin/serverless package -s dev -r us-east-1 --verbose",
     "serve:staging": "./node_modules/serverless/bin/serverless wsgi serve -s 'staging'",
+    "prune:staging": "SLS_DEBUG=* time ./node_modules/serverless/bin/serverless prune -n 10 -s staging -r us-east-1 --verbose",
     "serve:prod": "./node_modules/serverless/bin/serverless wsgi serve -s 'prod'",
+    "prune:prod": "SLS_DEBUG=* time ./node_modules/serverless/bin/serverless prune -n 10 -s prod -r us-east-1 --verbose",
     "install:dev": "sh dev.sh install",
     "add:user": "sh dev.sh add:user",
     "start:lambda": "sh dev.sh start:lambda",
     "start:dynamodb": "sh dev.sh start:dynamodb",
-    "start:s3": "sh dev.sh start:s3",
-    "deploy:dev": "SLS_DEBUG=* ./node_modules/serverless/bin/serverless deploy -s dev -r us-east-1 --verbose",
-    "package": "SLS_DEBUG=* ./node_modules/serverless/bin/serverless package -s dev -r us-east-1 --verbose"
+    "start:s3": "sh dev.sh start:s3"
   },
   "dependencies": {
     "install": "^0.13.0",


### PR DESCRIPTION
- Added prune:{dev|staging|prod} script targets to manually prune the
  code versions for Lambdas to avoid "Code storage limit exceeded" errors

Signed-off-by: David Deal <dealako@gmail.com>