### PR TITLE
github protected branch functionality and endpoints

### DIFF
--- a/cla-backend-go/cmd/functional_tests/main.go
+++ b/cla-backend-go/cmd/functional_tests/main.go
@@ -6,17 +6,15 @@ package main
 import (
 	"os"
 
-	"github.com/communitybridge/easycla/cla-backend-go/cmd/functional_tests/template"
-
+	"github.com/communitybridge/easycla/cla-backend-go/cmd/functional_tests/approval_list"
+	"github.com/communitybridge/easycla/cla-backend-go/cmd/functional_tests/cla_group"
+	"github.com/communitybridge/easycla/cla-backend-go/cmd/functional_tests/cla_manager"
 	"github.com/communitybridge/easycla/cla-backend-go/cmd/functional_tests/company"
 	"github.com/communitybridge/easycla/cla-backend-go/cmd/functional_tests/health"
-
-	"github.com/communitybridge/easycla/cla-backend-go/cmd/functional_tests/cla_group"
-
-	"github.com/communitybridge/easycla/cla-backend-go/cmd/functional_tests/cla_manager"
 	"github.com/communitybridge/easycla/cla-backend-go/cmd/functional_tests/signatures"
+	"github.com/communitybridge/easycla/cla-backend-go/cmd/functional_tests/template"
 
-	"github.com/communitybridge/easycla/cla-backend-go/cmd/functional_tests/approval_list"
+	"github.com/communitybridge/easycla/cla-backend-go/cmd/repositories"
 
 	"github.com/communitybridge/easycla/cla-backend-go/cmd/functional_tests/test_models"
 	log "github.com/communitybridge/easycla/cla-backend-go/logging"
@@ -98,5 +96,6 @@ func main() {
 	signatures.NewTestBehaviour(apiURL, auth0User1Config, auth0User2Config).RunAllTests()
 	approval_list.NewTestBehaviour(v2APIURL, auth0User1Config, auth0User2Config, auth0User3Config, auth0User4Config).RunAllTests()
 	cla_group.NewTestBehaviour(v2APIURL, auth0User5Config).RunAllTests()
+	repositories.NewTestBehaviour(v2APIURL, auth0User2Config).RunAllTests()
 	frisby.Global.PrintReport()
 }

--- a/cla-backend-go/cmd/repositories/repositories.go
+++ b/cla-backend-go/cmd/repositories/repositories.go
@@ -1,0 +1,226 @@
+// Copyright The Linux Foundation and each contributor to CommunityBridge.
+// SPDX-License-Identifier: MIT
+
+package repositories
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/LF-Engineering/lfx-kit/auth"
+	"github.com/aws/aws-sdk-go/aws/awsutil"
+
+	"github.com/communitybridge/easycla/cla-backend-go/cmd/functional_tests/test_models"
+	"github.com/communitybridge/easycla/cla-backend-go/gen/v2/models"
+	log "github.com/communitybridge/easycla/cla-backend-go/logging"
+	"github.com/go-openapi/swag"
+	"github.com/verdverm/frisby"
+)
+
+var (
+	claProjectManagerToken string
+)
+
+const (
+	// OpenColor IO project sfid
+	projectSFID = "a092M00001IV3zdQAD"
+	// repository id for the repo : LF-Engineering/easycla-protected-branch-test-repo
+	repositoryID = "debcb153-69b6-4b4a-8020-213e3bf471b3"
+)
+
+// GetXACL returns the X-ACL entry for this company
+func GetXACL() (string, error) {
+	xACL := auth.ACL{
+		Admin:    false,
+		Allowed:  true,
+		Resource: "cla_groups",
+		Context:  "staff",
+		Scopes: []auth.Scope{
+			{
+				Type:  "project",
+				ID:    projectSFID,
+				Role:  "cla-manager",
+				Level: "staff",
+			},
+		},
+	}
+
+	jsonString, marshalErr := json.Marshal(xACL)
+	if marshalErr != nil {
+		log.Warnf("unable to marshall X-ACL entry, error: %+v", marshalErr)
+		return "", marshalErr
+	}
+	return base64.StdEncoding.EncodeToString(jsonString), nil
+}
+
+// TestBehaviour data model
+type TestBehaviour struct {
+	apiURL                    string
+	auth0ProjectManagerConfig test_models.Auth0Config
+}
+
+// NewTestBehaviour creates a new test behavior model
+func NewTestBehaviour(apiURL string, auth0ProjectManagerConfig test_models.Auth0Config) *TestBehaviour {
+	return &TestBehaviour{
+		apiURL,
+		auth0ProjectManagerConfig,
+	}
+}
+
+// RunGetCLAProjectManagerToken acquires the Auth0 token
+func (t *TestBehaviour) RunGetCLAProjectManagerToken() {
+	fmt.Printf("auth config : %+v \n", t.auth0ProjectManagerConfig)
+	authTokenReqPayload := map[string]string{
+		"grant_type": "http://auth0.com/oauth/grant-type/password-realm",
+		"realm":      "Username-Password-Authentication",
+		"username":   t.auth0ProjectManagerConfig.Auth0UserName,
+		"password":   t.auth0ProjectManagerConfig.Auth0Password,
+		"client_id":  t.auth0ProjectManagerConfig.Auth0ClientID,
+		"audience":   "https://api-gw.dev.platform.linuxfoundation.org/",
+		"scope":      "access:api openid profile email",
+	}
+
+	frisby.Create(fmt.Sprintf("Get Protected Branch - Get Token - Project Manager Manager - %s", t.auth0ProjectManagerConfig.Auth0UserName)).
+		Post("https://linuxfoundation-dev.auth0.com/oauth/token").
+		SetJson(authTokenReqPayload).
+		Send().
+		ExpectStatus(200).
+		ExpectJsonType("access_token", reflect.String).
+		ExpectJsonType("id_token", reflect.String).
+		ExpectJsonType("scope", reflect.String).
+		ExpectJsonType("expires_in", reflect.String).
+		AfterText(func(F *frisby.Frisby, text string, err error) {
+			// log.Debugf("response: %s", text)
+			var auth0Response test_models.Auth0Response
+			unmarshallErr := json.Unmarshal([]byte(text), &auth0Response)
+			if unmarshallErr != nil {
+				F.AddError(unmarshallErr.Error())
+			}
+			if auth0Response.IDToken == "" {
+				F.AddError("Auth0Response id_token is empty")
+			}
+			claProjectManagerToken = auth0Response.IDToken
+			//log.Debugf("ID Token is: %s", token)
+		})
+}
+
+// getCLAProjectManagerHeaders is a helper function to get the request headers
+func (t *TestBehaviour) getCLAProjectManagerHeaders() map[string]string {
+	xacl, err := GetXACL()
+	if err != nil {
+		panic(err)
+	}
+	return map[string]string{
+		"Authorization":   "Bearer " + claProjectManagerToken,
+		"Content-Type":    "application/json",
+		"Accept-Encoding": "application/json",
+		"X-Email":         t.auth0ProjectManagerConfig.Auth0Email,
+		"X-USERNAME":      t.auth0ProjectManagerConfig.Auth0UserName,
+		"X-ACL":           xacl,
+	}
+}
+
+// RunGetProtectedBranch test the response for the protected branch of repo
+func (t *TestBehaviour) RunGetProtectedBranch(assertBranchProtection *models.GithubRepositoryBranchProtection) {
+
+	endpoint := fmt.Sprintf("%s/project/%s/github/repositories/%s/branch-protection", t.apiURL, projectSFID, repositoryID)
+	frisby.Create(fmt.Sprintf("Get Protected Branch - ProjectSFID : %s, RepositoryID: %s", projectSFID, repositoryID)).
+		Get(endpoint).
+		SetHeaders(t.getCLAProjectManagerHeaders()).
+		Send().
+		ExpectStatus(200).
+		ExpectJsonType("branch_name", reflect.String).
+		ExpectJsonType("enforce_admin", reflect.Bool).
+		ExpectJsonType("protection_enabled", reflect.Bool).
+		AfterText(func(F *frisby.Frisby, text string, err error) {
+			if err != nil {
+				F.AddError(err.Error())
+				return
+			}
+			var response models.GithubRepositoryBranchProtection
+			unmarshallErr := json.Unmarshal([]byte(text), &response)
+			if unmarshallErr != nil {
+				F.AddError(unmarshallErr.Error())
+				return
+			}
+
+			if *response.BranchName != "master" {
+				F.AddError(fmt.Sprintf("Get Protected Branch - Default Branch Name expected : %s", *response.BranchName))
+			}
+
+			if len(response.StatusChecks) == 0 {
+				F.AddError("Get Protected Branch - No Status Checks Returned by API")
+			} else {
+				var found bool
+				for _, c := range response.StatusChecks {
+					if *c.Name == "EasyCLA" {
+						found = true
+						break
+					}
+				}
+				if !found {
+					F.AddError("Get Protected Branch - EasyCLA not found it status checks (even if not enabled)")
+				}
+			}
+
+			if assertBranchProtection != nil {
+				if !awsutil.DeepEqual(response, assertBranchProtection) {
+					F.AddError(fmt.Sprintf("Get Protected Branch - Expected Result Not found - Expected : %+v - Got : %+v", assertBranchProtection, response))
+				}
+			}
+		})
+}
+
+// RunUpdateProtectionBranch is hits the branch protection endpoint with the given parameters
+func (t *TestBehaviour) RunUpdateProtectionBranch(msg string, param *models.GithubRepositoryBranchProtectionInput) {
+	//it should be checking enforce admin if worked
+	//it should be checking if all of the enabled checks are there and disabled are not there as well
+	endpoint := fmt.Sprintf("%s/project/%s/github/repositories/%s/branch-protection", t.apiURL, projectSFID, repositoryID)
+	frisby.Create(fmt.Sprintf("Update Protection  Branch - %s - ProjectSFID : %s, RepositoryID: %s", msg, projectSFID, repositoryID)).
+		Post(endpoint).
+		SetHeaders(t.getCLAProjectManagerHeaders()).
+		SetJson(param).
+		Send().
+		ExpectStatus(200).
+		ExpectJsonType("branch_name", reflect.String).
+		ExpectJsonType("enforce_admin", reflect.Bool).
+		ExpectJsonType("protection_enabled", reflect.Bool).
+		AfterText(func(F *frisby.Frisby, text string, err error) {
+			var response models.GithubRepositoryBranchProtection
+			unmarshallErr := json.Unmarshal([]byte(text), &response)
+			if unmarshallErr != nil {
+				F.AddError(unmarshallErr.Error())
+			}
+		})
+
+	t.RunGetProtectedBranch(&models.GithubRepositoryBranchProtection{
+		BranchName:        swag.String("master"),
+		EnforceAdmin:      *param.EnforceAdmin,
+		ProtectionEnabled: true,
+		StatusChecks:      param.StatusChecks,
+	})
+}
+
+// RunAllTests runs all the CLA Manager tests
+func (t *TestBehaviour) RunAllTests() {
+	// Need our authentication tokens for each persona/user
+	t.RunGetCLAProjectManagerToken()
+	// do an initial get query
+	t.RunGetProtectedBranch(nil)
+	// first enable it
+	t.RunUpdateProtectionBranch("Enable Protections", &models.GithubRepositoryBranchProtectionInput{
+		EnforceAdmin: swag.Bool(true),
+		StatusChecks: []*models.GithubRepositoryBranchProtectionStatusChecks{
+			{Name: swag.String("EasyCLA"), Enabled: swag.Bool(true)},
+		},
+	})
+	//then disable it again
+	t.RunUpdateProtectionBranch("Disable Protections", &models.GithubRepositoryBranchProtectionInput{
+		EnforceAdmin: swag.Bool(false),
+		StatusChecks: []*models.GithubRepositoryBranchProtectionStatusChecks{
+			{Name: swag.String("EasyCLA"), Enabled: swag.Bool(false)},
+		},
+	})
+}

