### PR TITLE
Added CLA Group project_live attribute support

### DIFF
--- a/cla-backend-go/project/helpers.go
+++ b/cla-backend-go/project/helpers.go
@@ -1,0 +1,59 @@
+// Copyright The Linux Foundation and each contributor to CommunityBridge.
+// SPDX-License-Identifier: MIT
+
+package project
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/communitybridge/easycla/cla-backend-go/gen/models"
+)
+
+// addStringAttribute adds a new string attribute to the existing map
+func addStringAttribute(item map[string]*dynamodb.AttributeValue, key string, value string) {
+	if value != "" {
+		item[key] = &dynamodb.AttributeValue{S: aws.String(value)}
+	}
+}
+
+// addBooleanAttribute adds a new boolean attribute to the existing map
+func addBooleanAttribute(item map[string]*dynamodb.AttributeValue, key string, value bool) {
+	item[key] = &dynamodb.AttributeValue{BOOL: aws.Bool(value)}
+}
+
+// addStringSliceAttribute adds a new string slice attribute to the existing map
+func addStringSliceAttribute(item map[string]*dynamodb.AttributeValue, key string, value []string) {
+	item[key] = &dynamodb.AttributeValue{SS: aws.StringSlice(value)}
+}
+
+// addListAttribute adds a list to the existing map
+func addListAttribute(item map[string]*dynamodb.AttributeValue, key string, value []*dynamodb.AttributeValue) {
+	item[key] = &dynamodb.AttributeValue{L: value}
+}
+
+// buildCLAGroupDocumentModels builds response models based on the array of db models
+func buildCLAGroupDocumentModels(dbDocumentModels []DBProjectDocumentModel) []models.ProjectDocument {
+	if dbDocumentModels == nil {
+		return nil
+	}
+
+	// Response model
+	var response []models.ProjectDocument
+
+	for _, dbDocumentModel := range dbDocumentModels {
+		response = append(response, models.ProjectDocument{
+			DocumentName:            dbDocumentModel.DocumentName,
+			DocumentAuthorName:      dbDocumentModel.DocumentAuthorName,
+			DocumentContentType:     dbDocumentModel.DocumentContentType,
+			DocumentFileID:          dbDocumentModel.DocumentFileID,
+			DocumentLegalEntityName: dbDocumentModel.DocumentLegalEntityName,
+			DocumentPreamble:        dbDocumentModel.DocumentPreamble,
+			DocumentS3URL:           dbDocumentModel.DocumentS3URL,
+			DocumentMajorVersion:    dbDocumentModel.DocumentMajorVersion,
+			DocumentMinorVersion:    dbDocumentModel.DocumentMinorVersion,
+			DocumentCreationDate:    dbDocumentModel.DocumentCreationDate,
+		})
+	}
+
+	return response
+}

