### PR TITLE
Feature/1267 retrofit corp console api

### DIFF
--- a/cla-backend-go/cmd/server.go
+++ b/cla-backend-go/cmd/server.go
@@ -232,7 +232,7 @@ func server(localMode bool) http.Handler {
 	v2CompanyService := v2Company.NewService(signaturesRepo, projectRepo, usersRepo, companyRepo, v2CompanyRepo, projectClaGroupRepo)
 	v2SignService := sign.NewService(configFile.ClaV1ApiURL, companyRepo, projectRepo, projectClaGroupRepo)
 	signaturesService := signatures.NewService(signaturesRepo, companyService, usersService, eventsService, githubOrgValidation)
-	v2SignatureService := v2Signatures.NewService(projectService, companyService, signaturesService)
+	v2SignatureService := v2Signatures.NewService(projectService, companyService, signaturesService, projectClaGroupRepo)
 	claManagerService := cla_manager.NewService(claManagerReqRepo, companyService, projectService, usersService, signaturesService, eventsService, configFile.CorporateConsoleURL)
 	repositoriesService := repositories.NewService(repositoriesRepo)
 	v2ClaManagerService := v2ClaManager.NewService(companyService, projectService, claManagerService, usersService, repositoriesService, v2CompanyService, eventsService)

--- a/cla-backend-go/cmd/server.go
+++ b/cla-backend-go/cmd/server.go
@@ -229,7 +229,7 @@ func server(localMode bool) http.Handler {
 	projectService := project.NewService(projectRepo, repositoriesRepo, gerritRepo)
 	v2ProjectService := v2Project.NewService(projectRepo)
 	companyService := company.NewService(companyRepo, configFile.CorporateConsoleURL, userRepo, usersService)
-	v2CompanyService := v2Company.NewService(signaturesRepo, projectRepo, usersRepo, companyRepo, v2CompanyRepo)
+	v2CompanyService := v2Company.NewService(signaturesRepo, projectRepo, usersRepo, companyRepo, v2CompanyRepo, projectClaGroupRepo)
 	v2SignService := sign.NewService(configFile.ClaV1ApiURL, companyRepo, projectRepo)
 	signaturesService := signatures.NewService(signaturesRepo, companyService, usersService, eventsService, githubOrgValidation)
 	v2SignatureService := v2Signatures.NewService(projectService, companyService, signaturesService)

--- a/cla-backend-go/cmd/server.go
+++ b/cla-backend-go/cmd/server.go
@@ -230,7 +230,7 @@ func server(localMode bool) http.Handler {
 	v2ProjectService := v2Project.NewService(projectRepo)
 	companyService := company.NewService(companyRepo, configFile.CorporateConsoleURL, userRepo, usersService)
 	v2CompanyService := v2Company.NewService(signaturesRepo, projectRepo, usersRepo, companyRepo, v2CompanyRepo, projectClaGroupRepo)
-	v2SignService := sign.NewService(configFile.ClaV1ApiURL, companyRepo, projectRepo)
+	v2SignService := sign.NewService(configFile.ClaV1ApiURL, companyRepo, projectRepo, projectClaGroupRepo)
 	signaturesService := signatures.NewService(signaturesRepo, companyService, usersService, eventsService, githubOrgValidation)
 	v2SignatureService := v2Signatures.NewService(projectService, companyService, signaturesService)
 	claManagerService := cla_manager.NewService(claManagerReqRepo, companyService, projectService, usersService, signaturesService, eventsService, configFile.CorporateConsoleURL)

--- a/cla-backend-go/events/mockrepo.go
+++ b/cla-backend-go/events/mockrepo.go
@@ -75,7 +75,7 @@ func eventInList(eventList []*models.Event, event *models.Event) bool {
 	return retVal
 }
 
-func (repo *mockRepository) GetProjectByID(projectID string) (*models.Project, error) {
+func (repo *mockRepository) GetProjectByID(projectID string, loadACLDetails bool) (*models.Project, error) {
 	return &models.Project{
 		DateCreated:             "",
 		DateModified:            "",

--- a/cla-backend-go/events/service.go
+++ b/cla-backend-go/events/service.go
@@ -12,6 +12,12 @@ import (
 	log "github.com/communitybridge/easycla/cla-backend-go/logging"
 )
 
+// constants
+const (
+	LoadRepoDetails     = true
+	DontLoadRepoDetails = false
+)
+
 // Service interface defines methods of event service
 type Service interface {
 	LogEvent(args *LogEventArgs)
@@ -24,7 +30,7 @@ type Service interface {
 
 // CombinedRepo contains the various methods of other repositories
 type CombinedRepo interface {
-	GetProjectByID(projectID string) (*models.Project, error)
+	GetProjectByID(projectID string, loadRepoDetails bool) (*models.Project, error)
 	GetCompany(companyID string) (*models.Company, error)
 	GetUserByUserName(userName string, fullMatch bool) (*models.User, error)
 	GetUser(userID string) (*models.User, error)
@@ -129,7 +135,7 @@ func (s *service) loadProject(args *LogEventArgs) error {
 		return nil
 	}
 	if args.ProjectID != "" {
-		projectModel, err := s.combinedRepo.GetProjectByID(args.ProjectID)
+		projectModel, err := s.combinedRepo.GetProjectByID(args.ProjectID, DontLoadRepoDetails)
 		if err != nil {
 			return err
 		}

--- a/cla-backend-go/project/repository.go
+++ b/cla-backend-go/project/repository.go
@@ -42,7 +42,7 @@ const (
 // ProjectRepository defines functions of Project repository
 type ProjectRepository interface { //nolint
 	CreateProject(project *models.Project) (*models.Project, error)
-	GetProjectByID(projectID string) (*models.Project, error)
+	GetProjectByID(projectID string, loadRepoDetails bool) (*models.Project, error)
 	GetProjectsByExternalID(params *project.GetProjectsByExternalIDParams, loadRepoDetails bool) (*models.Projects, error)
 	GetProjectByName(projectName string) (*models.Project, error)
 	GetExternalProject(projectExternalID string) (*models.Project, error)
@@ -174,8 +174,8 @@ func (repo *repo) getProjectByID(projectID string, loadProjectDetails bool) (*mo
 }
 
 // GetProjectByID returns the project model associated for the specified projectID
-func (repo *repo) GetProjectByID(projectID string) (*models.Project, error) {
-	return repo.getProjectByID(projectID, LoadRepoDetails)
+func (repo *repo) GetProjectByID(projectID string, loadRepoDetails bool) (*models.Project, error) {
+	return repo.getProjectByID(projectID, loadRepoDetails)
 }
 
 // GetProjectsByExternalID queries the database and returns a list of the projects
@@ -536,7 +536,7 @@ func (repo *repo) GetProjects(params *project.GetProjectsParams) (*models.Projec
 func (repo *repo) DeleteProject(projectID string) error {
 	tableName := fmt.Sprintf("cla-%s-projects", repo.stage)
 
-	existingProject, getErr := repo.GetProjectByID(projectID)
+	existingProject, getErr := repo.GetProjectByID(projectID, DontLoadRepoDetails)
 	if getErr != nil {
 		log.Warnf("delete - error locating the project id: %s, error: %+v", projectID, getErr)
 		return getErr
@@ -573,7 +573,7 @@ func (repo *repo) UpdateProject(projectModel *models.Project) (*models.Project, 
 		return nil, ErrProjectIDMissing
 	}
 
-	existingProject, getErr := repo.GetProjectByID(projectModel.ProjectID)
+	existingProject, getErr := repo.GetProjectByID(projectModel.ProjectID, DontLoadRepoDetails)
 	if getErr != nil {
 		log.Warnf("update - error locating the project id: %s, error: %+v", projectModel.ProjectID, getErr)
 		return nil, getErr
@@ -649,7 +649,7 @@ func (repo *repo) UpdateProject(projectModel *models.Project) (*models.Project, 
 	// Read the updated record back from the DB and return - probably could
 	// just create/update a new model in memory and return it to make it fast,
 	// but this approach return exactly what the DB has
-	return repo.GetProjectByID(projectModel.ProjectID)
+	return repo.GetProjectByID(projectModel.ProjectID, LoadRepoDetails)
 }
 
 // buildProjectModels converts the database response model into an API response data model

--- a/cla-backend-go/project/service.go
+++ b/cla-backend-go/project/service.go
@@ -55,11 +55,10 @@ func (s service) GetProjects(params *project.GetProjectsParams) (*models.Project
 
 // GetProjectByID service method
 func (s service) GetProjectByID(projectID string) (*models.Project, error) {
-	project, err := s.repo.GetProjectByID(projectID)
+	project, err := s.repo.GetProjectByID(projectID, LoadRepoDetails)
 	if err != nil {
 		return nil, err
 	}
-	s.fillRepoInfo(project)
 	return project, nil
 }
 

--- a/cla-backend-go/signatures/repository.go
+++ b/cla-backend-go/signatures/repository.go
@@ -874,9 +874,12 @@ func (repo repository) GetProjectCompanyEmployeeSignatures(params signatures.Get
 	// This is the keys we want to match
 	condition := expression.Key("signature_user_ccla_company_id").Equal(expression.Value(params.CompanyID)).And(
 		expression.Key("signature_project_id").Equal(expression.Value(params.ProjectID)))
+	// Check for approved signatures
+	filter := expression.Name("signature_approved").Equal(expression.Value(aws.Bool(true))).
+		And(expression.Name("signature_signed").Equal(expression.Value(aws.Bool(true))))
 
 	// Use the nice builder to create the expression
-	expr, err := expression.NewBuilder().WithKeyCondition(condition).WithProjection(buildProjection()).Build()
+	expr, err := expression.NewBuilder().WithKeyCondition(condition).WithFilter(filter).WithProjection(buildProjection()).Build()
 	if err != nil {
 		log.Warnf("error building expression for project signature ID query, project: %s, error: %v",
 			params.ProjectID, err)

--- a/cla-backend-go/swagger/cla.v2.yaml
+++ b/cla-backend-go/swagger/cla.v2.yaml
@@ -3041,18 +3041,12 @@ definitions:
     type: object
     required:
       - project_sfid
-      - cla_group_id
       - company_sfid
     properties:
       project_sfid:
         type: string
         example: 'a0941000005ouJFAAY'
         description: salesforce id of the project
-      cla_group_id:
-        type: string
-        example: 'c4d71673-e9e8-4e26-a035-99e8334620e5'
-        description: cla group id
-        format: uuid
       company_sfid:
         type: string
         example: '0014100000Te0fMAAR'

--- a/cla-backend-go/swagger/cla.v2.yaml
+++ b/cla-backend-go/swagger/cla.v2.yaml
@@ -2993,6 +2993,10 @@ definitions:
         type: string
         example: "John Doe"
         x-omitempty: false
+      signature_id:
+        type: string
+        example: "55ec4162-9e41-47da-a643-f81666953a51"
+        x-omitempty: false
       project_logo:
         type: string
         example: "http://wwwlinuxfoundation.org/logo.gif"

--- a/cla-backend-go/swagger/cla.v2.yaml
+++ b/cla-backend-go/swagger/cla.v2.yaml
@@ -2955,6 +2955,10 @@ definitions:
         type: boolean
         x-omitempty: false
         description: if requesting user is cla-designee then this would be true
+      sub_projects:
+        type: array
+        items:
+          type: string
 
   active-cla:
     type: object
@@ -2981,6 +2985,10 @@ definitions:
         type: string
         example: "Foundation"
         x-omitempty: false
+      sub_projects:
+        type: array
+        items:
+          type: string
       signatory_name:
         type: string
         example: "John Doe"

--- a/cla-backend-go/v2/company/models.go
+++ b/cla-backend-go/v2/company/models.go
@@ -5,11 +5,9 @@ package company
 
 import (
 	"github.com/communitybridge/easycla/cla-backend-go/company"
-	v1Models "github.com/communitybridge/easycla/cla-backend-go/gen/models"
 	"github.com/communitybridge/easycla/cla-backend-go/projects_cla_groups"
 	"github.com/communitybridge/easycla/cla-backend-go/signatures"
 	"github.com/communitybridge/easycla/cla-backend-go/users"
-	v2ProjectServiceModels "github.com/communitybridge/easycla/cla-backend-go/v2/project-service/models"
 )
 
 type service struct {
@@ -19,18 +17,6 @@ type service struct {
 	companyRepo          company.IRepository
 	repo                 IRepository
 	projectClaGroupsRepo projects_cla_groups.Repository
-}
-
-type signatureResponse struct {
-	companyID  string
-	projectID  string
-	signatures *v1Models.Signatures
-	err        error
-}
-
-type projectDetailedModel struct {
-	v1ProjectModel       *v1Models.Project
-	v2ProjectOutputModel *v2ProjectServiceModels.ProjectOutput
 }
 
 type claGroupModel struct {

--- a/cla-backend-go/v2/company/models.go
+++ b/cla-backend-go/v2/company/models.go
@@ -6,17 +6,19 @@ package company
 import (
 	"github.com/communitybridge/easycla/cla-backend-go/company"
 	v1Models "github.com/communitybridge/easycla/cla-backend-go/gen/models"
+	"github.com/communitybridge/easycla/cla-backend-go/projects_cla_groups"
 	"github.com/communitybridge/easycla/cla-backend-go/signatures"
 	"github.com/communitybridge/easycla/cla-backend-go/users"
 	v2ProjectServiceModels "github.com/communitybridge/easycla/cla-backend-go/v2/project-service/models"
 )
 
 type service struct {
-	signatureRepo signatures.SignatureRepository
-	projectRepo   ProjectRepo
-	userRepo      users.UserRepository
-	companyRepo   company.IRepository
-	repo          IRepository
+	signatureRepo        signatures.SignatureRepository
+	projectRepo          ProjectRepo
+	userRepo             users.UserRepository
+	companyRepo          company.IRepository
+	repo                 IRepository
+	projectClaGroupsRepo projects_cla_groups.Repository
 }
 
 type signatureResponse struct {
@@ -29,4 +31,17 @@ type signatureResponse struct {
 type projectDetailedModel struct {
 	v1ProjectModel       *v1Models.Project
 	v2ProjectOutputModel *v2ProjectServiceModels.ProjectOutput
+}
+
+type claGroupModel struct {
+	ProjectName  string
+	ProjectLogo  string
+	ProjectSFID  string
+	ProjectType  string
+	SubProjects  []string
+	ClaGroupName string
+
+	// For processing
+	FoundationSFID string
+	SubProjectIDs  []string
 }

--- a/cla-backend-go/v2/company/service.go
+++ b/cla-backend-go/v2/company/service.go
@@ -560,6 +560,7 @@ func (s *service) fillActiveCLA(wg *sync.WaitGroup, sig *v1Models.Signature, act
 	activeCla.ProjectID = sig.ProjectID
 	activeCla.SignedOn = sig.SignatureCreated
 	activeCla.ClaGroupName = cg.ClaGroupName
+	activeCla.SignatureID = sig.SignatureID
 
 	// fill details from project service
 	activeCla.ProjectName = cg.ProjectName

--- a/cla-backend-go/v2/company/service.go
+++ b/cla-backend-go/v2/company/service.go
@@ -65,7 +65,7 @@ type Service interface {
 
 // ProjectRepo contains project repo methods
 type ProjectRepo interface {
-	GetProjectByID(projectID string) (*v1Models.Project, error)
+	GetProjectByID(projectID string, loadRepoDetails bool) (*v1Models.Project, error)
 	GetProjectsByExternalID(params *v1ProjectParams.GetProjectsByExternalIDParams, loadRepoDetails bool) (*v1Models.Projects, error)
 }
 
@@ -281,7 +281,7 @@ func (s *service) GetCompanyCLAGroupManagers(companyID, claGroupID string) (*mod
 		return nil, nil
 	}
 
-	projectModel, projErr := s.projectRepo.GetProjectByID(claGroupID)
+	projectModel, projErr := s.projectRepo.GetProjectByID(claGroupID, DontLoadRepoDetails)
 	if projErr != nil {
 		log.Warnf("unable to query CLA Group ID: %s, error: %+v", claGroupID, err)
 		return nil, err
@@ -397,7 +397,7 @@ func (s *service) getCLAGroupsUnderProjectOrFoundation(id string) (map[string]*c
 		go func(claGroupID string, claGroup *claGroupModel) {
 			defer wg.Done()
 			// get cla-group info
-			cginfo, err := s.projectRepo.GetProjectByID(claGroupID)
+			cginfo, err := s.projectRepo.GetProjectByID(claGroupID, DontLoadRepoDetails)
 			if err != nil || cginfo == nil {
 				log.Warnf("Unable to get details of cla_group: %s", claGroupID)
 				return
@@ -705,7 +705,7 @@ func (s *service) getCompanyAndClaGroup(companySFID, projectSFID string) (*v1Mod
 			log.Debugf("cla group mapping not found for projectSFID %s", projectSFID)
 			return
 		}
-		claGroup, projectErr = s.projectRepo.GetProjectByID(pm.ClaGroupID)
+		claGroup, projectErr = s.projectRepo.GetProjectByID(pm.ClaGroupID, DontLoadRepoDetails)
 		if claGroup == nil {
 			projectErr = ErrProjectNotFound
 		}

--- a/cla-backend-go/v2/company/service.go
+++ b/cla-backend-go/v2/company/service.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/communitybridge/easycla/cla-backend-go/projects_cla_groups"
+
 	"github.com/jinzhu/copier"
 
 	"github.com/LF-Engineering/lfx-kit/auth"
@@ -47,6 +49,8 @@ const (
 	HugePageSize        = int64(10000)
 	LoadRepoDetails     = true
 	DontLoadRepoDetails = false
+	FoundationType      = "Foundation"
+	ProjectType         = "Project"
 )
 
 // Service functions for company
@@ -66,28 +70,23 @@ type ProjectRepo interface {
 }
 
 // NewService returns instance of company service
-func NewService(sigRepo signatures.SignatureRepository, projectRepo ProjectRepo, usersRepo users.UserRepository, companyRepo company.IRepository, v2CompanyRepo IRepository) Service {
+func NewService(sigRepo signatures.SignatureRepository, projectRepo ProjectRepo, usersRepo users.UserRepository, companyRepo company.IRepository, v2CompanyRepo IRepository, pcgRepo projects_cla_groups.Repository) Service {
 	return &service{
-		signatureRepo: sigRepo,
-		projectRepo:   projectRepo,
-		userRepo:      usersRepo,
-		companyRepo:   companyRepo,
-		repo:          v2CompanyRepo,
+		signatureRepo:        sigRepo,
+		projectRepo:          projectRepo,
+		userRepo:             usersRepo,
+		companyRepo:          companyRepo,
+		repo:                 v2CompanyRepo,
+		projectClaGroupsRepo: pcgRepo,
 	}
 }
 
 func (s *service) GetCompanyProjectCLAManagers(companyID string, projectSFID string) (*models.CompanyClaManagers, error) {
-	var projects map[string]*projectDetailedModel
 	var err error
-	projectIDs := utils.NewStringSet()
-	projects, err = s.getAllClaGroupsUnderProjectOrFoundation(projectSFID)
+	claGroups, err := s.getCLAGroupsUnderProjectOrFoundation(projectSFID)
 	if err != nil {
 		return nil, err
 	}
-	for _, p := range projects {
-		projectIDs.Add(p.v1ProjectModel.ProjectID)
-	}
-
 	sigs, err := s.getAllCCLASignatures(companyID)
 	if err != nil {
 		return nil, err
@@ -96,7 +95,7 @@ func (s *service) GetCompanyProjectCLAManagers(companyID string, projectSFID str
 	lfUsernames := utils.NewStringSet()
 	// Get CLA managers
 	for _, sig := range sigs {
-		if !projectIDs.Include(sig.ProjectID) {
+		if _, ok := claGroups[sig.ProjectID]; !ok {
 			continue
 		}
 		for _, user := range sig.SignatureACL {
@@ -118,7 +117,7 @@ func (s *service) GetCompanyProjectCLAManagers(companyID string, projectSFID str
 	// fill user info
 	fillUsersInfo(claManagers, usermap)
 	// fill project info
-	fillProjectInfo(claManagers, projects)
+	fillProjectInfo(claManagers, claGroups)
 	// sort result by cla manager name
 	sort.Slice(claManagers, func(i, j int) bool {
 		return claManagers[i].Name < claManagers[j].Name
@@ -127,15 +126,10 @@ func (s *service) GetCompanyProjectCLAManagers(companyID string, projectSFID str
 }
 
 func (s *service) GetCompanyProjectActiveCLAs(companyID string, projectSFID string) (*models.ActiveClaList, error) {
-	var projects map[string]*projectDetailedModel
 	var err error
-	projectIDs := utils.NewStringSet()
-	projects, err = s.getAllClaGroupsUnderProjectOrFoundation(projectSFID)
+	claGroups, err := s.getCLAGroupsUnderProjectOrFoundation(projectSFID)
 	if err != nil {
 		return nil, err
-	}
-	for _, p := range projects {
-		projectIDs.Add(p.v1ProjectModel.ProjectID)
 	}
 	var out models.ActiveClaList
 	sigs, err := s.getAllCCLASignatures(companyID)
@@ -149,7 +143,7 @@ func (s *service) GetCompanyProjectActiveCLAs(companyID string, projectSFID stri
 	var wg sync.WaitGroup
 	wg.Add(len(sigs))
 	for _, sig := range sigs {
-		if !projectIDs.Include(sig.ProjectID) {
+		if _, ok := claGroups[sig.ProjectID]; !ok {
 			// skip the cla_group which are not under current foundation/project
 			wg.Done()
 			continue
@@ -157,7 +151,7 @@ func (s *service) GetCompanyProjectActiveCLAs(companyID string, projectSFID stri
 		activeCla := &models.ActiveCla{}
 		out.List = append(out.List, activeCla)
 		go func(swg *sync.WaitGroup, signature *v1Models.Signature, acla *models.ActiveCla) {
-			s.fillActiveCLA(swg, signature, acla, projects)
+			s.fillActiveCLA(swg, signature, acla, claGroups)
 		}(&wg, sig, activeCla)
 	}
 	wg.Wait()
@@ -231,67 +225,38 @@ func (s *service) GetCompanyProjectCLA(authUser *auth.User, companySFID, project
 			break
 		}
 	}
-	// get company and projects
-	companyModel, projects, err := s.getCompanyAndProjects(companySFID, projectSFID)
-	if err != nil {
-		return nil, err
-	}
-	if len(projects.Projects) == 0 {
-		return nil, errors.New("project not found")
-	}
-	// get company project signatures
-	sigs, err := s.getCompanyProjectCCLASignatures(companyModel.CompanyID, projects)
+	companyModel, err := s.companyRepo.GetCompanyByExternalID(companySFID)
 	if err != nil {
 		return nil, err
 	}
 
+	claGroups, err := s.getCLAGroupsUnderProjectOrFoundation(projectSFID)
+	if err != nil {
+		return nil, err
+	}
+
+	activeCLAList, err := s.GetCompanyProjectActiveCLAs(companyModel.CompanyID, projectSFID)
+	if err != nil {
+		return nil, err
+	}
 	resp := &models.CompanyProjectClaList{
-		SignedClaList:       make([]*models.ActiveCla, 0),
+		SignedClaList:       activeCLAList.List,
 		UnsignedProjectList: make([]*models.UnsignedProject, 0),
 	}
-	psc := v2ProjectService.GetClient()
-	projectDetails, err := psc.GetProject(projectSFID)
-	if err != nil {
-		log.Error("GetCompanyProjectCLAStatus : unable to get project details", err)
-		return nil, err
+	for _, activeCLA := range activeCLAList.List {
+		// remove cla groups for which we have signed cla
+		delete(claGroups, activeCLA.ProjectID)
 	}
-	var pr v2ProjectServiceModels.ProjectOutput
-	err = copier.Copy(&pr, projectDetails)
-	if err != nil {
-		return nil, err
-	}
-	// pmap will keep track of unsigned project
-	pmap := make(map[string]*projectDetailedModel)
-	for i := range projects.Projects {
-		pmap[projects.Projects[i].ProjectID] = &projectDetailedModel{
-			v1ProjectModel:       &projects.Projects[i],
-			v2ProjectOutputModel: &pr,
-		}
-	}
-	// fill details for signed cla
-	var wg sync.WaitGroup
-	wg.Add(len(sigs))
-	for _, sig := range sigs {
-		activeCla := &models.ActiveCla{}
 
-		resp.SignedClaList = append(resp.SignedClaList, activeCla)
-		go func(swg *sync.WaitGroup, signature *v1Models.Signature, acla *models.ActiveCla) {
-			s.fillActiveCLA(swg, signature, acla, pmap)
-		}(&wg, sig, activeCla)
-	}
-	wg.Wait()
-	for _, sig := range sigs {
-		// delete projects from pmap for which we have signature
-		delete(pmap, sig.ProjectID)
-	}
 	// fill details for not signed cla
-	for _, project := range pmap {
+	for claGroupID, claGroup := range claGroups {
 		unsignedProject := &models.UnsignedProject{
 			CanSign:      canSign,
-			ClaGroupID:   project.v1ProjectModel.ProjectID,
-			ClaGroupName: project.v1ProjectModel.ProjectName,
-			ProjectName:  project.v2ProjectOutputModel.Name,
-			ProjectSfid:  project.v1ProjectModel.ProjectExternalID,
+			ClaGroupID:   claGroupID,
+			ClaGroupName: claGroup.ClaGroupName,
+			ProjectName:  claGroup.ProjectName,
+			ProjectSfid:  claGroup.ProjectSFID,
+			SubProjects:  claGroup.SubProjects,
 		}
 		resp.UnsignedProjectList = append(resp.UnsignedProjectList, unsignedProject)
 	}
@@ -358,62 +323,115 @@ func (s *service) GetCompanyCLAGroupManagers(companyID, claGroupID string) (*mod
 	return &models.CompanyClaManagers{List: claManagers}, nil
 }
 
-func (s *service) getAllClaGroupsUnderProjectOrFoundation(id string) (map[string]*projectDetailedModel, error) {
-	result := make(map[string]*projectDetailedModel)                // key cla_group_id
+func v2ProjectToMap(projectDetails *v2ProjectServiceModels.ProjectOutputDetailed) (map[string]*v2ProjectServiceModels.ProjectOutput, error) {
 	epmap := make(map[string]*v2ProjectServiceModels.ProjectOutput) // key project_sfid
-	psc := v2ProjectService.GetClient()
-	projectSFIDs := utils.NewStringSet()
-	projectSFIDs.Add(id)
-	projectDetails, err := psc.GetProject(id)
-	prChan := make(chan *v1Models.Projects)
-	if err != nil {
-		return nil, err
-	}
 	var pr v2ProjectServiceModels.ProjectOutput
-	err = copier.Copy(&pr, projectDetails)
+	err := copier.Copy(&pr, projectDetails)
 	if err != nil {
 		return nil, err
 	}
 	epmap[projectDetails.ID] = &pr
 	for _, p := range projectDetails.Projects {
 		epmap[p.ID] = p
-		projectSFIDs.Add(p.ID)
 	}
-	var wg sync.WaitGroup
-	wg.Add(projectSFIDs.Length())
-	go func() {
-		wg.Wait()
-		close(prChan)
-	}()
-	for _, projectSFID := range projectSFIDs.List() {
-		go func(pid string) {
-			defer wg.Done()
-			projects, err := s.projectRepo.GetProjectsByExternalID(&v1ProjectParams.GetProjectsByExternalIDParams{
-				ProjectSFID: pid,
-				PageSize:    aws.Int64(HugePageSize),
-			}, DontLoadRepoDetails)
+	return epmap, nil
+}
+
+func (s *service) getCLAGroupsUnderProjectOrFoundation(id string) (map[string]*claGroupModel, error) {
+	result := make(map[string]*claGroupModel)
+	psc := v2ProjectService.GetClient()
+	projectDetails, err := psc.GetProject(id)
+	if err != nil {
+		return nil, err
+	}
+	var allProjectMapping []*projects_cla_groups.ProjectClaGroup
+	if projectDetails.ProjectType == FoundationType {
+		// get all projects for all cla group under foundation
+		allProjectMapping, err = s.projectClaGroupsRepo.GetProjectsIdsForFoundation(id)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// get cla group id from project
+		projectMapping, err := s.projectClaGroupsRepo.GetClaGroupIDForProject(id)
+		if err != nil {
+			return nil, err
+		}
+		// get all projects for that cla group
+		allProjectMapping, err = s.projectClaGroupsRepo.GetProjectsIdsForClaGroup(projectMapping.ClaGroupID)
+		if err != nil {
+			return nil, err
+		}
+		if len(allProjectMapping) > 1 {
+			// reload data in projectDetails for all projects of foundation
+			projectDetails, err = psc.GetProject(projectDetails.Foundation.ID)
 			if err != nil {
-				log.Warnf("Unable to fetch project details for project with external id %s. error = %s", pid, err)
-				prChan <- nil
-				return
-			}
-			if projects.ResultCount == 0 {
-				prChan <- nil
-				return
-			}
-			prChan <- projects
-		}(projectSFID)
-	}
-	for p := range prChan {
-		if p != nil {
-			for i := range p.Projects {
-				result[p.Projects[i].ProjectID] = &projectDetailedModel{
-					v1ProjectModel:       &p.Projects[i],
-					v2ProjectOutputModel: epmap[p.Projects[i].ProjectExternalID],
-				}
+				return nil, err
 			}
 		}
 	}
+	// v2ProjectMap will contains projectSFID -> salesforce details of that project
+	v2ProjectMap, err := v2ProjectToMap(projectDetails)
+	if err != nil {
+		return nil, err
+	}
+	// for all cla-groups create claGroupModel
+	for _, pm := range allProjectMapping {
+		cg, ok := result[pm.ClaGroupID]
+		if !ok {
+			cg = &claGroupModel{
+				FoundationSFID: pm.FoundationSFID,
+				SubProjects:    make([]string, 0),
+			}
+			result[pm.ClaGroupID] = cg
+		}
+		cg.SubProjectIDs = append(cg.SubProjectIDs, pm.ProjectSFID)
+	}
+	// if no cla-group found, return empty result
+	if len(result) == 0 {
+		return result, nil
+	}
+	var wg sync.WaitGroup
+	wg.Add(len(result))
+	for id, cg := range result {
+		go func(claGroupID string, claGroup *claGroupModel) {
+			defer wg.Done()
+			// get cla-group info
+			cginfo, err := s.projectRepo.GetProjectByID(claGroupID)
+			if err != nil || cginfo == nil {
+				log.Warnf("Unable to get details of cla_group: %s", claGroupID)
+				return
+			}
+			claGroup.ClaGroupName = cginfo.ProjectName
+
+			var pid string
+			if len(claGroup.SubProjectIDs) == 1 {
+				// use project info if cla-group have only one project
+				pid = claGroup.SubProjectIDs[0]
+			} else {
+				// use foundation info if cla-group have multiple project
+				pid = claGroup.FoundationSFID
+				for _, spid := range claGroup.SubProjectIDs {
+					subProject, ok := v2ProjectMap[spid]
+					if !ok {
+						log.Warnf("Unable to fill details for cla_group: %s with project details of %s", claGroupID, spid)
+						return
+					}
+					claGroup.SubProjects = append(claGroup.SubProjects, subProject.Name)
+				}
+			}
+			project, ok := v2ProjectMap[pid]
+			if !ok {
+				log.Warnf("Unable to fill details for cla_group: %s with project details of %s", claGroupID, claGroup.ProjectSFID)
+				return
+			}
+			claGroup.ProjectLogo = project.ProjectLogo
+			claGroup.ProjectName = project.Name
+			claGroup.ProjectType = project.ProjectType
+			claGroup.ProjectSFID = pid
+		}(id, cg)
+	}
+	wg.Wait()
 	return result, nil
 }
 
@@ -518,54 +536,44 @@ func fillUsersInfo(claManagers []*models.CompanyClaManager, usermap map[string]*
 	}
 }
 
-func fillProjectInfo(claManagers []*models.CompanyClaManager, projects map[string]*projectDetailedModel) {
-	projectSFIDs := utils.NewStringSet()
-	for _, project := range projects {
-		projectSFIDs.Add(project.v1ProjectModel.ProjectExternalID)
-	}
+func fillProjectInfo(claManagers []*models.CompanyClaManager, claGroups map[string]*claGroupModel) {
 	for _, claManager := range claManagers {
-		project, ok := projects[claManager.ProjectID]
+		cg, ok := claGroups[claManager.ProjectID]
 		if !ok {
 			continue
 		}
-		claManager.ClaGroupName = project.v1ProjectModel.ProjectName
-		claManager.ProjectSfid = project.v1ProjectModel.ProjectExternalID
-		if sfproject, ok := projects[project.v1ProjectModel.ProjectID]; ok {
-			claManager.ProjectName = sfproject.v2ProjectOutputModel.Name
-		}
+		claManager.ClaGroupName = cg.ClaGroupName
+		claManager.ProjectSfid = cg.ProjectSFID
+		claManager.ProjectName = cg.ProjectName
 	}
 }
 
-func (s *service) fillActiveCLA(wg *sync.WaitGroup, sig *v1Models.Signature, activeCla *models.ActiveCla, projects map[string]*projectDetailedModel) {
+func (s *service) fillActiveCLA(wg *sync.WaitGroup, sig *v1Models.Signature, activeCla *models.ActiveCla, claGroups map[string]*claGroupModel) {
 	defer wg.Done()
-	p, err := s.projectRepo.GetProjectByID(sig.ProjectID)
-	if err != nil {
-		log.Error("fillActiveCLA : unable to get project", err)
-		return
-	}
-	pr, ok := projects[sig.ProjectID]
+	cg, ok := claGroups[sig.ProjectID]
 	if !ok {
-		log.Error("unable to get project details", err)
+		log.Warn("unable to get project details")
 		return
 	}
-	projectDetails := pr.v2ProjectOutputModel
 
 	// fill details from dynamodb
 	activeCla.ProjectID = sig.ProjectID
 	activeCla.SignedOn = sig.SignatureCreated
-	activeCla.ClaGroupName = p.ProjectName
+	activeCla.ClaGroupName = cg.ClaGroupName
 
 	// fill details from project service
-	activeCla.ProjectName = projectDetails.Name
-	activeCla.ProjectSfid = p.ProjectExternalID
-	activeCla.ProjectType = projectDetails.ProjectType
-	activeCla.ProjectLogo = projectDetails.ProjectLogo
+	activeCla.ProjectName = cg.ProjectName
+	activeCla.ProjectSfid = cg.ProjectSFID
+	activeCla.ProjectType = cg.ProjectType
+	activeCla.ProjectLogo = cg.ProjectLogo
+	activeCla.SubProjects = cg.SubProjects
 	var signatoryName string
 	var cwg sync.WaitGroup
 	cwg.Add(2)
 
 	var cclaURL string
 	go func() {
+		var err error
 		defer cwg.Done()
 		cclaURL, err = utils.GetDownloadLink(utils.SignedCLAFilename(sig.ProjectID, sig.SignatureType, sig.SignatureReferenceID, sig.SignatureID))
 		if err != nil {
@@ -659,59 +667,28 @@ func fillCorporateContributorModel(wg *sync.WaitGroup, usersRepo users.UserRepos
 }
 
 func (s *service) getAllCompanyProjectEmployeeSignatures(companySFID string, projectSFID string) ([]*v1Models.Signature, error) {
-	comp, projects, err := s.getCompanyAndProjects(companySFID, projectSFID)
+	comp, claGroup, err := s.getCompanyAndClaGroup(companySFID, projectSFID)
 	if err != nil {
 		return nil, err
 	}
-	if len(projects.Projects) == 0 {
-		return nil, nil
-	}
 	companyID := comp.CompanyID
-	resp := make(chan *signatureResponse)
-	var swg sync.WaitGroup
-	swg.Add(len(projects.Projects))
-	go func() {
-		swg.Wait()
-		close(resp)
-	}()
-	for _, project := range projects.Projects {
-		go getCompanyProjectEmployeeSignatures(&swg, s.signatureRepo, companyID, project.ProjectID, resp)
-	}
-	var sigs []*v1Models.Signature
-	for res := range resp {
-		if res.err != nil {
-			log.WithFields(logrus.Fields{
-				"company_id": res.companyID,
-				"project_id": res.projectID,
-			}).Error("unable to get company project signatures", res.err)
-			continue
-		}
-		sigs = append(sigs, res.signatures.Signatures...)
-	}
-	return sigs, nil
-}
-
-func getCompanyProjectEmployeeSignatures(wg *sync.WaitGroup, signatureRepo signatures.SignatureRepository, companyID, projectID string, resp chan<- *signatureResponse) {
-	defer wg.Done()
 	params := v1SignatureParams.GetProjectCompanyEmployeeSignaturesParams{
 		HTTPRequest: nil,
 		CompanyID:   companyID,
-		ProjectID:   projectID,
+		ProjectID:   claGroup.ProjectID,
 	}
-	sigs, err := signatureRepo.GetProjectCompanyEmployeeSignatures(params, HugePageSize)
-	resp <- &signatureResponse{
-		companyID:  companyID,
-		projectID:  projectID,
-		signatures: sigs,
-		err:        err,
+	sigs, err := s.signatureRepo.GetProjectCompanyEmployeeSignatures(params, HugePageSize)
+	if err != nil {
+		return nil, err
 	}
+	return sigs.Signatures, nil
 }
 
 // get company and project parallely
-func (s *service) getCompanyAndProjects(companySFID, projectSFID string) (*v1Models.Company, *v1Models.Projects, error) {
+func (s *service) getCompanyAndClaGroup(companySFID, projectSFID string) (*v1Models.Company, *v1Models.Project, error) {
 	var comp *v1Models.Company
+	var claGroup *v1Models.Project
 	var companyErr, projectErr error
-	var projects *v1Models.Projects
 	// query projects and company
 	var cp sync.WaitGroup
 	cp.Add(2)
@@ -722,10 +699,16 @@ func (s *service) getCompanyAndProjects(companySFID, projectSFID string) (*v1Mod
 	go func() {
 		defer cp.Done()
 		t := time.Now()
-		projects, projectErr = s.projectRepo.GetProjectsByExternalID(&v1ProjectParams.GetProjectsByExternalIDParams{
-			ProjectSFID: projectSFID,
-			PageSize:    aws.Int64(HugePageSize),
-		}, DontLoadRepoDetails)
+		var pm *projects_cla_groups.ProjectClaGroup
+		pm, projectErr = s.projectClaGroupsRepo.GetClaGroupIDForProject(projectSFID)
+		if projectErr != nil {
+			log.Debugf("cla group mapping not found for projectSFID %s", projectSFID)
+			return
+		}
+		claGroup, projectErr = s.projectRepo.GetProjectByID(pm.ClaGroupID)
+		if claGroup == nil {
+			projectErr = ErrProjectNotFound
+		}
 		log.WithField("time_taken", time.Since(t).String()).Debugf("getting project by external id : %s completed", projectSFID)
 	}()
 	cp.Wait()
@@ -735,5 +718,5 @@ func (s *service) getCompanyAndProjects(companySFID, projectSFID string) (*v1Mod
 	if projectErr != nil {
 		return nil, nil, projectErr
 	}
-	return comp, projects, nil
+	return comp, claGroup, nil
 }

--- a/cla-backend-go/v2/sign/handlers.go
+++ b/cla-backend-go/v2/sign/handlers.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/communitybridge/easycla/cla-backend-go/projects_cla_groups"
+
 	"github.com/LF-Engineering/lfx-kit/auth"
 	"github.com/communitybridge/easycla/cla-backend-go/gen/v2/models"
 	"github.com/communitybridge/easycla/cla-backend-go/gen/v2/restapi/operations"
@@ -35,6 +37,12 @@ func Configure(api *operations.EasyclaAPI, service Service) {
 			if err != nil {
 				if strings.Contains(err.Error(), "does not exist") {
 					return sign.NewRequestCorporateSignatureNotFound().WithPayload(errorResponse(err))
+				}
+				if err == projects_cla_groups.ErrProjectNotAssociatedWithClaGroup {
+					return sign.NewRequestCorporateSignatureNotFound().WithPayload(errorResponse(err))
+				}
+				if err == ErrCCLANotEnabled || err == ErrTemplateNotConfigured {
+					return sign.NewRequestCorporateSignatureBadRequest().WithPayload(errorResponse(err))
 				}
 				if err == err.(*organizations.ListOrgUsrAdminScopesNotFound) {
 					formatErr := errors.New("user role scopes not found for cla-signatory role ")

--- a/cla-backend-go/whitelist/service.go
+++ b/cla-backend-go/whitelist/service.go
@@ -25,6 +25,11 @@ var (
 	ErrCclaWhitelistRequestAlreadyExists = errors.New("CCLA whiltelist request already exist")
 )
 
+// constants
+const (
+	DontLoadRepoDetails = true
+)
+
 // IService interface defines the service methods/functions
 type IService interface {
 	AddCclaWhitelistRequest(companyID string, projectID string, args models.CclaWhitelistRequestInput) (string, error)
@@ -74,7 +79,7 @@ func (s service) AddCclaWhitelistRequest(companyID string, projectID string, arg
 		log.Warnf("AddCclaWhitelistRequest - unable to lookup company by id: %s, error: %+v", companyID, err)
 		return "", err
 	}
-	projectModel, err := s.projectRepo.GetProjectByID(projectID)
+	projectModel, err := s.projectRepo.GetProjectByID(projectID, DontLoadRepoDetails)
 	if err != nil {
 		log.Warnf("AddCclaWhitelistRequest - unable to lookup project by id: %s, error: %+v", projectID, err)
 		return "", err
@@ -132,7 +137,7 @@ func (s service) ApproveCclaWhitelistRequest(companyID, projectID, requestID str
 		log.Warnf("ApproveCclaWhitelistRequest - unable to lookup company by id: %s, error: %+v", companyID, err)
 		return err
 	}
-	projectModel, err := s.projectRepo.GetProjectByID(projectID)
+	projectModel, err := s.projectRepo.GetProjectByID(projectID, DontLoadRepoDetails)
 	if err != nil {
 		log.Warnf("ApproveCclaWhitelistRequest - unable to lookup project by id: %s, error: %+v", projectID, err)
 		return err
@@ -170,7 +175,7 @@ func (s service) RejectCclaWhitelistRequest(companyID, projectID, requestID stri
 		log.Warnf("RejectCclaWhitelistRequest - unable to lookup company by id: %s, error: %+v", companyID, err)
 		return err
 	}
-	projectModel, err := s.projectRepo.GetProjectByID(projectID)
+	projectModel, err := s.projectRepo.GetProjectByID(projectID, DontLoadRepoDetails)
 	if err != nil {
 		log.Warnf("RejectCclaWhitelistRequest - unable to lookup project by id: %s, error: %+v", projectID, err)
 		return err


### PR DESCRIPTION
Updated api. Following api will use project-cla-group mapping
    1) get company project cla managers [foundation and project dashboard]
    2) get company project active cla [foundation and project dashboard]
    3) get company project cla [foundation and project dashboard]
    4) get company project signatures [project dashboard]
    5) get company project contributors acknowledgement [project dashboard]
    6) request corporate signature [project dashboard] 

adding loadRepo flag in GetProjectByID function
Removing cla_group_id from input of RequestCorporateSignature
Adding extra error messages in RequestCorporateSignature api
passing signature_id in response for active-cla api
fixing getProjectCompanyContributors api using condition signature_signed=True and signature_approved=True

adding sub_projects in response of active cla api which will include list of projects of cla_group.
passing foundationName if cla_group have multiple projects.