### PR TITLE
[#1503] CLA Group Delete - Role Cleanup

### DIFF
--- a/cla-backend-go/v2/dynamo_events/signatures.go
+++ b/cla-backend-go/v2/dynamo_events/signatures.go
@@ -159,7 +159,7 @@ func (s *service) SignatureSignedEvent(event events.DynamoDBEventRecord) error {
 					// Remove any roles that were previously assigned for cla-manager-designee
 					log.WithFields(f).Debugf("removing existing %s role for project: '%s' (%s) and company: '%s' (%s)",
 						utils.CLADesigneeRole, projectCLAGroup.ProjectName, projectCLAGroup.ProjectSFID, companyModel.CompanyName, companyModel.CompanyExternalID)
-					err = s.removeCLAPermissionsByProjectOrganizationRole(projectCLAGroup.ProjectSFID, companyModel.CompanyExternalID, utils.CLADesigneeRole)
+					err = s.removeCLAPermissionsByProjectOrganizationRole(projectCLAGroup.ProjectSFID, companyModel.CompanyExternalID, []string{utils.CLADesigneeRole})
 					if err != nil {
 						log.WithFields(f).Warnf("failed to remove %s roles for project: '%s' (%s) and company: '%s' (%s), error: %+v",
 							utils.CLADesigneeRole, projectCLAGroup.ProjectName, projectCLAGroup.ProjectSFID, companyModel.CompanyName, companyModel.CompanyExternalID, err)


### PR DESCRIPTION
- Added additional logic to remove CLA roles associated with Projects
  and Orgs associated with a CLA Group when the CLA Group is removed.

Signed-off-by: David Deal <dealako@gmail.com>