### PR TITLE
Set GitHub Installation ID if Missing

### DIFF
--- a/cla-backend/cla/models/dynamo_models.py
+++ b/cla-backend/cla/models/dynamo_models.py
@@ -3260,6 +3260,7 @@ class GitHubOrg(model_interfaces.GitHubOrg):  # pylint: disable=too-many-public-
         return ret
 
     def save(self):
+        self.model.date_modified = datetime.datetime.utcnow()
         self.model.save()
 
     def load(self, organization_name):


### PR DESCRIPTION
- Updated GitHub repo event logic to set the GitHub installation ID if
  missing
- Added logic to set the modified time when we save the GH org record

Signed-off-by: David Deal <dealako@gmail.com>