### PR TITLE
Feature/GitHub add remove repos

### DIFF
--- a/cla-backend-go/repositories/models.go
+++ b/cla-backend-go/repositories/models.go
@@ -7,18 +7,20 @@ import "github.com/communitybridge/easycla/cla-backend-go/gen/models"
 
 // GithubRepository represent repositories table
 type GithubRepository struct {
-	DateCreated                string `json:"date_created,omitempty"`
-	DateModified               string `json:"date_modified,omitempty"`
-	RepositoryExternalID       string `json:"repository_external_id,omitempty"`
-	RepositoryID               string `json:"repository_id,omitempty"`
-	RepositoryName             string `json:"repository_name,omitempty"`
-	RepositoryOrganizationName string `json:"repository_organization_name,omitempty"`
-	RepositoryProjectID        string `json:"repository_project_id,omitempty"`
-	RepositorySfdcID           string `json:"repository_sfdc_id,omitempty"`
-	RepositoryType             string `json:"repository_type,omitempty"`
-	RepositoryURL              string `json:"repository_url,omitempty"`
-	ProjectSFID                string `json:"project_sfid,omitempty"`
-	Version                    string `json:"version,omitempty"`
+	DateCreated                string `dynamodbav:"date_created" json:"date_created,omitempty"`
+	DateModified               string `dynamodbav:"date_modified" json:"date_modified,omitempty"`
+	RepositoryExternalID       string `dynamodbav:"repository_external_id" json:"repository_external_id,omitempty"`
+	RepositoryID               string `dynamodbav:"repository_id" json:"repository_id,omitempty"`
+	RepositoryName             string `dynamodbav:"repository_name" json:"repository_name,omitempty"`
+	RepositoryOrganizationName string `dynamodbav:"repository_organization_name" json:"repository_organization_name,omitempty"`
+	RepositoryProjectID        string `dynamodbav:"repository_project_id" json:"repository_project_id,omitempty"`
+	RepositorySfdcID           string `dynamodbav:"repository_sfdc_id" json:"repository_sfdc_id,omitempty"`
+	RepositoryType             string `dynamodbav:"repository_type" json:"repository_type,omitempty"`
+	RepositoryURL              string `dynamodbav:"repository_url" json:"repository_url,omitempty"`
+	ProjectSFID                string `dynamodbav:"project_sfid" json:"project_sfid,omitempty"`
+	Enabled                    bool   `dynamodbav:"enabled" json:"enabled"`
+	Note                       string `dynamodbav:"note" json:"note,omitempty"`
+	Version                    string `dynamodbav:"version" json:"version,omitempty"`
 }
 
 func (gr *GithubRepository) toModel() *models.GithubRepository {
@@ -34,6 +36,8 @@ func (gr *GithubRepository) toModel() *models.GithubRepository {
 		RepositoryType:             gr.RepositoryType,
 		RepositoryURL:              gr.RepositoryURL,
 		ProjectSFID:                gr.ProjectSFID,
+		Enabled:                    gr.Enabled,
+		Note:                       gr.Note,
 		Version:                    gr.Version,
 	}
 }

--- a/cla-backend-go/swagger/cla.v2.yaml
+++ b/cla-backend-go/swagger/cla.v2.yaml
@@ -987,9 +987,10 @@ paths:
 
   /template/{claGroupID}/preview:
     get:
-      summary: Get Template pdf for given claGroupID with specified cla type
-      description: Endpoint to return the cla template
+      summary: Preview Template PDF
+      description: Get Template PDF for given CLA Group identifier with specified CLA type
       operationId: getCLATemplatePreview
+      security: []
       parameters:
         - $ref: "#/parameters/path-claGroupID"
         - $ref: "#/parameters/templateCLAType"
@@ -1809,7 +1810,7 @@ paths:
                 description: Proposed CLA Manager name
                 example: "Harold Wanyama"
                 pattern: "^[a-zA-Z]+(([',. -][a-zA-Z ])?[a-zA-Z]*)*$"
-                minLength: 1 
+                minLength: 1
                 maxLength: 60
       responses:
         '200':
@@ -1908,7 +1909,7 @@ paths:
           $ref: '#/responses/internal-server-error'
       tags:
         - cla-manager
-  
+
   /company/{companySFID}/contributorAssociation:
     post:
       summary: Associates a contributor with a company
@@ -3141,7 +3142,7 @@ definitions:
         items:
           $ref:
             '#/definitions/cla-manager-designee'
-  
+
   contributor:
     type: object
     title: Contributor

--- a/cla-backend-go/swagger/common/github-organization.yaml
+++ b/cla-backend-go/swagger/common/github-organization.yaml
@@ -30,6 +30,7 @@ properties:
     example: "a0941000002wBz4AAA"
   autoEnabled:
     type: boolean
+    description: Flag to indicate if this GitHub Organization is configured to allow new repositories to be auto-enabled/auto-enrolled in EasyCLA.
     x-omitempty: false
   githubInfo:
     type: object

--- a/cla-backend-go/swagger/common/github-repository.yaml
+++ b/cla-backend-go/swagger/common/github-repository.yaml
@@ -5,25 +5,43 @@ type: object
 properties:
   dateCreated:
     type: string
+    description: Created date/time
   dateModified:
     type: string
+    description: Last modified date/time
   repositoryExternalID:
     type: string
