### PR TITLE
use companySFID for invitation sending instead of internal id

### DIFF
--- a/cla-backend-go/v2/acs-service/client.go
+++ b/cla-backend-go/v2/acs-service/client.go
@@ -122,8 +122,8 @@ func (ac *Client) SendUserInvite(email *string,
 	log.Debugf("CreateUserinvite called with args email: %s, scope: %s, roleName: %s, type: %s, scopeID: %s",
 		*email, scope, roleName, inviteType, organizationID)
 	if inviteErr != nil {
-		log.WithFields(f).Error("CreateUserInvite failed", inviteErr)
-		return inviteErr
+		log.WithFields(f).Errorf("CreateUserInvite failed for payload : %+v : %v", params, inviteErr)
+		return nil
 	}
 
 	log.WithFields(f).Debugf("CreatedUserInvite :%+v", result.Payload)

--- a/cla-backend-go/v2/cla_manager/service.go
+++ b/cla-backend-go/v2/cla_manager/service.go
@@ -812,7 +812,7 @@ func (s *service) CreateCLAManagerRequest(contactAdmin bool, companySFID string,
 		msg := fmt.Sprintf("User: %s does not have an LF Login", userEmail)
 		log.WithFields(f).Warn(msg)
 		// Send email
-		sendEmailErr := sendEmailToUserWithNoLFID(projectSF.Name, authUser.UserName, authUser.Email, fullName, userEmail, v1CompanyModel.CompanyID, &projectSF.ID, utils.CLADesigneeRole)
+		sendEmailErr := sendEmailToUserWithNoLFID(projectSF.Name, authUser.UserName, authUser.Email, fullName, userEmail, companySFID, &projectSF.ID, utils.CLADesigneeRole)
 		if sendEmailErr != nil {
 			log.WithFields(f).Warnf("Error sending email: %+v", sendEmailErr)
 			return nil, sendEmailErr


### PR DESCRIPTION
- use companySFID for invitation sending instead of internal id
- revert back the change for failing on error for invitation sending