--- a/cla-backend-go/project/models.go
+++ b/cla-backend-go/project/models.go
@@ -18,6 +18,7 @@ type DBProjectModel struct {
 	ProjectCclaEnabled               bool                     `dynamodbav:"project_ccla_enabled"`
 	ProjectCclaRequiresIclaSignature bool                     `dynamodbav:"project_ccla_requires_icla_signature"`
 	ProjectIclaEnabled               bool                     `dynamodbav:"project_icla_enabled"`
+	ProjectLive                      bool                     `dynamodbav:"project_live"`
 	ProjectCorporateDocuments        []DBProjectDocumentModel `dynamodbav:"project_corporate_documents"`
 	ProjectIndividualDocuments       []DBProjectDocumentModel `dynamodbav:"project_individual_documents"`
 	ProjectMemberDocuments           []DBProjectDocumentModel `dynamodbav:"project_member_documents"`

--- a/cla-backend-go/project/projections.go
+++ b/cla-backend-go/project/projections.go
@@ -1,0 +1,31 @@
+// Copyright The Linux Foundation and each contributor to CommunityBridge.
+// SPDX-License-Identifier: MIT
+
+package project
+
+import "github.com/aws/aws-sdk-go/service/dynamodb/expression"
+
+// buildProject is a helper function to build a common set of projection/columns for the query
+func buildProjection() expression.ProjectionBuilder {
+	// These are the columns we want returned
+	return expression.NamesList(
+		expression.Name("project_id"),
+		expression.Name("foundation_sfid"),
+		expression.Name("root_project_repositories_count"),
+		expression.Name("project_external_id"),
+		expression.Name("project_name"),
+		expression.Name("project_name_lower"),
+		expression.Name("project_description"),
+		expression.Name("project_acl"),
+		expression.Name("project_ccla_enabled"),
+		expression.Name("project_icla_enabled"),
+		expression.Name("project_ccla_requires_icla_signature"),
+		expression.Name("project_live"),
+		expression.Name("project_corporate_documents"),
+		expression.Name("project_individual_documents"),
+		expression.Name("project_member_documents"),
+		expression.Name("date_created"),
+		expression.Name("date_modified"),
+		expression.Name("version"),
+	)
+}

--- a/cla-backend-go/swagger/common/project.yaml
+++ b/cla-backend-go/swagger/common/project.yaml
@@ -43,6 +43,10 @@ properties:
     description: Flag to indicate if the CCLA configuration also requires an ICLA
     type: boolean
     x-omitempty: false
+  projectLive:
+    description: Flag to indicate if the CLA Group is live in production. Applies to the production environment only, flag indicates if the CLA Group is being actively used by the community.
+    type: boolean
+    x-omitempty: false
   projectCorporateDocuments:
     description: Project Corporate Documents
     type: array

--- a/cla-backend/cla/models/dynamo_models.py
+++ b/cla-backend/cla/models/dynamo_models.py
@@ -931,6 +931,7 @@ class ProjectModel(BaseModel):
     project_icla_enabled = BooleanAttribute(default=True)
     project_ccla_enabled = BooleanAttribute(default=True)
     project_ccla_requires_icla_signature = BooleanAttribute(default=False)
+    project_live = BooleanAttribute(default=False)
     foundation_sfid = UnicodeAttribute(null=True)
     root_project_repositories_count = NumberAttribute(null=True)
     # Indexes
@@ -959,6 +960,7 @@ class Project(model_interfaces.Project):  # pylint: disable=too-many-public-meth
             project_ccla_enabled=True,
             project_ccla_requires_icla_signature=False,
             project_acl=None,
+            project_live=False,
     ):
         super(Project).__init__()
         self.model = ProjectModel()
@@ -970,6 +972,7 @@ class Project(model_interfaces.Project):  # pylint: disable=too-many-public-meth
         self.model.project_ccla_enabled = project_ccla_enabled
         self.model.project_ccla_requires_icla_signature = project_ccla_requires_icla_signature
         self.model.project_acl = project_acl
+        self.model.project_live = project_live
 
     def __str__(self):
         return (
@@ -981,6 +984,7 @@ class Project(model_interfaces.Project):  # pylint: disable=too-many-public-meth
             f"project_icla_enabled: {self.model.project_icla_enabled}, "
             f"project_ccla_enabled: {self.model.project_ccla_enabled}, "
             f"project_ccla_requires_icla_signature: {self.model.project_ccla_requires_icla_signature}, "
+            f"project_live: {self.model.project_live}, "
             f"project_acl: {self.model.project_acl}, "
             f"root_project_repositories_count: {self.model.root_project_repositories_count}, "
             f"date_created: {self.model.date_created}, "
@@ -1060,6 +1064,9 @@ class Project(model_interfaces.Project):  # pylint: disable=too-many-public-meth
 
     def get_project_ccla_enabled(self):
         return self.model.project_ccla_enabled
+
+    def get_project_live(self):
+        return self.model.project_live
 
     def get_project_individual_documents(self):
         documents = []
@@ -1188,6 +1195,9 @@ class Project(model_interfaces.Project):  # pylint: disable=too-many-public-meth
 
     def set_project_ccla_enabled(self, project_ccla_enabled):
         self.model.project_ccla_enabled = project_ccla_enabled
+
+    def set_project_live(self, project_live):
+        self.model.project_live = project_live
 
     def add_project_individual_document(self, document):
         self.model.project_individual_documents.append(document.model)


### PR DESCRIPTION
- Added CLA Group project_live attribute/column to allow PROD reporting
  of which repos are actually LIVE used by the community.
- Updated Python Data Model
- Updated GoLang Data Models
- Updated Project repository - moved helpers and projections to separate file

Signed-off-by: David Deal <dealako@gmail.com>