### PR TITLE
[#1104] supporting cla signing at foundation level

### DIFF
--- a/cla-backend-go/swagger/cla.v2.yaml
+++ b/cla-backend-go/swagger/cla.v2.yaml
@@ -2442,6 +2442,8 @@ paths:
           $ref: '#/responses/forbidden'
         '404':
           $ref: '#/responses/not-found'
+        '500':
+          $ref: '#/responses/internal-server-error'
         '409':
           $ref: '#/responses/conflict'
       tags:

--- a/cla-backend-go/v2/sign/handlers.go
+++ b/cla-backend-go/v2/sign/handlers.go
@@ -38,6 +38,9 @@ func Configure(api *operations.EasyclaAPI, service Service) {
 				if strings.Contains(err.Error(), "does not exist") {
 					return sign.NewRequestCorporateSignatureNotFound().WithPayload(errorResponse(err))
 				}
+				if strings.Contains(err.Error(), "internal server error") {
+					return sign.NewRequestCorporateSignatureInternalServerError().WithPayload(errorResponse(err))
+				}
 				if err == projects_cla_groups.ErrProjectNotAssociatedWithClaGroup {
 					return sign.NewRequestCorporateSignatureNotFound().WithPayload(errorResponse(err))
 				}


### PR DESCRIPTION
root_project_sfid  i.e foundation_sfid can be passed to the request_corporate_signature api if only one cla-group is linked with it
adding extra validations in request_corporate_signature api

