### PR TITLE
[#1497] CLA Group Name Length

### DIFF
--- a/cla-backend-go/project/handlers.go
+++ b/cla-backend-go/project/handlers.go
@@ -239,7 +239,7 @@ func Configure(api *operations.ClaAPI, service Service, eventsService events.Ser
 		return project.NewDeleteProjectByIDNoContent()
 	})
 
-	// Update Project By ID
+	// Update Project By Name
 	api.ProjectUpdateProjectHandler = project.UpdateProjectHandlerFunc(func(projectParams project.UpdateProjectParams, claUser *user.CLAUser) middleware.Responder {
 
 		exitingModel, getErr := service.GetCLAGroupByName(projectParams.Body.ProjectName)
@@ -253,11 +253,11 @@ func Configure(api *operations.ClaAPI, service Service, eventsService events.Ser
 		}
 
 		// If the project with the same name exists...
-		if exitingModel != nil {
-			msg := fmt.Sprintf("Project with same name exists: %s", projectParams.Body.ProjectName)
-			log.Warnf("Update Project Failed - %s", msg)
-			return project.NewCreateProjectConflict().WithPayload(&models.ErrorResponse{
-				Code:    "409",
+		if exitingModel == nil {
+			msg := fmt.Sprintf("unable to locate project with name: %s", projectParams.Body.ProjectName)
+			log.Warn(msg)
+			return project.NewUpdateProjectNotFound().WithPayload(&models.ErrorResponse{
+				Code:    "404",
 				Message: msg,
 			})
 		}

--- a/cla-backend-go/project/models.go
+++ b/cla-backend-go/project/models.go
@@ -11,9 +11,9 @@ type DBProjectModel struct {
 	ProjectID                        string                   `dynamodbav:"project_id"`
 	FoundationSFID                   string                   `dynamodbav:"foundation_sfid"`
 	RootProjectRepositoriesCount     int64                    `dynamodbav:"root_project_repositories_count"`
-	ProjectDescription               string                   `dynamodbav:"project_description"`
 	ProjectName                      string                   `dynamodbav:"project_name"`
 	ProjectNameLower                 string                   `dynamodbav:"project_name_lower"`
+	ProjectDescription               string                   `dynamodbav:"project_description"`
 	Version                          string                   `dynamodbav:"version"`
 	ProjectCclaEnabled               bool                     `dynamodbav:"project_ccla_enabled"`
 	ProjectCclaRequiresIclaSignature bool                     `dynamodbav:"project_ccla_requires_icla_signature"`

--- a/cla-backend-go/project/repository.go
+++ b/cla-backend-go/project/repository.go
@@ -661,6 +661,14 @@ func (repo *repo) UpdateCLAGroup(projectModel *models.Project) (*models.Project,
 		expressionAttributeValues[":low"] = &dynamodb.AttributeValue{S: aws.String(strings.ToLower(projectModel.ProjectName))}
 		updateExpression = updateExpression + " #LOW = :low, "
 	}
+
+	if projectModel.ProjectDescription != "" {
+		log.WithFields(f).Debugf("adding project_description: %s", projectModel.ProjectDescription)
+		expressionAttributeNames["#DESC"] = aws.String("project_description")
+		expressionAttributeValues[":desc"] = &dynamodb.AttributeValue{S: aws.String(projectModel.ProjectDescription)}
+		updateExpression = updateExpression + " #DESC = :desc, "
+	}
+
 	if projectModel.ProjectACL != nil && len(projectModel.ProjectACL) > 0 {
 		log.WithFields(f).Debugf("adding project_acl: %s", projectModel.ProjectACL)
 		expressionAttributeNames["#A"] = aws.String("project_acl")
@@ -808,13 +816,14 @@ func (repo *repo) buildCLAGroupModel(dbModel DBProjectModel, loadRepoDetails boo
 				dbModel.ProjectName, dbModel.ProjectID)
 		}
 	}
+
 	return &models.Project{
 		ProjectID:                    dbModel.ProjectID,
 		FoundationSFID:               dbModel.FoundationSFID,
 		RootProjectRepositoriesCount: dbModel.RootProjectRepositoriesCount,
-		ProjectDescription:           dbModel.ProjectDescription,
 		ProjectExternalID:            dbModel.ProjectExternalID,
 		ProjectName:                  dbModel.ProjectName,
+		ProjectDescription:           dbModel.ProjectDescription,
 		ProjectACL:                   dbModel.ProjectACL,
 		ProjectCCLAEnabled:           dbModel.ProjectCclaEnabled,
 		ProjectICLAEnabled:           dbModel.ProjectIclaEnabled,
@@ -864,10 +873,10 @@ func buildProjection() expression.ProjectionBuilder {
 		expression.Name("project_id"),
 		expression.Name("foundation_sfid"),
 		expression.Name("root_project_repositories_count"),
-		expression.Name("project_description"),
 		expression.Name("project_external_id"),
 		expression.Name("project_name"),
 		expression.Name("project_name_lower"),
+		expression.Name("project_description"),
 		expression.Name("project_acl"),
 		expression.Name("project_ccla_enabled"),
 		expression.Name("project_icla_enabled"),

--- a/cla-backend-go/swagger/common/properties/cla-group-name.yaml
+++ b/cla-backend-go/swagger/common/properties/cla-group-name.yaml
@@ -1,6 +1,7 @@
 example: 'OpenCue'
 type: string
 description: name of the CLA group
-pattern: '^([\w\p{L}][\w\s\p{L}()\[\]+-]*){2,255}$'
+pattern: '^([\w\p{L}][\w\s\p{L}()\[\]+-]*){2,100}$'
 minLength: 2
-maxLength: 255
+# No more than 100 - DocuSign limits the CLA Group/Project Name to 100 characters when filling out CLA agreements
+maxLength: 100

--- a/cla-frontend-project-console/src/ionic/modals/cla-contract-config-modal/cla-contract-config-modal.html
+++ b/cla-frontend-project-console/src/ionic/modals/cla-contract-config-modal/cla-contract-config-modal.html
@@ -17,7 +17,12 @@
         <ion-col col-12>
           <ion-item>
             <ion-label stacked>CLA Group Name</ion-label>
-            <ion-input type="text" maxlength="150" (ionFocus)="clearError($event)" formControlName="name"></ion-input>
+            <ion-input type="text" maxlength="100" (ionFocus)="clearError($event)" formControlName="name"></ion-input>
+          </ion-item>
+
+          <ion-item>
+            <ion-label stacked>CLA Group Description</ion-label>
+            <ion-input type="text" maxlength="256" (ionFocus)="clearError($event)" formControlName="description"></ion-input>
           </ion-item>
 
           <!-- <ion-item no-lines> -->

--- a/cla-frontend-project-console/src/ionic/modals/cla-contract-config-modal/cla-contract-config-modal.ts
+++ b/cla-frontend-project-console/src/ionic/modals/cla-contract-config-modal/cla-contract-config-modal.ts
@@ -1,11 +1,11 @@
 // Copyright The Linux Foundation and each contributor to CommunityBridge.
 // SPDX-License-Identifier: MIT
 
-import { Component } from '@angular/core';
-import { NavController, NavParams, ViewController, IonicPage, Events } from 'ionic-angular';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { ClaService } from '../../services/cla.service';
-import { PlatformLocation } from '@angular/common';
+import {Component} from '@angular/core';
+import {Events, IonicPage, NavController, NavParams, ViewController} from 'ionic-angular';
+import {FormBuilder, FormGroup, Validators} from '@angular/forms';
+import {ClaService} from '../../services/cla.service';
+import {PlatformLocation} from '@angular/common';
 
 @IonicPage({
   segment: 'cla-contract-config-modal'
@@ -41,7 +41,18 @@ export class ClaContractConfigModal {
       this.viewCtrl.dismiss(false);
     });
     this.form = formBuilder.group({
-      name: [this.claProject.projectName, Validators.compose([Validators.required])],
+      name: [this.claProject.projectName, Validators.compose(
+        [
+          Validators.required,
+          Validators.minLength(2),
+          Validators.maxLength(100)
+        ])],
+      description: [this.claProject.projectDescription, Validators.compose(
+        [
+          Validators.required,
+          Validators.minLength(2),
+          Validators.maxLength(256)
+        ])],
       ccla: [this.claProject.projectCCLAEnabled],
       cclaAndIcla: [this.claProject.projectCCLARequiresICLA],
       icla: [this.claProject.projectICLAEnabled]
@@ -60,6 +71,7 @@ export class ClaContractConfigModal {
       this.claProject = {
         projectExternalID: this.projectId,
         projectName: '',
+        projectDescription: '',
         projectCCLAEnabled: false,
         projectCCLARequiresICLA: false,
         projectICLAEnabled: false
@@ -67,7 +79,8 @@ export class ClaContractConfigModal {
     }
   }
 
-  ngOnInit() { }
+  ngOnInit() {
+  }
 
   submit() {
     this.submitAttempt = true;
@@ -99,6 +112,7 @@ export class ClaContractConfigModal {
     let claProject = {
       projectExternalID: this.claProject.projectExternalID,
       projectName: this.form.value.name,
+      projectDescription: this.form.value.description,
       projectCCLAEnabled: this.form.value.ccla,
       projectACL: [localStorage.getItem('userid')],
       projectCCLARequiresICLA: this.form.value.cclaAndIcla,
@@ -122,6 +136,7 @@ export class ClaContractConfigModal {
       projectID: this.claProject.projectID,
       projectExternalID: this.claProject.projectExternalID,
       projectName: this.form.value.name,
+      projectDescription: this.form.value.description,
       projectCCLAEnabled: this.form.value.ccla,
       projectCCLARequiresICLA: this.form.value.cclaAndIcla,
       projectICLAEnabled: this.form.value.icla

--- a/cla-frontend-project-console/src/ionic/pages/project/project-cla/project-cla.ts
+++ b/cla-frontend-project-console/src/ionic/pages/project/project-cla/project-cla.ts
@@ -1,13 +1,13 @@
 // Copyright The Linux Foundation and each contributor to CommunityBridge.
 // SPDX-License-Identifier: MIT
 
-import { Component, ViewChild } from '@angular/core';
-import { AlertController, Events, IonicPage, ModalController, Nav, NavController, NavParams } from 'ionic-angular';
-import { ClaService } from '../../../services/cla.service';
-import { RolesService } from '../../../services/roles.service';
-import { Restricted } from '../../../decorators/restricted';
-import { GithubOrganisationModel } from '../../../models/github-organisation-model';
-import { PlatformLocation } from '@angular/common';
+import {Component, ViewChild} from '@angular/core';
+import {AlertController, Events, IonicPage, ModalController, Nav, NavController, NavParams} from 'ionic-angular';
+import {ClaService} from '../../../services/cla.service';
+import {RolesService} from '../../../services/roles.service';
+import {Restricted} from '../../../decorators/restricted';
+import {GithubOrganisationModel} from '../../../models/github-organisation-model';
+import {PlatformLocation} from '@angular/common';
 
 @Restricted({
   roles: ['isAuthenticated', 'isPmcUser']
@@ -261,7 +261,8 @@ export class ProjectClaPage {
           text: 'Cancel',
           role: 'cancel',
           cssClass: 'secondary',
-          handler: () => { }
+          handler: () => {
+          }
         },
         {
           text: 'Delete',
@@ -293,7 +294,8 @@ export class ProjectClaPage {
           text: 'Cancel',
           role: 'cancel',
           cssClass: 'secondary',
-          handler: () => { }
+          handler: () => {
+          }
         },
         {
           text: 'Delete',
@@ -316,7 +318,8 @@ export class ProjectClaPage {
           text: 'Cancel',
           role: 'cancel',
           cssClass: 'secondary',
-          handler: () => { }
+          handler: () => {
+          }
         },
         {
           text: 'Retry',
@@ -339,7 +342,8 @@ export class ProjectClaPage {
           text: 'Close',
           role: 'cancel',
           cssClass: 'secondary',
-          handler: () => { }
+          handler: () => {
+          }
         }
       ]
     });
@@ -354,8 +358,7 @@ export class ProjectClaPage {
       if (res.status === 204) {
         this.getClaProjects();
         this.deleteClaGroupSuccess(name);
-      }
-      else {
+      } else {
         this.deleteClaGroupError(name, id)
         this.loading.claProject = false;
       }

--- a/cla-frontend-project-console/src/ionic/services/cla.service.ts
+++ b/cla-frontend-project-console/src/ionic/services/cla.service.ts
@@ -114,7 +114,7 @@ export class ClaService {
     const url: URL = this.getV2Endpoint('/v2/user/' + userId);
     return this.http.get(url).map((res) => res.json());
   }
-  
+
   /**
    * GET /v3/signatures/project/{project_id}
    *
@@ -183,6 +183,7 @@ export class ClaService {
       {
         'project_external_id': '<proj-external-id>',
         'project_name': 'Project Name',
+        'project_description': 'Project Description....',
         'project_ccla_enabled': True,
         'project_ccla_requires_icla_signature': True,
         'project_icla_enabled': True
@@ -200,7 +201,11 @@ export class ClaService {
     /*
       {
         'project_id': '<project-id>',
-        'project_name': 'New Project Name'
+        'project_name': 'New Project Name',
+        'project_description': 'Project Description....',
+        'project_ccla_enabled': True,
+        'project_ccla_requires_icla_signature': True,
+        'project_icla_enabled': True
       }
      */
     const url: URL = this.getV3Endpoint('/v3/project');


### PR DESCRIPTION
- Added swagger spec constraints on the CLA Group name and CLA Group description - resolves issue with DocuSign envelope submission (too long)
- Updated PMC to match max length for CLA Group name and description.
- Added v1 UI description to CLA Group - users can now add/edit the CLA Group description field. Added UI validation.
- Resolved CLA Group edit/update issue which prevents updates.

Signed-off-by: David Deal <dealako@gmail.com>