### PR TITLE
[#1519] V2 - While sending request to signatory 500 is returned when only spaces is provided for the authority_name api bugfix 

### DIFF
--- a/cla-backend-go/swagger/cla.v2.yaml
+++ b/cla-backend-go/swagger/cla.v2.yaml
@@ -3487,6 +3487,7 @@ definitions:
         type: string
         example: 'John Doe'
         description: name of the cla signatory
+        pattern: "^[a-zA-Z]+(([',. -][a-zA-Z ])?[a-zA-Z]*)*$"
       authority_email:
         type: string
         example: 'user@linuxfoundation.org'

--- a/cla-backend-go/v2/sign/service.go
+++ b/cla-backend-go/v2/sign/service.go
@@ -98,7 +98,9 @@ func (in *requestCorporateSignatureOutput) toModel() *models.CorporateSignatureO
 
 func validateCorporateSignatureInput(input *models.CorporateSignatureInput) error {
 	if input.SendAsEmail {
-		if input.AuthorityName == "" {
+		log.Debugf("input.AuthorityName validation %s", input.AuthorityName)
+		if strings.TrimSpace(input.AuthorityName) == "" {
+			log.Warn("error in input.AuthorityName ")
 			return errors.New("require authority_name")
 		}
 		if input.AuthorityEmail == "" {
@@ -207,6 +209,7 @@ func (s *service) RequestCorporateSignature(lfUsername string, authorizationHead
 }
 
 func requestCorporateSignature(authToken string, apiURL string, input *requestCorporateSignatureInput) (*requestCorporateSignatureOutput, error) {
+	log.Debugf("input.AuthorityName %s", input.AuthorityName)
 	f := logrus.Fields{
 		"functionName":   "requestCorporateSignature",
 		"apiURL":         apiURL,


### PR DESCRIPTION
- Fix the issue reported by Nirupama regarding authority_name provided as space than giving 500 internal server error.
- Update the validation while checking empty before that doing string trimming.

Signed-off-by: Rinkesh Bhutwala rbhutwal@proximabiz.com