### PR TITLE
[#1043,#1498] CLA Check Comment Update

### DIFF
--- a/cla-backend/cla/models/github_models.py
+++ b/cla-backend/cla/models/github_models.py
@@ -806,6 +806,8 @@ def has_check_previously_failed(pull_request: PullRequest) -> bool:
             return True
         if '[![CLA Check](' in comment.body and 'must confirm their affiliation' in comment.body:
             return True
+        if '[![CLA Check](' in comment.body and 'is missing the User' in comment.body:
+            return True
     return False
 
 


### PR DESCRIPTION
- Resolved case where previous GitHub failed comment was not being updated

Signed-off-by: David Deal <dealako@gmail.com>