### PR TITLE
Resolved Potentially Unsafe External Link

### DIFF
--- a/cla-frontend-project-console/src/ionic/pages/project/project-cla/project-cla.html
+++ b/cla-frontend-project-console/src/ionic/pages/project/project-cla/project-cla.html
@@ -474,7 +474,7 @@
                           <ion-card-content>
                             <h1>{{ gerrit.gerrit_name }} </h1>
                             <p>
-                              <a target="_blank" href="{{ gerrit.gerrit_url }}">
+                              <a target="_blank" href="{{ gerrit.gerrit_url }}" rel="noopener noreferrer">
                                 {{gerrit.gerrit_url }}
                               </a>
                             </p>


### PR DESCRIPTION
- Resolved issue identified by Code Scanning Alert: External links that
  open in a new tab or window but do not specify link type 'noopener' or
  'noreferrer' are a potential security risk. Added anchor attributes.

Signed-off-by: David Deal <dealako@gmail.com>