### PR TITLE
Reduced event logging on dynamodb record updates

### DIFF
--- a/cla-backend-go/v2/dynamo_events/service.go
+++ b/cla-backend-go/v2/dynamo_events/service.go
@@ -113,10 +113,12 @@ func (s *service) ProcessEvents(events events.DynamoDBEvent) {
 	for _, event := range events.Records {
 		tableName := strings.Split(event.EventSourceArn, "/")[1]
 		fields := logrus.Fields{
-			"table_name": tableName,
-			"event":      event,
-			"eventID":    event.EventID,
-			"eventName":  event.EventName,
+			"table_name":  tableName,
+			"eventID":     event.EventID,
+			"eventName":   event.EventName,
+			"eventSource": event.EventSource,
+			// Dumping the event is super verbose
+			// "event":      event,
 		}
 		b, _ := json.Marshal(events) // nolint
 		fields["events_data"] = string(b)


### PR DESCRIPTION
- Don't log raw event - way too verbose in the log stream

Signed-off-by: David Deal <dealako@gmail.com>