### PR TITLE
Remove GH Secret from Log + Re-Order Docusign Callback

### DIFF
--- a/bug-reporting.md
+++ b/bug-reporting.md
@@ -1,0 +1,13 @@
+# Feature Requests and Bug Reporting
+
+The EasyCLA team welcomes new feature requests and bug reports.  Please file a
+feature request, documentation update, or bug fix using the
+[GitHub Issues](https://github.com/communitybridge/easycla/issues) feature of
+this repository.
+
+To file a new ticket, select 'New Issue' from the issues page. Select one of the
+existing Issue types, fill out the ticket and press the 'Submit new issue'
+button.
+
+Generally, the EasyCLA team reviews the backlog of tickets once a week.
+

--- a/cla-backend/cla/controllers/github.py
+++ b/cla-backend/cla/controllers/github.py
@@ -765,17 +765,23 @@ def webhook_secret_validation(webhook_signature: str, data: bytes) -> bool:
     :param data:
     :return:
     """
-    cla.log.debug(f"webhook_secret_validation for signature {webhook_signature} and env : {cla.config.GITHUB_APP_WEBHOOK_SECRET}")
+    cla.log.debug(f"webhook_secret_validation for signature {webhook_signature}")
     if cla.config.GITHUB_APP_WEBHOOK_SECRET == "":
+        cla.log.warning('webhook_secret_validation - GITHUB_APP_WEBHOOK_SECRET is empty')
         raise RuntimeError("GITHUB_APP_WEBHOOK_SECRET is empty")
 
     if not webhook_signature:
+        cla.log.warning('webhook_secret_validation - webhook_signature not provided - '
+                        'unable to validate webhook callback')
         return False
 
     sha_name, signature = webhook_signature.split('=')
     if not sha_name == 'sha1':
+        cla.log.warning(f'webhook_secret_validation - unsupported sha_name: {sha_name} - '
+                        'unable to validate webhook callback')
         return False
 
+    cla.log.debug(f'webhook_secret_validation - calculating and comparing webhook secret...')
     mac = hmac.new(cla.config.GITHUB_APP_WEBHOOK_SECRET.encode('utf-8'), msg=data, digestmod='sha1')
     hex_digest = mac.hexdigest()
     return True if hmac.compare_digest(hex_digest, signature.strip()) else False

--- a/cla-backend/cla/models/github_models.py
+++ b/cla-backend/cla/models/github_models.py
@@ -782,22 +782,24 @@ def get_pull_request_commit_authors(pull_request):
             # commit.author is a github.NamedUser.NamedUser type object
             # https://pygithub.readthedocs.io/en/latest/github_objects/NamedUser.html
             if commit.author.name is not None:
-                cla.log.debug('PR: {}, GitHub NamedUser author found for commit SHA {}, '
+                cla.log.debug('PR: {}, GitHub commit.author.name author found for commit SHA {}, '
                               'author id: {}, name: {}, email: {}'.
                               format(pull_request.number, commit.sha, commit.author.id,
                                      commit.author.name, commit.author.email))
                 commit_authors.append((commit.sha, (commit.author.id, commit.author.name, commit.author.email)))
             elif commit.author.login is not None:
-                cla.log.debug('PR: {}, GitHub NamedUser author found for commit SHA {}, '
+                cla.log.debug('PR: {}, GitHub commit.author.login author found for commit SHA {}, '
                               'author id: {}, login: {}, email: {}'.
                               format(pull_request.number, commit.sha, commit.author.id,
                                      commit.author.login, commit.author.email))
                 commit_authors.append((commit.sha, (commit.author.id, commit.author.login, commit.author.email)))
             else:
-                cla.log.debug('PR: {}, GitHub NamedUser author NOT found for commit SHA {}, '
-                              'author id: {}, name: {}, login: {}, email: {}'.
-                              format(pull_request.number, commit.sha, commit.author.id, commit.author.name,
-                                     commit.author.login, commit.author.email))
+                cla.log.debug(f'PR: {pull_request.number}, GitHub commit.author.name and commit.author.login '
+                              f'author information NOT found for commit SHA {commit.sha}, '
+                              f'author id: {commit.author.id}, '
+                              f'name: {commit.author.name}, '
+                              f'login: {commit.author.login}, '
+                              f'email: {commit.author.email}')
                 commit_authors.append((commit.sha, None))
         elif commit.commit.author is not None:
             cla.log.debug('github.GitAuthor.GitAuthor object: {}'.format(commit.commit.author))

--- a/cla-frontend-project-console/edge/security-headers.js
+++ b/cla-frontend-project-console/edge/security-headers.js
@@ -81,7 +81,10 @@ function generateCSP(env, isDevServer) {
       'https://cla-signature-files-staging.s3.amazonaws.com/',
       'https://s3.amazonaws.com/cla-project-logo-staging/',
       'https://cla-signature-files-prod.s3.amazonaws.com/',
-      'https://s3.amazonaws.com/cla-project-logo-prod/'
+      'https://s3.amazonaws.com/cla-project-logo-prod/',
+      'https://linuxfoundation-dev.auth0.com',
+      'https://linuxfoundation-staging.auth0.com',
+      'https://linuxfoundation.auth0.com'
     ],
     'child-src': [],
     'media-src': [],

--- a/cla-frontend-project-console/src/ionic/decorators/restricted.ts
+++ b/cla-frontend-project-console/src/ionic/decorators/restricted.ts
@@ -1,10 +1,18 @@
 // Copyright The Linux Foundation and each contributor to CommunityBridge.
 // SPDX-License-Identifier: MIT
 
+import { tap } from "rxjs/operators";
+
 export function Restricted(restrictions: any) {
   return function (target: Function) {
     target.prototype.ionViewCanEnter = function () {
-      return true;
+      return this.auth.isAuthenticated$.pipe(
+        tap((loggedIn) => {
+          if (!loggedIn) {
+            this.auth.login('');
+          }
+        })
+      );
     };
   };
 }

--- a/cla-frontend-project-console/src/ionic/pages/all-projects/all-projects.ts
+++ b/cla-frontend-project-console/src/ionic/pages/all-projects/all-projects.ts
@@ -8,6 +8,7 @@ import { FilterService } from '../../services/filter.service';
 import { Restricted } from '../../decorators/restricted';
 import { generalConstants } from '../../constants/general';
 import { EnvConfig } from '../../services/cla.env.utils';
+import { AuthService } from '../../services/auth.service';
 
 @Restricted({
   roles: ['isAuthenticated', 'isPmcUser']
@@ -33,7 +34,8 @@ export class AllProjectsPage {
   constructor(
     public navCtrl: NavController,
     private claService: ClaService,
-    private filterService: FilterService
+    private filterService: FilterService,
+    public auth: AuthService
   ) {
     this.getDefaults();
   }

--- a/cla-frontend-project-console/src/ionic/pages/auth/auth.ts
+++ b/cla-frontend-project-console/src/ionic/pages/auth/auth.ts
@@ -34,21 +34,5 @@ export class AuthPage implements AfterViewInit {
     this.lfxHeaderService.setUserInLFxHeader();
     this.navCtrl.setRoot('AllProjectsPage');
 
-    // setTimeout(() => {
-    //   if (this.authService.loggedIn) {
-    //     this.lfxHeaderService.setUserInLFxHeader();
-    //     this.navCtrl.setRoot('AllProjectsPage');
-    //   } else {
-    //     this.redirectToLogin();
-    //   }
-    // }, 5000); // Added delay to initialse auth service.
-  }
-
-  redirectToLogin() {
-    if (EnvConfig['lfx-header-enabled'] === "true") {
-      window.open(EnvConfig['landing-page'], '_self');
-    } else {
-      this.navCtrl.setRoot('LoginPage');
-    }
   }
 }

--- a/cla-frontend-project-console/src/ionic/services/auth.service.ts
+++ b/cla-frontend-project-console/src/ionic/services/auth.service.ts
@@ -1,8 +1,3 @@
-/**
- * updated: 2020-10-21
- * v0.0.3
- *
- */
 
 import { Injectable } from '@angular/core';
 import createAuth0Client from '@auth0/auth0-spa-js';

--- a/cla-landing-page/package.json
+++ b/cla-landing-page/package.json
@@ -49,6 +49,7 @@
     "auth0-js": "^9.13.2",
     "aws-sdk": "^2.733.0",
     "bootstrap": "^4.4.0",
+    "query-string": "^6.13.6",
     "rxjs": "~6.5.4",
     "serverless": "^2.8.0",
     "serverless-aws-alias": "^1.8.0",
@@ -58,6 +59,7 @@
     "serverless-plugin-tracing": "^2.0.0",
     "serverless-pseudo-parameters": "^2.5.0",
     "tslib": "^1.10.0",
+    "url-parse": "^1.4.7",
     "zone.js": "~0.10.2"
   },
   "devDependencies": {

--- a/cla-landing-page/src/app/app.component.ts
+++ b/cla-landing-page/src/app/app.component.ts
@@ -3,6 +3,7 @@
 
 import { Component, OnInit } from '@angular/core';
 import { environment } from 'src/environments/environment';
+import { LfxHeaderService } from './core/services/lfx-header.service';
 
 @Component({
   selector: 'app-root',
@@ -13,7 +14,9 @@ export class AppComponent implements OnInit {
   hasExpanded: boolean;
   links: any[];
 
-  constructor() {
+  constructor(
+    private lfxHeaderService: LfxHeaderService
+  ) {
     this.hasExpanded = true;
     this.links = [
       {

--- a/cla-landing-page/src/app/app.module.ts
+++ b/cla-landing-page/src/app/app.module.ts
@@ -13,6 +13,7 @@ import { AuthService } from './core/services/auth.service';
 import { HomeComponent } from './components/home/home.component';
 import { PageNotFoundComponent } from './components/page-not-found/page-not-found.component';
 import { StorageService } from './core/services/storage.service';
+import { LfxHeaderService } from './core/services/lfx-header.service';
 
 @NgModule({
   declarations: [
@@ -27,7 +28,7 @@ import { StorageService } from './core/services/storage.service';
     BrowserModule,
     AppRoutingModule
   ],
-  providers: [AuthService, StorageService],
+  providers: [AuthService, StorageService, LfxHeaderService],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/cla-landing-page/src/app/core/services/lfx-header.service.spec.ts
+++ b/cla-landing-page/src/app/core/services/lfx-header.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { LfxHeaderService } from './lfx-header.service';
+
+describe('LfxHeaderService', () => {
+  let service: LfxHeaderService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(LfxHeaderService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/cla-landing-page/src/app/core/services/lfx-header.service.ts
+++ b/cla-landing-page/src/app/core/services/lfx-header.service.ts
@@ -1,0 +1,29 @@
+
+import { Injectable } from '@angular/core';
+import { AuthService } from './auth.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LfxHeaderService {
+
+  constructor(private auth: AuthService) {
+    this.setUserInLFxHeader();
+  }
+
+  setUserInLFxHeader(): void {
+    setTimeout(() => {
+      const lfHeaderEl: any = document.getElementById('lfx-header');
+      console.log(lfHeaderEl);
+      if (!lfHeaderEl) {
+        return;
+      }
+      this.auth.userProfile$.subscribe((data) => {
+        console.log(data);
+        if (data) {
+          lfHeaderEl.authuser = data;
+        }
+      });
+    }, 2000);
+  }
+}

--- a/cla-landing-page/yarn.lock
+++ b/cla-landing-page/yarn.lock
@@ -9499,6 +9499,15 @@ query-string@^5.0.1:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
+query-string@^6.13.6:
+  version "6.13.6"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.13.6.tgz#e5ac7c74f2a5da43fbca0b883b4f0bafba439966"
+  integrity sha512-/WWZ7d9na6s2wMEGdVCVgKWE9Rt7nYyNIf7k8xmHXcesPMlEzicWo3lbYwHyA4wBktI2KrXxxZeACLbE84hvSQ==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -10784,6 +10793,11 @@ speed-measure-webpack-plugin@1.3.1:
   dependencies:
     chalk "^2.0.1"
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -10926,6 +10940,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-width@^1.0.1:
   version "1.0.2"
@@ -11785,7 +11804,7 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-url-parse@^1.4.3:
+url-parse@^1.4.3, url-parse@^1.4.7:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
   integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==


### PR DESCRIPTION
- Removed GitHub Secret printout from the AWS log
- Added more Github Secret processing debug
- Reordered DocuSign logic callback - updated GH comment/status early in the flow rather than at the end to make the GH refresh/status more responsive to use as they are navigated back to the UI from DocuSign

Signed-off-by: David Deal <dealako@gmail.com>