+    description: The repository ID from the external service
   repositoryID:
     type: string
+    description: The internal repository ID
   repositoryName:
     type: string
+    description: The repository name
   repositoryOrganizationName:
     type: string
+    description: The organization name associated with this repository
   repositoryProjectID:
     type: string
+    description: The CLA Group ID associated with this repository
   repositorySfdcID:
     type: string
   repositoryType:
     type: string
+    description: The repository type - typically github, gerrit or possibly gitlab
   repositoryUrl:
     type: string
+    description: The external repository URL
+  enabled:
+    type: boolean
+    description: Flag to indicate if this repository is enabled or not. Repositories may become disabled if they have been moved or deleted from GitHub.
+    x-omitempty: false
+  note:
+    type: string
+    description: An optional note field to store any additional information about this record.  Helpful for auditing.
   version:
     type: string
+    description: The version identifier for this repository record
   projectSFID:
     type: string
+    description: The project SFID associated with this repository

--- a/cla-backend-go/v2/template/handlers.go
+++ b/cla-backend-go/v2/template/handlers.go
@@ -85,7 +85,7 @@ func Configure(api *operations.EasyclaAPI, service v1Template.Service, eventsSer
 		})
 	})
 
-	api.TemplateGetCLATemplatePreviewHandler = template.GetCLATemplatePreviewHandlerFunc(func(params template.GetCLATemplatePreviewParams, user *auth.User) middleware.Responder {
+	api.TemplateGetCLATemplatePreviewHandler = template.GetCLATemplatePreviewHandlerFunc(func(params template.GetCLATemplatePreviewParams) middleware.Responder {
 		pdf, err := service.GetCLATemplatePreview(params.HTTPRequest.Context(), params.ClaGroupID, params.ClaType, *params.Watermark)
 		if err != nil {
 			log.Warnf("Error getting PDFs for provided clagroupID : %s, error: %v", params.ClaGroupID, err)

--- a/cla-backend/cla/models/event_types.py
+++ b/cla-backend/cla/models/event_types.py
@@ -43,4 +43,8 @@ class EventType(Enum):
     IndividualSignatureSigned = "Individual signature signed"
     EmployeeSignatureSigned = "Employee signature signed"
     CompanySignatureSigned = "Company signature signed"
+    RepositoryAdded = "Repository Added"
+    RepositoryRemoved = "Repository Removed"
+    RepositoryDisable = "Repository Disabled"
+    RepositoryEnabled = "Repository Enabled"
 

--- a/cla-backend/cla/tests/unit/test_github_controller.py
+++ b/cla-backend/cla/tests/unit/test_github_controller.py
@@ -698,10 +698,10 @@ class TestGitHubController(unittest.TestCase):
 
         self.assertEqual(len(sesClient.emails_sent), 2)
         msg1 = sesClient.emails_sent[0]
-        self.assertEqual(msg1['Subject'], 'EasyCLA: Unable to check PRs')
+        self.assertEqual(msg1['Subject'], 'EasyCLA: Unable to check GitHub Pull Requests for CLA Group: None')
         self.assertEqual(msg1['To'], ['pm1@linuxfoundation.org', 'pm2@linuxfoundation.org'])
         msg2 = sesClient.emails_sent[1]
-        self.assertEqual(msg2['Subject'], 'EasyCLA: Unable to check PRs')
+        self.assertEqual(msg2['Subject'], 'EasyCLA: Unable to check GitHub Pull Requests for CLA Group: None')
         self.assertEqual(msg2['To'], ['pm3@linuxfoundation.org'])
 
 

--- a/cla-backend/cla/utils.py
+++ b/cla-backend/cla/utils.py
@@ -22,6 +22,7 @@ from cla.models.dynamo_models import User, Signature, Repository, \
     Company, Project, Document, \
     GitHubOrg, Gerrit, UserPermissions, Event, CompanyInvite, ProjectCLAGroup, CCLAWhitelistRequest
 from cla.models.event_types import EventType
+from datetime import datetime
 
 API_BASE_URL = os.environ.get('CLA_API_BASE', '')
 CLA_LOGO_URL = os.environ.get('CLA_BUCKET_LOGO_URL', '')
@@ -1458,3 +1459,20 @@ def get_email_sign_off_content() -> str:
         <p>Thanks,</p>
         <p>EasyCLA support team</p>
     """
+
+
+def get_current_time() -> str:
+    """
+    Helper function to return the current UTC datetime in an ISO standard format with timezone
+    :return:
+    """
+    now = datetime.utcnow()
+    return now.strftime("%Y-%m-%dT%H:%M:%S.%f%z") + "+0000"
+
+
+def get_formatted_time(the_time: datetime) -> str:
+    """
+    Helper function to return the specified datetime object in an ISO standard format with timezone
+    :return:
+    """
+    return the_time.strftime("%Y-%m-%dT%H:%M:%S.%f%z") + "+0000"


### PR DESCRIPTION
    [#212, #1617] Auto Enable All Repos for Org
    
    - Added initial hooks to auto-enable repos for a given organization
    - Updated repository data model - added enabled flag and notes, added
      set/get functions
    - Changed delete repository logic to "disable" repo, add note
    - Updated swagger spec
    - Resolved get template preview swagger security issue
    - Added common python get_current_time string functions
    
    Signed-off-by: David Deal <dealako@gmail.com>
