### PR TITLE
Updated kind-of library

### DIFF
--- a/cla-frontend-contributor-console/src/package.json
+++ b/cla-frontend-contributor-console/src/package.json
@@ -59,11 +59,12 @@
     "typescript": "3.0.1"
   },
   "resolutions": {
-    "node-sass": "4.13.1",
-    "mem": "^4.0.0",
-    "tunnel-agent": "^0.6.0",
     "cryptiles": "^4.1.2",
     "hoek": "^4.2.1",
+    "kind-of": "^6.0.3",
+    "mem": "^4.0.0",
+    "node-sass": "4.13.1",
+    "tunnel-agent": "^0.6.0",
     "yargs-parser": "13.1.2"
   },
   "cordovaPlugins": [

--- a/cla-frontend-contributor-console/src/yarn.lock
+++ b/cla-frontend-contributor-console/src/yarn.lock
@@ -1978,10 +1978,6 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-buffer@^1.1.5:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
-
 is-data-descriptor@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
@@ -2237,25 +2233,7 @@ jwt-decode@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-2.2.0.tgz#7d86bd56679f58ce6a84704a657dd392bba81a79"
 
-kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
-  dependencies:
-    is-buffer "^1.1.5"
-
-kind-of@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
-  integrity sha1-IIE989cSkosgc3hpGkUGb65y3Vc=
-  dependencies:
-    is-buffer "^1.1.5"
-
-kind-of@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
-  integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
-
-kind-of@^6.0.0, kind-of@^6.0.2:
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0, kind-of@^4.0.0, kind-of@^5.0.0, kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==


### PR DESCRIPTION
- Resolved low severity Vulnerable versions: >= 6.0.0, < 6.0.3 Patched
version: 6.0.3 Versions of kind-of 6.x prior to 6.0.3 are vulnerable to
a Validation Bypass. A maliciously crafted object can alter the result
of the type check, allowing attackers to bypass the type checking
validation.

Signed-off-by: David Deal <dealako@gmail.com>