### PR TITLE
Removed Admin User Permissions Check

### DIFF
--- a/cla-backend-go/utils/utils_user_auth.go
+++ b/cla-backend-go/utils/utils_user_auth.go
@@ -14,48 +14,34 @@ func IsUserAdmin(user *auth.User) bool {
 
 // IsUserAuthorizedForOrganization helper function for determining if the user is authorized for this company
 func IsUserAuthorizedForOrganization(user *auth.User, companySFID string) bool {
-	if !user.Admin {
-		if !user.Allowed || !user.IsUserAuthorizedForOrganizationScope(companySFID) {
-			return false
-		}
-	}
-	return true
+	// Previously, we checked for user.Admin - admins should be in a separate role
+	// Previously, we checked for user.Allowed, which is currently not used (future flag that is currently not implemented)
+	return user.IsUserAuthorizedForOrganizationScope(companySFID)
 }
 
 // IsUserAuthorizedForProject helper function for determining if the user is authorized for this project
 func IsUserAuthorizedForProject(user *auth.User, projectSFID string) bool {
-	if !user.Admin {
-		if !user.Allowed || !user.IsUserAuthorizedForProjectScope(projectSFID) {
-			return false
-		}
-	}
-	return true
+	// Previously, we checked for user.Admin - admins should be in a separate role
+	// Previously, we checked for user.Allowed, which is currently not used (future flag that is currently not implemented)
+	return user.IsUserAuthorizedForProjectScope(projectSFID)
 }
 
 // IsUserAuthorizedForProjectTree helper function for determining if the user is authorized for this project hierarchy/tree
 func IsUserAuthorizedForProjectTree(user *auth.User, projectSFID string) bool {
-	if !user.Admin {
-		if !user.Allowed || !user.IsUserAuthorized(auth.Project, projectSFID, true) {
-			return false
-		}
-	}
-	return true
+	// Previously, we checked for user.Admin - admins should be in a separate role
+	// Previously, we checked for user.Allowed, which is currently not used (future flag that is currently not implemented)
+	return user.IsUserAuthorized(auth.Project, projectSFID, true)
 }
 
 // IsUserAuthorizedForProjectOrganization helper function for determining if the user is authorized for this project organization scope
 func IsUserAuthorizedForProjectOrganization(user *auth.User, projectSFID, companySFID string) bool {
-	if !user.Allowed || !user.IsUserAuthorizedByProject(projectSFID, companySFID) {
-		return false
-	}
-	return true
+	// Previously, we checked for user.Allowed, which is currently not used (future flag that is currently not implemented)
+	return user.IsUserAuthorizedByProject(projectSFID, companySFID)
 }
 
 // IsUserAuthorizedForProjectOrganizationTree helper function for determining if the user is authorized for this project organization scope and nested projects/orgs
 func IsUserAuthorizedForProjectOrganizationTree(user *auth.User, projectSFID, companySFID string) bool {
-	if !user.Admin {
-		if !user.Allowed || !user.IsUserAuthorized(auth.ProjectOrganization, projectSFID+"|"+companySFID, true) {
-			return false
-		}
-	}
-	return true
+	// Previously, we checked for user.Admin - admins should be in a separate role
+	// Previously, we checked for user.Allowed, which is currently not used (future flag that is currently not implemented)
+	return user.IsUserAuthorized(auth.ProjectOrganization, projectSFID+"|"+companySFID, true)
 }


### PR DESCRIPTION
- Removed user.Admin check -> user.admin will be true if the caller is
  super-admin or system-admin or m2m client. In our case, users should be
  in another role to access EasyCLA.
- Remmoved the user.Allowed check -> this may be used in the future, but
  currently not implemented

Signed-off-by: David Deal <dealako@gmail.com>