### PR TITLE
[#1503] Delete CLA Group Cleanup

### DIFF
--- a/cla-backend-go/cmd/dynamo_events_lambda/main.go
+++ b/cla-backend-go/cmd/dynamo_events_lambda/main.go
@@ -78,7 +78,18 @@ func init() {
 	token.Init(configFile.Auth0Platform.ClientID, configFile.Auth0Platform.ClientSecret, configFile.Auth0Platform.URL, configFile.Auth0Platform.Audience)
 	user_service.InitClient(configFile.APIGatewayURL, configFile.AcsAPIKey)
 	project_service.InitClient(configFile.APIGatewayURL)
-	organization_service.InitClient(configFile.APIGatewayURL)
+
+	type combinedRepo struct {
+		users.UserRepository
+		company.IRepository
+		project.ProjectRepository
+	}
+	eventsService := claevents.NewService(eventsRepo, combinedRepo{
+		usersRepo,
+		companyRepo,
+		projectRepo,
+	})
+	organization_service.InitClient(configFile.APIGatewayURL, eventsService)
 	acs_service.InitClient(configFile.APIGatewayURL, configFile.AcsAPIKey)
 	dynamoEventsService = dynamo_events.NewService(stage, signaturesRepo, companyRepo, projectClaGroupRepo, eventsRepo, projectRepo)
 }

--- a/cla-backend-go/events/event_data.go
+++ b/cla-backend-go/events/event_data.go
@@ -17,7 +17,9 @@ type GithubRepositoryDeletedEventData struct {
 	RepositoryName string
 }
 
-type GerritProjectDeletedEventData struct{}
+type GerritProjectDeletedEventData struct {
+	DeletedCount int
+}
 
 type GerritAddedEventData struct {
 	GerritRepositoryName string
@@ -27,9 +29,13 @@ type GerritDeletedEventData struct {
 	GerritRepositoryName string
 }
 
-type GithubProjectDeletedEventData struct{}
+type GithubProjectDeletedEventData struct {
+	DeletedCount int
+}
 
-type SignatureProjectInvalidatedEventData struct{}
+type SignatureProjectInvalidatedEventData struct {
+	InvalidatedCount int
+}
 
 type UserCreatedEventData struct{}
 type UserDeletedEventData struct {
@@ -230,6 +236,20 @@ type UserConvertToContactData struct{}
 type AssignRoleScopeData struct {
 	Role  string
 	Scope string
+}
+
+type ClaManagerRoleCreatedData struct {
+	Role      string
+	Scope     string
+	UserName  string
+	UserEmail string
+}
+
+type ClaManagerRoleDeletedData struct {
+	Role      string
+	Scope     string
+	UserName  string
+	UserEmail string
 }
 
 func (ed *GithubRepositoryAddedEventData) GetEventString(args *LogEventArgs) (string, bool) {
@@ -441,8 +461,8 @@ func (ed *CLAGroupDeletedEventData) GetEventString(args *LogEventArgs) (string, 
 }
 
 func (ed *GerritProjectDeletedEventData) GetEventString(args *LogEventArgs) (string, bool) {
-	data := fmt.Sprintf("Gerrit Repository Deleted  due to CLA Group/Project: [%s] deletion",
-		args.projectName)
+	data := fmt.Sprintf("Deleted %d Gerrit Repositories due to CLA Group/Project: [%s] deletion",
+		ed.DeletedCount, args.projectName)
 	containsPII := false
 	return data, containsPII
 }
@@ -460,14 +480,14 @@ func (ed *GerritDeletedEventData) GetEventString(args *LogEventArgs) (string, bo
 }
 
 func (ed *GithubProjectDeletedEventData) GetEventString(args *LogEventArgs) (string, bool) {
-	data := fmt.Sprintf("Github Repository Deleted  due to CLA Group/Project: [%s] deletion",
-		args.projectName)
+	data := fmt.Sprintf("Deleted %d Github Repositories  due to CLA Group/Project: [%s] deletion",
+		ed.DeletedCount, args.projectName)
 	return data, true
 }
 
 func (ed *SignatureProjectInvalidatedEventData) GetEventString(args *LogEventArgs) (string, bool) {
-	data := fmt.Sprintf("Signature invalidated (approved set to false) due to CLA Group/Project: [%s] deletion",
-		args.projectName)
+	data := fmt.Sprintf("Invalidated %d signatures (approved set to false) due to CLA Group/Project: [%s] deletion",
+		ed.InvalidatedCount, args.projectName)
 	return data, true
 }
 
@@ -504,4 +524,14 @@ func (ed *AssignRoleScopeData) GetEventString(args *LogEventArgs) (string, bool)
 		args.LfUsername,
 		ed.Scope, ed.Role, args.ExternalProjectID)
 	return data, true
+}
+
+func (ed *ClaManagerRoleCreatedData) GetEventString(args *LogEventArgs) (string, bool) {
+	data := fmt.Sprintf("user [%s] added user %s/%s from role: %s with scope: %s", args.userName, ed.UserName, ed.UserEmail, ed.Role, ed.Scope)
+	return data, false
+}
+
+func (ed *ClaManagerRoleDeletedData) GetEventString(args *LogEventArgs) (string, bool) {
+	data := fmt.Sprintf("user [%s] removed user %s/%s from role: %s with scope: %s", args.userName, ed.UserName, ed.UserEmail, ed.Role, ed.Scope)
+	return data, false
 }

--- a/cla-backend-go/events/event_types.go
+++ b/cla-backend-go/events/event_types.go
@@ -64,8 +64,10 @@ const (
 
 	ClaApprovalListUpdated = "cla_manager.approval_list_updated"
 
-	ClaManagerCreated = "cla_manager.added"
-	ClaManagerDeleted = "cla_manager.deleted"
+	ClaManagerCreated     = "cla_manager.added"
+	ClaManagerDeleted     = "cla_manager.deleted"
+	ClaManagerRoleCreated = "cla_manager.added"
+	ClaManagerRoleDeleted = "cla_manager.deleted"
 
 	CLAGroupCreated = "cla_group.created"
 	CLAGroupUpdated = "cla_group.updated"

--- a/cla-backend-go/gerrits/service.go
+++ b/cla-backend-go/gerrits/service.go
@@ -16,7 +16,7 @@ import (
 
 // Service handles gerrit Repository service
 type Service interface {
-	DeleteClaGroupGerrits(claGroupID string) error
+	DeleteClaGroupGerrits(claGroupID string) (int, error)
 	DeleteGerrit(gerritID string) error
 	GetGerrit(gerritID string) (*models.Gerrit, error)
 	AddGerrit(claGroupID string, projectSFID string, input *models.AddGerritInput) (*models.Gerrit, error)
@@ -36,21 +36,21 @@ func NewService(repo Repository, lfg *LFGroup) Service {
 	}
 }
 
-func (s service) DeleteClaGroupGerrits(claGroupID string) error {
+func (s service) DeleteClaGroupGerrits(claGroupID string) (int, error) {
 	gerrits, err := s.repo.GetClaGroupGerrits(claGroupID, nil)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	if len(gerrits.List) > 0 {
 		log.Debugf(fmt.Sprintf("Deleting gerrits for cla-group :%s ", claGroupID))
 		for _, gerrit := range gerrits.List {
 			err = s.repo.DeleteGerrit(gerrit.GerritID)
 			if err != nil {
-				return err
+				return 0, err
 			}
 		}
 	}
-	return nil
+	return len(gerrits.List), nil
 }
 
 func (s service) DeleteGerrit(gerritID string) error {

--- a/cla-backend-go/repositories/service.go
+++ b/cla-backend-go/repositories/service.go
@@ -14,7 +14,7 @@ type Service interface {
 	DeleteGithubRepository(externalProjectID string, repositoryID string) error
 	ListProjectRepositories(externalProjectID string) (*models.ListGithubRepositories, error)
 	GetGithubRepository(repositoryID string) (*models.GithubRepository, error)
-	DeleteProject(projectID string) error
+	DeleteProject(projectID string) (int, error)
 	GetGithubRepositoryByCLAGroup(claGroupID string) (*models.GithubRepository, error)
 }
 
@@ -45,11 +45,12 @@ func (s *service) GetGithubRepository(repositoryID string) (*models.GithubReposi
 	return s.repo.GetGithubRepository(repositoryID)
 }
 
-func (s *service) DeleteProject(projectID string) error {
+// DeleteProject removes the repositories by Organizations
+func (s *service) DeleteProject(projectID string) (int, error) {
 	var deleteErr error
 	ghOrgs, err := s.repo.GetProjectRepositoriesGroupByOrgs(projectID)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	if len(ghOrgs) > 0 {
 		log.Debugf("Deleting repositories for project :%s", projectID)
@@ -62,7 +63,8 @@ func (s *service) DeleteProject(projectID string) error {
 			}
 		}
 	}
-	return nil
+
+	return len(ghOrgs), nil
 }
 
 func (s *service) GetGithubRepositoryByCLAGroup(claGroupID string) (*models.GithubRepository, error) {

--- a/cla-backend-go/signatures/models.go
+++ b/cla-backend-go/signatures/models.go
@@ -1,0 +1,12 @@
+// Copyright The Linux Foundation and each contributor to CommunityBridge.
+// SPDX-License-Identifier: MIT
+
+package signatures
+
+// SignatureCompanyID is a simple data model to hold the signature ID and come company details for CCLA's
+type SignatureCompanyID struct {
+	SignatureID string
+	CompanyID   string
+	CompanySFID string
+	CompanyName string
+}

--- a/cla-backend-go/v2/acs-service/client.go
+++ b/cla-backend-go/v2/acs-service/client.go
@@ -109,7 +109,12 @@ func (ac *Client) GetRoleID(roleName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		closeErr := resp.Body.Close()
+		if closeErr != nil {
+			log.Warnf("error closing resource: %+v", closeErr)
+		}
+	}()
 	var roles []struct {
 		RoleName string `json:"role_name"`
 		RoleID   string `json:"role_id"`

--- a/cla-backend-go/v2/dynamo_events/projects_cla_groups.go
+++ b/cla-backend-go/v2/dynamo_events/projects_cla_groups.go
@@ -1,9 +1,15 @@
 package dynamo_events
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/aws/aws-lambda-go/events"
+	"github.com/communitybridge/easycla/cla-backend-go/gen/models"
 	log "github.com/communitybridge/easycla/cla-backend-go/logging"
+	"github.com/communitybridge/easycla/cla-backend-go/utils"
 	v2ProjectService "github.com/communitybridge/easycla/cla-backend-go/v2/project-service"
+	"github.com/sirupsen/logrus"
 )
 
 // ProjectClaGroup is database model for projects_cla_group table
@@ -31,19 +37,58 @@ func (s *service) ProjectAddedEvent(event events.DynamoDBEventRecord) error {
 	return nil
 }
 
+// ProjectDeleteEvent handles the CLA Group (projects table) delete event
 func (s *service) ProjectDeletedEvent(event events.DynamoDBEventRecord) error {
+	f := logrus.Fields{
+		"functionName": "ProjectDeletedEvent",
+		"eventID":      event.EventID,
+		"eventName":    event.EventName,
+		"eventSource":  event.EventSource,
+	}
 	log.Debug("ProjectDeletedEvent called")
 	var oldProject ProjectClaGroup
 	err := unmarshalStreamImage(event.Change.OldImage, &oldProject)
 	if err != nil {
+		log.WithFields(f).Warnf("problem unmarshalling stream image, error: %+v", err)
 		return err
 	}
+
+	// Add more fields for the logger
+	f["ProjectSFID"] = oldProject.ProjectSFID
+	f["ClaGroupID"] = oldProject.ClaGroupID
+	f["FoundationSFID"] = oldProject.FoundationSFID
+
 	psc := v2ProjectService.GetClient()
-	log.WithField("project_sfid", oldProject.ProjectSFID).Debug("disabling CLA service")
+	// Gathering metrics - grab the time before the API call
+	before, _ := utils.CurrentTime()
+	log.WithFields(f).Debug("disabling CLA service")
 	err = psc.DisableCLA(oldProject.ProjectSFID)
+	log.WithFields(f).Debugf("disabling CLA service took %s", time.Since(before).String())
+
 	if err != nil {
-		log.WithField("project_sfid", oldProject.ProjectSFID).Error("disabling CLA service failed")
+		log.WithFields(f).Warnf("disabling CLA service failed, error: %+v", err)
 		return err
 	}
+
+	// Log the event
+	eventErr := s.eventsRepo.CreateEvent(&models.Event{
+		ContainsPII:            false,
+		EventData:              fmt.Sprintf("disabled CLA service for Project: %s", oldProject.ProjectSFID),
+		EventFoundationSFID:    oldProject.FoundationSFID,
+		EventProjectExternalID: oldProject.ProjectSFID,
+		EventProjectID:         oldProject.ClaGroupID,
+		EventProjectSFID:       oldProject.ProjectSFID,
+		EventType:              "disable.cla",
+		LfUsername:             "easycla system",
+		UserID:                 "easycla system",
+		UserName:               "easycla system",
+		// EventProjectName:       "",
+		// EventProjectSFName:     "",
+	})
+	if eventErr != nil {
+		log.WithFields(f).Warnf("problem logging event for disabling CLA service, error: %+v", eventErr)
+		// Ok - don't fail for now
+	}
+
 	return nil
 }


### PR DESCRIPTION
- Refactored delete CLA Group logic - moved most of delete code to service layer
- Added count to delete gerrit repos - only show event log when one or more gerrits are removed
- Added count to delete github repos - only show event log when one or more github repositories are removed
- Added count to number of signatures invalidated - only show event log when one or more signatures are invalidated
- Added remove permissions for CLA Manager, CLA Manger Designee, CLA Signatory
- Logging Updates
- Added additional event logging

Signed-off-by: David Deal <dealako@gmail.com>