### PR TITLE
Resolved DynamoDB Events Table Index Configuration Issue

### DIFF
--- a/infra/index.ts
+++ b/infra/index.ts
@@ -650,6 +650,7 @@ function buildEventsTable(importResources: boolean): aws.dynamodb.Table {
         { name: 'event_user_id', type: 'S' },
         { name: 'event_project_id', type: 'S' },
         { name: 'event_date_and_contains_pii', type: 'B' },
+        { name: 'company_id_external_project_id', type: 'S' },
         { name: 'event_time_epoch', type: 'N' },
       ],
       hashKey: 'event_id',


### PR DESCRIPTION
- Added company_id_external_project_id column to the attributes list since it was referenced in an index

Signed-off-by: David Deal <dealako@gmail.com>