### PR TITLE
Enabled Functional Test Gating

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -812,7 +812,6 @@ jobs:
             tavern-ci test_*.tavern.yaml --alluredir=allure_result_folder -v || true
       - run:
           name: functional-tests-go
-          halt_build_on_fail: false  # for now, we will pass all functional tests
           command: |
             source ${BASH_ENV}
             echo "Running golang functional tests for stage: ${STAGE}"


### PR DESCRIPTION
- Now that the functional tests are working properly, I removed
halt_build_on_fail=false condition to allow failed functional tests to
fail the CI/CD workflow

Signed-off-by: David Deal <dealako@gmail.com>