### PR TITLE
Corporate Console - Error message is not displayed when trying to add already accepted/added CLA Manager

### DIFF
--- a/cla-frontend-corporate-console/src/ionic/modals/add-manager-modal/add-manager-modal.ts
+++ b/cla-frontend-corporate-console/src/ionic/modals/add-manager-modal/add-manager-modal.ts
@@ -61,7 +61,12 @@ export class AddManagerModal {
         }
       },
       (exception) => {
-        this.errorMsg = 'User not found with given LFID.';
+        // Added trick to indentify error meesage as no diffrent status code present.
+        if (exception._body.indexOf('manager already in signature ACL') >= 0) {
+          this.errorMsg = 'CLA manager already in signature ACL';
+        } else {
+          this.errorMsg = 'User not found with given LFID.';
+        }
       }
     );
   }


### PR DESCRIPTION

![Screenshot from 2020-09-07 12-39-35](https://user-images.githubusercontent.com/56335654/92378720-e668d200-f123-11ea-95af-98ec21d385eb.png)

Signed-off-by: Amol Sontakke <amols@proximabiz.com>