### PR TITLE
Add CORS rules to `cla-signature-files-...` bucket

### DIFF
--- a/infra/index.ts
+++ b/infra/index.ts
@@ -137,6 +137,16 @@ function buildSignatureFilesBucket(importResources: boolean): aws.s3.Bucket {
     {
       bucket: 'cla-signature-files-' + stage,
       acl: PrivateAcl,
+      region: region,
+      corsRules: [
+        {
+          allowedHeaders: ['*'],
+          allowedMethods: ['GET'],
+          allowedOrigins: ['*'],
+          exposeHeaders: ['ETag'],
+          maxAgeSeconds: 3000,
+        },
+      ],
       tags: defaultTags,
     },
     importResources ? { import: 'cla-signature-files-' + stage } : {},


### PR DESCRIPTION
Extend CORS rules to `cla-signature-files-...` bucket.

Included explicit `region` attribute to align with other bucket configurations.