### PR TITLE
[#1737] Bug/Invite Admin with no LFID (Contributor Console)

### DIFF
--- a/cla-backend-go/v2/cla_manager/service.go
+++ b/cla-backend-go/v2/cla_manager/service.go
@@ -836,7 +836,9 @@ func (s *service) InviteCompanyAdmin(contactAdmin bool, companyID string, projec
 			contributorEmail = &contributor.LFEmail
 		}
 
-		sendErr := sendEmailToUserWithNoLFID(project.ProjectName, contributor.UserName, *contributorEmail, name, userEmail, organization.ID, nil, "cla-manager-designee")
+		// Use FoundationSFID
+		foundationSFID := projectCLAGroups[0].FoundationSFID
+		sendErr := sendEmailToUserWithNoLFID(project.ProjectName, contributor.UserName, *contributorEmail, name, userEmail, organization.ID, &foundationSFID, "cla-manager-designee")
 		if sendErr != nil {
 			return nil, sendErr
 		}


### PR DESCRIPTION
- Fixed user invite with project ID missing.. Passing foundationSFID in the user invite payload

Signed-off-by: wanyaland <wanyaland@gmail.com>