### PR TITLE
[#2110] adding pr comment handler to check for comment commands

### DIFF
--- a/cla-backend/cla/config.py
+++ b/cla-backend/cla/config.py
@@ -14,7 +14,7 @@ import logging
 import os
 
 from boto3 import client
-from botocore.exceptions import ClientError, ProfileNotFound
+from botocore.exceptions import ClientError, ProfileNotFound, NoCredentialsError
 
 
 def get_ssm_key(region, key):
@@ -120,4 +120,9 @@ PDF_SERVICE = 'DocRaptor'
 # Moved to GitHub application class GitHubInstallation as loading this property is taking ~1 sec on startup which is
 # killing our response performance - in most API calls this key/attribute is not used, so, we will lazy load this
 # property on class construction
-GITHUB_PRIVATE_KEY = get_ssm_key('us-east-1', f'cla-gh-app-private-key-{stage}')
+GITHUB_PRIVATE_KEY = ""
+try:
+    GITHUB_PRIVATE_KEY = get_ssm_key('us-east-1', f'cla-gh-app-private-key-{stage}')
+except NoCredentialsError as ex:
+    # we don't want things to fail during unit testing
+    pass

--- a/cla-backend/cla/controllers/github.py
+++ b/cla-backend/cla/controllers/github.py
@@ -278,6 +278,10 @@ def activity(event_type, body):
     elif event_type == 'pull_request':
         handle_pull_request_event(action, body)
 
+    elif event_type == "issue_comment":
+        cla.log.debug(f'github.activity - received issue_comment action: {action}...')
+        handle_pull_request_comment_event(action, body)
+
     else:
         cla.log.debug(f'github.activity - ignoring github activity event, action: {action}...')
 
@@ -351,6 +355,24 @@ def handle_pull_request_event(action: str, body: dict):
         return result
     else:
         cla.log.debug(f'{func_name} - ignoring github pull_request activity for action: {action}')
+
+
+def handle_pull_request_comment_event(action: str, body: dict):
+    func_name = 'github.activity.handle_pull_request_comment_event'
+    cla.log.debug(f'{func_name} - processing github pull_request comment activity callback...')
+
+    # New comment created or edited
+    if action == 'created' or action == 'edited':
+        cla.log.debug(f'{func_name} - processing github pull_request comment activity for action: {action}')
+        service = cla.utils.get_repository_service('github')
+        try:
+            result = service.process_easycla_command_comment(body)
+            return result
+        except ValueError as ex:
+            cla.log.warning(f"process_easycla_command_comment failed with : {str(ex)}")
+            return None
+    else:
+        cla.log.debug(f'{func_name} - ignoring github pull_request comment activity for action: {action}')
 
 
 def handle_installation_repositories_event(action: str, body: dict):

--- a/cla-backend/requirements.txt
+++ b/cla-backend/requirements.txt
@@ -20,7 +20,7 @@ gossip==2.3.1
 gunicorn==19.9.0
 hug==2.6.0
 idna==2.8
-importlib-metadata==1.3.0
+importlib-metadata==1.6.1
 jmespath==0.9.4
 lazy-object-proxy==1.4.3
 Logbook==1.5.3


### PR DESCRIPTION
* adds pr comment handler to check for `/easycla` command in order to re-run the cla checks.