### PR TITLE
V1 - REMOVE button is shown for disabled repos in Configure Github Repistories popup

### DIFF
--- a/cla-frontend-project-console/src/ionic/modals/cla-configure-github-repositories-modal/cla-configure-github-repositories-modal.ts
+++ b/cla-frontend-project-console/src/ionic/modals/cla-configure-github-repositories-modal/cla-configure-github-repositories-modal.ts
@@ -72,10 +72,7 @@ export class ClaConfigureGithubRepositoriesModal {
 
           if (this.isTaken(repository)) {
             repository.status = 'taken';
-
-            if (this.isAssignedToLocalContractGroup(repository)) {
-              repository.status = 'assigned';
-            }
+            this.isAssignedToLocalContractGroup(repository);
           }
 
           return repository;
@@ -94,7 +91,13 @@ export class ClaConfigureGithubRepositoriesModal {
   }
 
   isAssignedToLocalContractGroup(repository) {
-    return String(repository.repository_project_id) === String(this.claProjectId);
+    if (repository.repository_project_id === String(this.claProjectId)) {
+      if (repository.enabled) {
+        repository.status = 'assigned';
+      } else {
+        repository.status = 'free';
+      }
+    }
   }
 
   isTaken(repository) {


### PR DESCRIPTION
Signed-off-by: Amol Sontakke <amols@proximabiz.com>

@nirupamav This fix depends on @wanyaland to update the old records flag.