### PR TITLE
Updated CircleCI Golang Build Version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
 
   buildGoBackend: &buildGoBackendAnchor
     docker:
-      - image: circleci/golang:1.14
+      - image: circleci/golang:1.14.2
     working_directory: /go/src/github.com/communitybridge/easycla/
     steps:
       - checkout


### PR DESCRIPTION
- Updated golang build version to 1.14.2

Signed-off-by: David Deal <dealako@gmail.com>