### PR TITLE
[#722, #2194] Resolved GitHub Comment Update Issue

### DIFF
--- a/cla-backend-go/github/github_repository.go
+++ b/cla-backend-go/github/github_repository.go
@@ -50,6 +50,7 @@ func GetRepositories(ctx context.Context, organizationName string) ([]*github.Re
 	client := NewGithubOauthClient()
 
 	// API https://docs.github.com/en/free-pro-team@latest/rest/reference/repos
+	// TODO: - only can pull 100 repos at a time - need to do pagination
 	repoList, resp, err := client.Repositories.ListByOrg(ctx, organizationName, &github.RepositoryListByOrgOptions{
 		Type:      "public",
 		Sort:      "full_name",

--- a/cla-backend/cla/models/github_models.py
+++ b/cla-backend/cla/models/github_models.py
@@ -865,11 +865,11 @@ def has_check_previously_failed(pull_request: PullRequest) -> bool:
     for comment in comments:
         # Our bot comments include the following text
         # A previously failed check has 'not authorized' somewhere in the body
-        if '[![CLA Check](' in comment.body and 'not authorized' in comment.body:
+        if 'CLA Not Signed' in comment.body and 'not authorized' in comment.body:
             return True
-        if '[![CLA Check](' in comment.body and 'must confirm their affiliation' in comment.body:
+        if 'CLA Confirmation Needed' in comment.body and 'must confirm their affiliation' in comment.body:
             return True
-        if '[![CLA Check](' in comment.body and 'is missing the User' in comment.body:
+        if 'CLA Missing ID' in comment.body and 'is missing the User' in comment.body:
             return True
     return False
 


### PR DESCRIPTION
- Updated logic to detect our existing GitHub comment - should now
  properly identify own comment and update the comment details when we
  transition from failed PR check to successful PR check.

Signed-off-by: David Deal <dealako@gmail.com>