### PR TITLE
Updated CI golang build version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ jobs:
 
   buildGoBackend: &buildGoBackendAnchor
     docker:
-      - image: circleci/golang:1.14.5
+      - image: circleci/golang:1.14.6
     working_directory: /go/src/github.com/communitybridge/easycla/
     steps:
       - checkout
@@ -895,7 +895,7 @@ jobs:
 
   functionalTestsGo: &functionalTestsGo
     docker:
-      - image: circleci/golang:1.14.5
+      - image: circleci/golang:1.14.6
     steps:
       - attach_workspace:
           at: ~/


### PR DESCRIPTION
- Updated golang build ci version to 1.14.6

Signed-off-by: David Deal <dealako@gmail.com>