### PR TITLE
Lazy Load GitHub private Key

### DIFF
--- a/cla-backend/cla/config.py
+++ b/cla-backend/cla/config.py
@@ -116,4 +116,7 @@ LOCAL_STORAGE_FOLDER = '/tmp/cla'  #: Local folder when using the LocalStorage s
 PDF_SERVICE = 'DocRaptor'
 
 # GH Private Key
-GITHUB_PRIVATE_KEY = get_ssm_key('us-east-1', f'cla-gh-app-private-key-{stage}')
+# Moved to GitHub application class GitHubInstallation as loading this property is taking ~1 sec on startup which is
+# killing our response performance - in most API calls this key/attribute is not used, so, we will lazy load this
+# property on class construction
+#GITHUB_PRIVATE_KEY = get_ssm_key('us-east-1', f'cla-gh-app-private-key-{stage}')

--- a/cla-backend/cla/utils.py
+++ b/cla-backend/cla/utils.py
@@ -940,11 +940,12 @@ def get_authorization_url_and_state(client_id, redirect_uri, scope, authorize_ur
     :param authorize_url: The URL to submit the OAuth2 request.
     :type authorize_url: string
     """
+    fn = 'utils.get_authorization_url_and_state'
     oauth = OAuth2Session(client_id, redirect_uri=redirect_uri, scope=scope)
     authorization_url, state = oauth.authorization_url(authorize_url)
-    cla.log.debug(
-        'utils.py - get_authorization_url_and_state - authorization_url: {}, state: {}'.format(authorization_url,
-                                                                                               state))
+    cla.log.debug(f'{fn} - get_authorization_url_and_state - '
+                  f'authorization_url: {authorization_url}, '
+                  f'state: {state}')
     return authorization_url, state
 
 
@@ -966,12 +967,16 @@ def fetch_token(client_id, state, token_url, client_secret, code,
     :param redirect_uri: The redirect URI for this OAuth2 session.
     :type redirect_uri: string
     """
+    fn = 'utils.fetch_token'
     if redirect_uri is not None:
         oauth2 = OAuth2Session(client_id, state=state, scope=['user:email'], redirect_uri=redirect_uri)
     else:
         oauth2 = OAuth2Session(client_id, state=state, scope=['user:email'])
-    cla.log.debug('utils.py - oauth2.fetch_token - token_url: {}, client_id: {}, client_secret: {}, code: {}'.
-                  format(token_url, client_id, client_secret, code))
+    cla.log.debug(f'{fn} - oauth2.fetch_token - '
+                  f'token_url: {token_url}, '
+                  f'client_id: {client_id}, '
+                  f'client_secret: {client_secret}, '
+                  f'code: {code}')
     return oauth2.fetch_token(token_url, client_secret=client_secret, code=code)
 
 


### PR DESCRIPTION
-  Moved to GitHub application class GitHubInstallation as loading the
GITHUB_PRIVATE_KEY from SSM is taking ~1 sec on startup which is killing
our response performance - in most API calls this key/attribute is not
used, so, we will lazy load this property on class construction

Signed-off-by: David Deal <dealako@gmail.com>