--- a/cla-backend-go/github/client.go
+++ b/cla-backend-go/github/client.go
@@ -5,6 +5,8 @@ package github
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/bradleyfalzon/ghinstallation"
@@ -12,7 +14,59 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func newGithubAppClient(installationID int64) (*github.Client, error) {
+var (
+	// ErrAccessDenied is returned whenever github return 403 or 401
+	ErrAccessDenied = errors.New("access denied")
+	// ErrRateLimited is returned when github detects rate limit abuse
+	ErrRateLimited = errors.New("rate limit")
+)
+
+func isGithub403(resp *github.Response, err error) (bool, error) {
+	if resp == nil {
+		return false, err
+	}
+
+	statusCode := resp.StatusCode
+	if statusCode == 403 || statusCode == 401 {
+		var msg string
+		if gErr, ok := err.(*github.ErrorResponse); ok {
+			msg = gErr.Message
+		}
+		if msg != "" {
+			return true, fmt.Errorf("%s : %w", msg, ErrAccessDenied)
+		}
+		return true, ErrAccessDenied
+	}
+
+	return false, nil
+}
+
+func isGithubRateLimit(err error) (bool, error) {
+	if gErr, ok := err.(*github.RateLimitError); ok {
+		return true, fmt.Errorf("%s : %w", gErr.Message, ErrRateLimited)
+	}
+
+	if gErr, ok := err.(*github.AbuseRateLimitError); ok {
+		return true, fmt.Errorf("%s : %w", gErr.Message, ErrRateLimited)
+	}
+
+	return false, nil
+}
+
+func checkAndWrapForKnownErrors(resp *github.Response, err error) (bool, error) {
+	if ok, wErr := isGithubRateLimit(err); ok {
+		return ok, wErr
+	}
+
+	if ok, wErr := isGithub403(resp, err); ok {
+		return ok, wErr
+	}
+
+	return false, err
+}
+
+// NewGithubAppClient creates a new github client from the supplied installationID
+func NewGithubAppClient(installationID int64) (*github.Client, error) {
 	itr, err := ghinstallation.New(http.DefaultTransport, int64(getGithubAppID()), installationID, []byte(getGithubAppPrivateKey()))
 	if err != nil {
 		return nil, err
@@ -20,10 +74,16 @@ func newGithubAppClient(installationID int64) (*github.Client, error) {
 	return github.NewClient(&http.Client{Transport: itr}), nil
 }
 
-func newGithubOauthClient() *github.Client {
+// NewGithubOauthClient creates github client from global accessToken
+func NewGithubOauthClient() *github.Client {
+	return NewGithubOauthClientWithAccessToken(getSecretAccessToken())
+}
+
+// NewGithubOauthClientWithAccessToken creates github client from specified accessToken
+func NewGithubOauthClientWithAccessToken(accessToken string) *github.Client {
 	ctx := context.TODO()
 	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: getSecretAccessToken()},
+		&oauth2.Token{AccessToken: accessToken},
 	)
 	tc := oauth2.NewClient(ctx, ts)
 	return github.NewClient(tc)

--- a/cla-backend-go/github/github_installation.go
+++ b/cla-backend-go/github/github_installation.go
@@ -15,7 +15,7 @@ import (
 
 // GetInstallationRepositories returns list of repositories for github app installation
 func GetInstallationRepositories(installationID int64) ([]*github.Repository, error) {
-	client, err := newGithubAppClient(installationID)
+	client, err := NewGithubAppClient(installationID)
 	if err != nil {
 		return nil, errors.New("cannot create github client")
 	}

--- a/cla-backend-go/github/github_org.go
+++ b/cla-backend-go/github/github_org.go
@@ -19,7 +19,7 @@ var (
 
 // GetOrganization gets github organization
 func GetOrganization(organizationName string) (*github.Organization, error) {
-	client := newGithubOauthClient()
+	client := NewGithubOauthClient()
 	org, resp, err := client.Organizations.Get(context.TODO(), organizationName)
 	if err != nil {
 		logging.Warnf("GetOrganization %s failed. error = %s", organizationName, err.Error())

--- a/cla-backend-go/github/github_repository.go
+++ b/cla-backend-go/github/github_repository.go
@@ -18,7 +18,7 @@ var (
 
 // GetRepositoryByExternalID finds gitub repository by github repository id
 func GetRepositoryByExternalID(installationID, id int64) (*github.Repository, error) {
-	client, err := newGithubAppClient(installationID)
+	client, err := NewGithubAppClient(installationID)
 	if err != nil {
 		return nil, err
 	}

--- a/cla-backend-go/github/github_user.go
+++ b/cla-backend-go/github/github_user.go
@@ -14,7 +14,7 @@ import (
 
 // GetUserDetails return github users details
 func GetUserDetails(user string) (*github.User, error) {
-	client := newGithubOauthClient()
+	client := NewGithubOauthClient()
 	userResp, _, err := client.Users.Get(context.TODO(), user)
 	if err != nil {
 		logging.Warnf("GetUserDetails failed for user : %s, error = %s\n", user, err.Error())

--- a/cla-backend-go/github/protected_branch.go
+++ b/cla-backend-go/github/protected_branch.go
@@ -1,0 +1,221 @@
+// Copyright The Linux Foundation and each contributor to CommunityBridge.
+// SPDX-License-Identifier: MIT
+
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	log "github.com/communitybridge/easycla/cla-backend-go/logging"
+
+	githubpkg "github.com/google/go-github/github"
+)
+
+var (
+	// ErrBranchNotProtected indicates the situation where the branch is not enabled for protection on github side
+	ErrBranchNotProtected = errors.New("not protected")
+)
+
+// GetOwnerName retrieves the owner name of the given org and repo name
+func GetOwnerName(ctx context.Context, client *githubpkg.Client, orgName, repoName string) (string, error) {
+	log.Debugf("GetOwnerName : getting owner name for org %s and repoName : %s", orgName, repoName)
+	listOpt := &githubpkg.RepositoryListByOrgOptions{
+		ListOptions: githubpkg.ListOptions{
+			PerPage: 30,
+		},
+	}
+	for {
+		repos, resp, err := client.Repositories.ListByOrg(ctx, orgName, listOpt)
+		if err != nil {
+			if ok, wErr := checkAndWrapForKnownErrors(resp, err); ok {
+				return "", wErr
+			}
+			return "", err
+		}
+
+		if len(repos) == 0 {
+			log.Warnf("GetOwnerName : no repos found under orgName : %s (maybe no access ?)", orgName)
+			return "", nil
+		}
+
+		for _, repo := range repos {
+			if *repo.Name == repoName {
+				if repo.Owner != nil {
+					owner := *repo.Owner
+					return *owner.Login, nil
+				}
+			}
+		}
+
+		// means we're at the end of it so exit
+		if resp.NextPage == 0 {
+			log.Warnf("GetOwnerName : owner name not found for org : %s and repo : %s", orgName, repoName)
+			return "", nil
+		}
+
+		// set it to the next page
+		listOpt.Page = resp.NextPage
+	}
+}
+
+// GetDefaultBranchForRepo helps with pulling the default branch for the given repo
+func GetDefaultBranchForRepo(ctx context.Context, client *githubpkg.Client, owner, repoName string) (string, error) {
+	repo, resp, err := client.Repositories.Get(ctx, owner, repoName)
+	if err != nil {
+		if ok, wErr := checkAndWrapForKnownErrors(resp, err); ok {
+			return "", wErr
+		}
+		return "", err
+	}
+
+	var defaultBranch string
+	if repo.DefaultBranch == nil {
+		defaultBranch = "master"
+	} else {
+		defaultBranch = *repo.DefaultBranch
+	}
+
+	return defaultBranch, nil
+}
+
+// GetProtectedBranch fetches the protected branch details
+func GetProtectedBranch(ctx context.Context, client *githubpkg.Client, owner, repoName, protectedBranchName string) (*githubpkg.Protection, error) {
+	protection, resp, err := client.Repositories.GetBranchProtection(ctx, owner, repoName, protectedBranchName)
+
+	if err != nil {
+		if ok, wErr := checkAndWrapForKnownErrors(resp, err); ok {
+			return nil, wErr
+		}
+		if resp != nil && resp.StatusCode == 404 {
+			if gErr, ok := err.(*githubpkg.ErrorResponse); ok {
+				if strings.Contains(strings.ToLower(gErr.Message), "not protected") {
+					return nil, ErrBranchNotProtected
+				}
+			}
+		}
+
+		return nil, fmt.Errorf("fetching branch proteciton : %w", err)
+	}
+	return protection, err
+}
+
+//EnableBranchProtection enables branch protection if not enabled and makes sure passed arguments such as enforceAdmin
+//statusChecks are applied. The operation makes sure it doesn't override the existing checks.
+func EnableBranchProtection(ctx context.Context, client *githubpkg.Client, owner, repoName, branchName string, enforceAdmin bool, enableStatusChecks, disableStatusChecks []string) error {
+	protectedBranch, err := GetProtectedBranch(ctx, client, owner, repoName, branchName)
+	if err != nil {
+		if !errors.Is(err, ErrBranchNotProtected) {
+			return fmt.Errorf("fetching the protected branch : %w", err)
+		}
+		return err
+	}
+
+	var currentChecks *githubpkg.RequiredStatusChecks
+	if protectedBranch != nil {
+		currentChecks = protectedBranch.RequiredStatusChecks
+	}
+	requiredStatusChecks := mergeStatusChecks(currentChecks, enableStatusChecks, disableStatusChecks)
+
+	branchProtection := &githubpkg.ProtectionRequest{
+		EnforceAdmins:        enforceAdmin,
+		RequiredStatusChecks: requiredStatusChecks,
+	}
+	_, resp, err := client.Repositories.UpdateBranchProtection(ctx, owner, repoName, branchName, branchProtection)
+
+	if ok, wErr := checkAndWrapForKnownErrors(resp, err); ok {
+		return wErr
+	}
+	return err
+}
+
+//mergeStatusChecks merges the current checks with the new ones and disable the ones that are specified
+func mergeStatusChecks(currentCheck *githubpkg.RequiredStatusChecks, enableContexts, disableContexts []string) *githubpkg.RequiredStatusChecks {
+
+	// seems github api is not happy with nils for arrays ;)
+	if len(enableContexts) == 0 {
+		enableContexts = []string{}
+	}
+
+	if currentCheck == nil || len(currentCheck.Contexts) == 0 {
+		return &githubpkg.RequiredStatusChecks{
+			Strict:   true,
+			Contexts: enableContexts,
+		}
+	}
+
+	finalContexts := []string{}
+	uniqueEnableContexts := map[string]bool{}
+
+	for _, c := range currentCheck.Contexts {
+		// first disable the ones we're not interested into
+		found := false
+		if len(disableContexts) > 0 {
+			for _, disableContext := range disableContexts {
+				if disableContext == c {
+					found = true
+					break
+				}
+			}
+		}
+
+		if found {
+			continue
+		}
+
+		uniqueEnableContexts[c] = true
+		finalContexts = append(finalContexts, c)
+	}
+
+	for _, c := range enableContexts {
+		if uniqueEnableContexts[c] {
+			continue
+		}
+
+		uniqueEnableContexts[c] = true
+		finalContexts = append(finalContexts, c)
+	}
+
+	currentCheck.Contexts = finalContexts
+	currentCheck.Strict = true
+
+	return currentCheck
+}
+
+//IsEnforceAdminEnabled checks if enforce admin option is enabled for the branch protection
+func IsEnforceAdminEnabled(protection *githubpkg.Protection) bool {
+	if protection.EnforceAdmins == nil {
+		return false
+	}
+
+	return protection.EnforceAdmins.Enabled
+}
+
+//AreStatusChecksEnabled checks if all of the status checks are enabled
+func AreStatusChecksEnabled(protection *githubpkg.Protection, checks []string) bool {
+	if len(checks) == 0 {
+		return false
+	}
+
+	currentChecks := protection.RequiredStatusChecks
+	if currentChecks == nil || !protection.RequiredStatusChecks.Strict {
+		return false
+	}
+
+	if len(currentChecks.Contexts) < len(checks) {
+		return false
+	}
+
+	var found []string
+	for _, cc := range currentChecks.Contexts {
+		for _, c := range checks {
+			if c == cc {
+				found = append(found, cc)
+			}
+		}
+	}
+
+	return len(found) == len(checks)
+}

--- a/cla-backend-go/github/protected_branch_test.go
+++ b/cla-backend-go/github/protected_branch_test.go
@@ -1,0 +1,80 @@
+// Copyright The Linux Foundation and each contributor to CommunityBridge.
+// SPDX-License-Identifier: MIT
+
+package github
+
+import (
+	"testing"
+
+	"github.com/bmizerany/assert"
+	githubsdk "github.com/google/go-github/github"
+)
+
+// TestMergeStatusChecks tests the functionality of where we enable/disable checks
+func TestMergeStatusChecks(t *testing.T) {
+
+	testCases := []struct {
+		Name            string
+		currentChecks   *githubsdk.RequiredStatusChecks
+		expectedChecks  *githubsdk.RequiredStatusChecks
+		enableContexts  []string
+		disableContexts []string
+	}{
+		{
+			Name: "all empty",
+			expectedChecks: &githubsdk.RequiredStatusChecks{
+				Strict:   true,
+				Contexts: []string{},
+			},
+		},
+		{
+			Name: "empty state enable",
+			expectedChecks: &githubsdk.RequiredStatusChecks{
+				Strict:   true,
+				Contexts: []string{"EasyCLA"},
+			},
+			enableContexts: []string{"EasyCLA"},
+		},
+		{
+			Name: "preserve existing enable more",
+			currentChecks: &githubsdk.RequiredStatusChecks{
+				Contexts: []string{"travis-ci"},
+			},
+			expectedChecks: &githubsdk.RequiredStatusChecks{
+				Strict:   true,
+				Contexts: []string{"travis-ci", "EasyCLA"},
+			},
+			enableContexts: []string{"EasyCLA"},
+		},
+		{
+			Name: "preserve existing disable some",
+			currentChecks: &githubsdk.RequiredStatusChecks{
+				Contexts: []string{"travis-ci", "EasyCLA"},
+			},
+			expectedChecks: &githubsdk.RequiredStatusChecks{
+				Strict:   true,
+				Contexts: []string{"travis-ci"},
+			},
+			disableContexts: []string{"EasyCLA"},
+		},
+		{
+			Name: "add and remove in same operation",
+			currentChecks: &githubsdk.RequiredStatusChecks{
+				Contexts: []string{"travis-ci", "DCO", "EasyCLA"},
+			},
+			expectedChecks: &githubsdk.RequiredStatusChecks{
+				Strict:   true,
+				Contexts: []string{"travis-ci", "EasyCLA", "CodeQL"},
+			},
+			enableContexts:  []string{"CodeQL"},
+			disableContexts: []string{"DCO"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(tt *testing.T) {
+			result := mergeStatusChecks(tc.currentChecks, tc.enableContexts, tc.disableContexts)
+			assert.Equal(tt, tc.expectedChecks, result)
+		})
+	}
+}

--- a/cla-backend-go/go.mod
+++ b/cla-backend-go/go.mod
@@ -12,8 +12,9 @@ require (
 	github.com/aws/aws-sdk-go v1.30.14
 	github.com/aymerick/raymond v2.0.2+incompatible
 	github.com/bitly/go-simplejson v0.5.0 // indirect
-	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
+	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/bradleyfalzon/ghinstallation v1.1.1
+	github.com/davecgh/go-spew v1.1.1
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fnproject/fdk-go v0.0.2
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
@@ -28,6 +29,7 @@ require (
 	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/golang/protobuf v1.4.2 // indirect
 	github.com/google/go-github v17.0.0+incompatible
+	github.com/google/go-github/v29 v29.0.2
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/sessions v1.2.0 // indirect
 	github.com/imroc/req v0.3.0

--- a/cla-backend-go/repositories/handlers.go
+++ b/cla-backend-go/repositories/handlers.go
@@ -75,6 +75,7 @@ func Configure(api *operations.ClaAPI, service Service, eventService events.Serv
 			})
 			return github_repositories.NewDeleteProjectGithubRepositoryOK()
 		})
+
 }
 
 // codedResponse interface

--- a/cla-backend-go/repositories/repository.go
+++ b/cla-backend-go/repositories/repository.go
@@ -27,10 +27,10 @@ import (
 
 // index
 const (
-	ProjectRepositoryIndex                    = "project-repository-index"
-	SFDCRepositoryIndex                       = "sfdc-repository-index"
-	ExternalRepositoryIndex                   = "external-repository-index"
-	ProjectSFIDRepositoryOrgnizationNameIndex = "project-sfid-repository-organization-name-index"
+	ProjectRepositoryIndex                     = "project-repository-index"
+	SFDCRepositoryIndex                        = "sfdc-repository-index"
+	ExternalRepositoryIndex                    = "external-repository-index"
+	ProjectSFIDRepositoryOrganizationNameIndex = "project-sfid-repository-organization-name-index"
 )
 
 // errors
@@ -297,7 +297,7 @@ func (repo repo) ListProjectRepositories(externalProjectID string, projectSFID s
 		indexName = SFDCRepositoryIndex
 	} else {
 		condition = expression.Key("project_sfid").Equal(expression.Value(projectSFID))
-		indexName = ProjectSFIDRepositoryOrgnizationNameIndex
+		indexName = ProjectSFIDRepositoryOrganizationNameIndex
 	}
 
 	// Add the enabled filter

--- a/cla-backend-go/swagger/cla.v2.yaml
+++ b/cla-backend-go/swagger/cla.v2.yaml
@@ -1278,6 +1278,82 @@ paths:
       tags:
         - github-repositories
 
+  /project/{projectSFID}/github/repositories/{repositoryID}/branch-protection:
+    post:
+      summary: API to manage github branch protection for given repository
+      description: Endpoint to set branch protection options for the given branch, defaults to repository's default branch
+      operationId: updateProjectGithubRepositoryBranchProtection
+      parameters:
+        - $ref: "#/parameters/x-request-id"
+        - $ref: "#/parameters/x-acl"
+        - $ref: "#/parameters/x-username"
+        - $ref: "#/parameters/x-email"
+        - name: projectSFID
+          in: path
+          type: string
+          required: true
+        - name: repositoryID
+          in: path
+          type: string
+          required: true
+        - in: body
+          name: github-repository-branch-protection-input
+          schema:
+            $ref: '#/definitions/github-repository-branch-protection-input'
+          required: true
+      responses:
+        '200':
+          description: 'Success'
+          schema:
+            $ref: '#/definitions/github-repository-branch-protection'
+        '400':
+          $ref: '#/responses/invalid-request'
+        '401':
+          $ref: '#/responses/unauthorized'
+        '403':
+          $ref: '#/responses/forbidden'
+        '404':
+          $ref: '#/responses/not-found'
+        '500':
+          $ref: '#/responses/internal-server-error'
+      tags:
+        - github-repositories
+
+    get:
+      summary: API to manage github branch protection for given repository
+      description: Endpoint to get branch protection options for the given branch, defaults to repository's default branch
+      operationId: getProjectGithubRepositoryBranchProtection
+      parameters:
+        - $ref: "#/parameters/x-request-id"
+        - $ref: "#/parameters/x-acl"
+        - $ref: "#/parameters/x-username"
+        - $ref: "#/parameters/x-email"
+        - name: projectSFID
+          in: path
+          type: string
+          required: true
+        - name: repositoryID
+          in: path
+          type: string
+          required: true
+      responses:
+        '200':
+          description: 'Success'
+          schema:
+            $ref: '#/definitions/github-repository-branch-protection'
+        '400':
+          $ref: '#/responses/invalid-request'
+        '401':
+          $ref: '#/responses/unauthorized'
+        '403':
+          $ref: '#/responses/forbidden'
+        '404':
+          $ref: '#/responses/not-found'
+        '500':
+          $ref: '#/responses/internal-server-error'
+      tags:
+        - github-repositories
+
   /cla-group/{claGroupID}/icla/signatures:
     get:
       summary: List icla signatures for cla group
@@ -3003,6 +3079,50 @@ definitions:
         type: string
       cla_group_id:
         type: string
+
+  github-repository-branch-protection-status-checks:
+    type: object
+    required:
+      - name
+    properties:
+      name:
+        type: string
+        description: check status name
+        example: EasyCLA
+      enabled:
+        type: boolean
+        default: false
+
+  github-repository-branch-protection:
+    type: object
+    required:
+      - branch_name
+      - protection_enabled
+      - enforce_admin
+    properties:
+      branch_name:
+        type: string
+      protection_enabled:
+        type: boolean
+        default: false
+      enforce_admin:
+        type: boolean
+        default: false
+      status_checks:
+        type: array
+        items:
+          $ref: '#/definitions/github-repository-branch-protection-status-checks'
+
+  github-repository-branch-protection-input:
+    type: object
+    properties:
+      enforce_admin:
+        type: boolean
+        default: false
+      status_checks:
+        type: array
+        items:
+          $ref: '#/definitions/github-repository-branch-protection-status-checks'
 
   github-repository:
     $ref: './common/github-repository.yaml'

--- a/cla-backend-go/v2/repositories/handlers.go
+++ b/cla-backend-go/v2/repositories/handlers.go
@@ -4,7 +4,12 @@
 package repositories
 
 import (
+	"errors"
 	"fmt"
+
+	log "github.com/communitybridge/easycla/cla-backend-go/logging"
+
+	"github.com/communitybridge/easycla/cla-backend-go/github"
 
 	"github.com/LF-Engineering/lfx-kit/auth"
 	"github.com/communitybridge/easycla/cla-backend-go/events"
@@ -112,6 +117,68 @@ func Configure(api *operations.EasyclaAPI, service Service, eventService events.
 			})
 
 			return github_repositories.NewDeleteProjectGithubRepositoryNoContent()
+		})
+
+	api.GithubRepositoriesGetProjectGithubRepositoryBranchProtectionHandler = github_repositories.GetProjectGithubRepositoryBranchProtectionHandlerFunc(
+		func(params github_repositories.GetProjectGithubRepositoryBranchProtectionParams, authUser *auth.User) middleware.Responder {
+			utils.SetAuthUserProperties(authUser, params.XUSERNAME, params.XEMAIL)
+			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID) {
+				return github_repositories.NewGetProjectGithubRepositoryBranchProtectionForbidden().WithPayload(&models.ErrorResponse{
+					Code: "403",
+					Message: fmt.Sprintf("EasyCLA - 403 Forbidden - user %s does not have access to Query Protected Branch GitHub Repository with Project scope of %s",
+						authUser.UserName, params.ProjectSFID),
+				})
+			}
+
+			protectedBranch, err := service.GetProtectedBranch(params.RepositoryID)
+			if err != nil {
+				if err == repositories.ErrGithubRepositoryNotFound {
+					return github_repositories.NewGetProjectGithubRepositoryBranchProtectionNotFound()
+				}
+				if errors.Is(err, github.ErrAccessDenied) {
+					return github_repositories.NewGetProjectGithubRepositoryBranchProtectionForbidden().WithPayload(errorResponse(err))
+				}
+
+				// shall we return the actual code for rate liming ?
+				if errors.Is(err, github.ErrRateLimited) {
+					return github_repositories.NewGetProjectGithubRepositoryBranchProtectionInternalServerError()
+				}
+
+				return github_repositories.NewGetProjectGithubRepositoryBranchProtectionBadRequest().WithPayload(errorResponse(err))
+			}
+
+			return github_repositories.NewGetProjectGithubRepositoryBranchProtectionOK().WithPayload(protectedBranch)
+		})
+	api.GithubRepositoriesUpdateProjectGithubRepositoryBranchProtectionHandler = github_repositories.UpdateProjectGithubRepositoryBranchProtectionHandlerFunc(
+		func(params github_repositories.UpdateProjectGithubRepositoryBranchProtectionParams, authUser *auth.User) middleware.Responder {
+			utils.SetAuthUserProperties(authUser, params.XUSERNAME, params.XEMAIL)
+			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID) {
+				return github_repositories.NewUpdateProjectGithubRepositoryBranchProtectionForbidden().WithPayload(&models.ErrorResponse{
+					Code: "403",
+					Message: fmt.Sprintf("EasyCLA - 403 Forbidden - user %s does not have access to Update Protected Branch GitHub Repository with Project scope of %s",
+						authUser.UserName, params.ProjectSFID),
+				})
+			}
+
+			protectedBranch, err := service.UpdateProtectedBranch(params.RepositoryID, params.GithubRepositoryBranchProtectionInput)
+			if err != nil {
+				log.Warnf("UpdateProjectGithubRepositoryBranchProtectionHandler : failed for repo %s : %v", params.RepositoryID, err)
+				if err == repositories.ErrGithubRepositoryNotFound {
+					return github_repositories.NewGetProjectGithubRepositoryBranchProtectionNotFound()
+				}
+				if errors.Is(err, github.ErrAccessDenied) {
+					return github_repositories.NewGetProjectGithubRepositoryBranchProtectionForbidden().WithPayload(errorResponse(err))
+				}
+
+				// shall we return the actual code for rate liming ?
+				if errors.Is(err, github.ErrRateLimited) {
+					return github_repositories.NewGetProjectGithubRepositoryBranchProtectionInternalServerError().WithPayload(errorResponse(err))
+				}
+
+				return github_repositories.NewGetProjectGithubRepositoryBranchProtectionBadRequest().WithPayload(errorResponse(err))
+			}
+
+			return github_repositories.NewGetProjectGithubRepositoryBranchProtectionOK().WithPayload(protectedBranch)
 		})
 }
 

--- a/cla-backend-go/v2/repositories/service.go
+++ b/cla-backend-go/v2/repositories/service.go
@@ -4,9 +4,15 @@
 package repositories
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
+
+	"github.com/go-openapi/swag"
+
+	githubsdk "github.com/google/go-github/github"
 
 	"github.com/communitybridge/easycla/cla-backend-go/gen/v2/models"
 
@@ -16,6 +22,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	v1Models "github.com/communitybridge/easycla/cla-backend-go/gen/models"
+	v2Models "github.com/communitybridge/easycla/cla-backend-go/gen/v2/models"
 	log "github.com/communitybridge/easycla/cla-backend-go/logging"
 	"github.com/communitybridge/easycla/cla-backend-go/projects_cla_groups"
 	v1Repositories "github.com/communitybridge/easycla/cla-backend-go/repositories"
@@ -30,6 +37,8 @@ type Service interface {
 	ListProjectRepositories(projectSFID string) (*v1Models.ListGithubRepositories, error)
 	GetRepository(repositoryID string) (*v1Models.GithubRepository, error)
 	DisableCLAGroupRepositories(claGroupID string) error
+	GetProtectedBranch(repositoryID string) (*v2Models.GithubRepositoryBranchProtection, error)
+	UpdateProtectedBranch(repositoryID string, input *v2Models.GithubRepositoryBranchProtectionInput) (*v2Models.GithubRepositoryBranchProtection, error)
 }
 
 // GithubOrgRepo provide method to get github organization by name
@@ -42,6 +51,8 @@ type service struct {
 	projectsClaGroupsRepo projects_cla_groups.Repository
 	ghOrgRepo             GithubOrgRepo
 }
+
+var requiredBranchProtectionChecks = []string{"EasyCLA"}
 
 // NewService creates a new githubOrganizations service
 func NewService(repo v1Repositories.Repository, pcgRepo projects_cla_groups.Repository, ghOrgRepo GithubOrgRepo) Service {
@@ -118,6 +129,186 @@ func (s *service) ListProjectRepositories(projectSFID string) (*v1Models.ListGit
 
 func (s *service) GetRepository(repositoryID string) (*v1Models.GithubRepository, error) {
 	return s.repo.GetRepository(repositoryID)
+}
+
+func (s *service) GetProtectedBranch(repositoryID string) (*v2Models.GithubRepositoryBranchProtection, error) {
+	githubRepository, err := s.GetRepository(repositoryID)
+	if err != nil {
+		log.Warnf("fetching repository failed : %s : %v", repositoryID, err)
+		return nil, err
+	}
+
+	githubOrgName := githubRepository.RepositoryOrganizationName
+	githubRepoName := githubRepository.RepositoryName
+	githubRepoName = s.cleanGithubRepoName(githubRepoName)
+
+	githubClient, err := s.getGithubClientForOrgName(githubOrgName)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	owner, branchName, err := s.getGithubOwnerBranchName(githubClient, githubOrgName, githubRepoName)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &v2Models.GithubRepositoryBranchProtection{
+		BranchName: &branchName,
+	}
+	branchProtection, err := github.GetProtectedBranch(ctx, githubClient, owner, githubRepoName, branchName)
+	if err != nil {
+		if errors.Is(err, github.ErrBranchNotProtected) {
+			return result, nil
+		}
+		log.Warnf("getting the github protected branch for owner : %s, repo : %s and branch : %s failed : %v", owner, githubRepoName, branchName, err)
+		return nil, err
+	}
+
+	result.ProtectionEnabled = true
+	if github.IsEnforceAdminEnabled(branchProtection) {
+		result.EnforceAdmin = true
+	}
+
+	requiredChecks := requiredBranchProtectionChecks
+	requiredChecksResult := s.getRequiredProtectedBranchCheckStatus(branchProtection, requiredChecks)
+	result.StatusChecks = requiredChecksResult
+
+	return result, nil
+}
+
+func (s *service) UpdateProtectedBranch(repositoryID string, input *v2Models.GithubRepositoryBranchProtectionInput) (*v2Models.GithubRepositoryBranchProtection, error) {
+	githubRepository, err := s.GetRepository(repositoryID)
+	if err != nil {
+		log.Warnf("fetching repository failed : %s : %v", repositoryID, err)
+		return nil, err
+	}
+
+	githubOrgName := githubRepository.RepositoryOrganizationName
+	githubRepoName := githubRepository.RepositoryName
+	githubRepoName = s.cleanGithubRepoName(githubRepoName)
+
+	githubClient, err := s.getGithubClientForOrgName(githubOrgName)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	owner, branchName, err := s.getGithubOwnerBranchName(githubClient, githubOrgName, githubRepoName)
+	if err != nil {
+		return nil, err
+	}
+
+	var requiredChecks []string
+	var disabledChecks []string
+	if input.StatusChecks != nil {
+		for _, inputCheck := range input.StatusChecks {
+			// we want to make sure we only mutate checks related to lf
+			var found bool
+			for _, rc := range requiredBranchProtectionChecks {
+				if rc == *inputCheck.Name {
+					found = true
+					break
+				}
+			}
+
+			// just ignore that check if it's something not in our options
+			if !found {
+				continue
+			}
+
+			if !*inputCheck.Enabled {
+				disabledChecks = append(disabledChecks, *inputCheck.Name)
+				continue
+			}
+			requiredChecks = append(requiredChecks, *inputCheck.Name)
+		}
+	}
+
+	err = github.EnableBranchProtection(ctx, githubClient, owner, githubRepoName, branchName, *input.EnforceAdmin, requiredChecks, disabledChecks)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.GetProtectedBranch(repositoryID)
+}
+
+func (s *service) cleanGithubRepoName(githubRepoName string) string {
+	if strings.Contains(githubRepoName, "/") {
+		parts := strings.Split(githubRepoName, "/")
+		githubRepoName = parts[len(parts)-1]
+	}
+	return githubRepoName
+}
+
+func (s *service) getGithubClientForOrgName(githubOrgName string) (*githubsdk.Client, error) {
+	githubOrg, err := s.ghOrgRepo.GetGithubOrganization(githubOrgName)
+	if err != nil {
+		log.Warnf("fetching githubOrg failed : %s : %v", githubOrgName, err)
+		return nil, err
+	}
+
+	githubClient, err := github.NewGithubAppClient(githubOrg.OrganizationInstallationID)
+	if err != nil {
+		log.Warnf("creating the github client for installation id failed  : %d : %v", githubOrg.OrganizationInstallationID, err)
+		return nil, err
+	}
+
+	return githubClient, nil
+}
+
+func (s *service) getGithubOwnerBranchName(githubClient *githubsdk.Client, githubOrgName, githubRepoName string) (string, string, error) {
+	ctx := context.Background()
+	owner, err := github.GetOwnerName(ctx, githubClient, githubOrgName, githubRepoName)
+	if err != nil {
+		log.Warnf("getting the owner name for org : %s and repo : %s failed : %v", githubOrgName, githubRepoName, err)
+		return "", "", err
+	}
+
+	if owner == "" {
+		log.Warnf("github returned empty owner name for org : %s and repo : %s", githubOrgName, githubRepoName)
+		return "", "", fmt.Errorf("empty owner name")
+	}
+
+	log.Debugf("getGithubOwnerBranchName : owner of the repo : %s found : %s", owner, githubRepoName)
+	branchName, err := github.GetDefaultBranchForRepo(ctx, githubClient, owner, githubRepoName)
+	if err != nil {
+		log.Warnf("getting default github branch failed for owner : %s and repo : %s : %v", owner, githubRepoName, err)
+		return "", "", err
+	}
+
+	return owner, branchName, nil
+}
+
+// getRequiredProtectedBranchCheckStatus
+func (s *service) getRequiredProtectedBranchCheckStatus(protectedBranch *githubsdk.Protection, requiredChecks []string) []*v2Models.GithubRepositoryBranchProtectionStatusChecks {
+	var result []*v2Models.GithubRepositoryBranchProtectionStatusChecks
+	resultMap := map[string]bool{}
+	for _, rc := range requiredChecks {
+		result = append(result, &v2Models.GithubRepositoryBranchProtectionStatusChecks{
+			Name:    swag.String(rc),
+			Enabled: swag.Bool(false),
+		})
+		resultMap[rc] = true
+	}
+	if protectedBranch.RequiredStatusChecks == nil || len(protectedBranch.RequiredStatusChecks.Contexts) == 0 {
+		return result
+	}
+
+	for _, existingCheck := range protectedBranch.RequiredStatusChecks.Contexts {
+		if !resultMap[existingCheck] {
+			continue
+		}
+
+		// we mark it as enabled in this case
+		for i := range result {
+			if *result[i].Name == existingCheck {
+				result[i].Enabled = swag.Bool(true)
+			}
+		}
+	}
+
+	return result
 }
 
 func (s *service) DisableCLAGroupRepositories(claGroupID string) error {


### PR DESCRIPTION
Adds 2 new endpoints for working with github protected branches
- `GET /project/{projectSFID}/github/repositories/{repositoryID}/branch-protection`  : gets the current status for the repo
- `POST /project/{projectSFID}/github/repositories/{repositoryID}/branch-protection`  : updates branch protection
