### PR TITLE
[#1623] V2 - get cla groups endpoint returns empty list when queried by projectsfid

### DIFF
--- a/cla-backend-go/project/service.go
+++ b/cla-backend-go/project/service.go
@@ -28,6 +28,7 @@ type Service interface {
 	DeleteCLAGroup(projectID string) error
 	UpdateCLAGroup(projectModel *models.Project) (*models.Project, error)
 	GetClaGroupsByFoundationSFID(foundationSFID string, loadRepoDetails bool) (*models.Projects, error)
+	GetClaGroupByProjectSFID(projectSFID string, loadRepoDetails bool) (*models.Project, error)
 	SignedAtFoundationLevel(foundationSFID string) (bool, error)
 }
 
@@ -186,6 +187,11 @@ func (s service) UpdateCLAGroup(projectModel *models.Project) (*models.Project, 
 // GetClaGroupsByFoundationSFID service method
 func (s service) GetClaGroupsByFoundationSFID(foundationSFID string, loadRepoDetails bool) (*models.Projects, error) {
 	return s.repo.GetClaGroupsByFoundationSFID(foundationSFID, loadRepoDetails)
+}
+
+// GetClaGroupByProjectSFID( service method
+func (s service) GetClaGroupByProjectSFID(projectSFID string, loadRepoDetails bool) (*models.Project, error) {
+	return s.repo.GetClaGroupByProjectSFID(projectSFID, loadRepoDetails)
 }
 
 // SignedAtFoundationLevel returns true if the specified foundation has a CLA Group at the foundation level, returns false otherwise.

--- a/cla-backend-go/v2/cla_groups/service.go
+++ b/cla-backend-go/v2/cla_groups/service.go
@@ -719,11 +719,14 @@ func (s *service) ListClaGroupsForFoundationOrProject(foundationSFID string) (*m
 			return nil, prjerr
 		}
 		v1ClaGroups.Projects = append(v1ClaGroups.Projects, *v1ClaGroupsByProject)
-	} else {
+	} else if projectDetails.ProjectType == "Project Group" {
 		v1ClaGroups, err = s.v1ProjectService.GetClaGroupsByFoundationSFID(foundationSFID, DontLoadDetails)
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		log.Warn("invalid foundation/project SFID")
+		return nil, errors.New("invalid foundation/project SFID")
 	}
 
 	m := make(map[string]*models.ClaGroup)

--- a/cla-backend-go/v2/cla_groups/service.go
+++ b/cla-backend-go/v2/cla_groups/service.go
@@ -705,10 +705,25 @@ func getS3Url(claGroupID string, docs []v1Models.ProjectDocument) string {
 
 // ListClaGroupsForFoundationOrProject returns the CLA Group list for the specified foundation ID
 func (s *service) ListClaGroupsForFoundationOrProject(foundationSFID string) (*models.ClaGroupList, error) {
+	var v1ClaGroups = new(v1Models.Projects)
 	out := &models.ClaGroupList{List: make([]*models.ClaGroup, 0)}
-	v1ClaGroups, err := s.v1ProjectService.GetClaGroupsByFoundationSFID(foundationSFID, DontLoadDetails)
-	if err != nil {
-		return nil, err
+	var err error
+
+	projectDetails, projDetailsErr := v2ProjectService.GetClient().GetProject(foundationSFID)
+	if projDetailsErr != nil {
+		log.Warnf("unable to lookup foundation/project SFID: %s - error: %+v", foundationSFID, projDetailsErr)
+	}
+	if projectDetails.ProjectType == "Project" {
+		v1ClaGroupsByProject, prjerr := s.v1ProjectService.GetClaGroupByProjectSFID(foundationSFID, DontLoadDetails)
+		if prjerr != nil {
+			return nil, prjerr
+		}
+		v1ClaGroups.Projects = append(v1ClaGroups.Projects, *v1ClaGroupsByProject)
+	} else {
+		v1ClaGroups, err = s.v1ProjectService.GetClaGroupsByFoundationSFID(foundationSFID, DontLoadDetails)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	m := make(map[string]*models.ClaGroup)
@@ -724,7 +739,11 @@ func (s *service) ListClaGroupsForFoundationOrProject(foundationSFID string) (*m
 		} else {
 			foundationName = projectServiceModel.Name
 		}
-
+		projectList := make([]*models.ClaGroupProject, 0)
+		projectList = append(projectList, &models.ClaGroupProject{
+			ProjectSfid: projectDetails.ProjectOutput.ID,
+			ProjectName: projectDetails.ProjectCommon.Name,
+		})
 		cg := &models.ClaGroup{
 			CclaEnabled:         v1ClaGroup.ProjectCCLAEnabled,
 			CclaRequiresIcla:    v1ClaGroup.ProjectCCLARequiresICLA,
@@ -736,7 +755,7 @@ func (s *service) ListClaGroupsForFoundationOrProject(foundationSFID string) (*m
 			IclaEnabled:         v1ClaGroup.ProjectICLAEnabled,
 			CclaPdfURL:          getS3Url(v1ClaGroup.ProjectID, v1ClaGroup.ProjectCorporateDocuments),
 			IclaPdfURL:          getS3Url(v1ClaGroup.ProjectID, v1ClaGroup.ProjectIndividualDocuments),
-			ProjectList:         make([]*models.ClaGroupProject, 0),
+			ProjectList:         projectList,
 			// Add root_project_repositories_count to repositories_count initially
 			RepositoriesCount:            v1ClaGroup.RootProjectRepositoriesCount,
 			RootProjectRepositoriesCount: v1ClaGroup.RootProjectRepositoriesCount,


### PR DESCRIPTION
1. Call the Platform Project Service to determine the type =  project and project-group.
2. Based on type call the GetClaGroupByProjectSFID and GetClaGroupsByFoundationSFID function and returns the cla-group details.

Signed-off-by: Rinkesh Bhutwala rbhutwal@proximabiz.com