### PR TITLE
Updated kind-of and minimist libraries

### DIFF
--- a/cla-frontend-corporate-console/src/package.json
+++ b/cla-frontend-corporate-console/src/package.json
@@ -67,11 +67,13 @@
   ],
   "resolutions": {
     "bl": "^1.2.3",
-    "node-sass": "4.13.1",
-    "mem": "^4.0.0",
-    "tunnel-agent": "^0.6.0",
     "cryptiles": "^4.1.2",
     "hoek": "^4.2.1",
+    "kind-of": "^6.0.3",
+    "mem": "^4.0.0",
+    "minimist": "^1.2.3",
+    "node-sass": "4.13.1",
+    "tunnel-agent": "^0.6.0",
     "yargs-parser": "13.1.2"
   },
   "cordovaPlatforms": [

--- a/cla-frontend-corporate-console/src/yarn.lock
+++ b/cla-frontend-corporate-console/src/yarn.lock
@@ -1936,10 +1936,6 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-buffer@^1.1.5:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
-
 is-data-descriptor@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
@@ -2186,26 +2182,7 @@ jwt-decode@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-2.2.0.tgz#7d86bd56679f58ce6a84704a657dd392bba81a79"
 
-kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
-  integrity sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
-  dependencies:
-    is-buffer "^1.1.5"
-
-kind-of@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
-  integrity sha1-IIE989cSkosgc3hpGkUGb65y3Vc=
-  dependencies:
-    is-buffer "^1.1.5"
-
-kind-of@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
-  integrity sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
-
-kind-of@^6.0.0, kind-of@^6.0.2:
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0, kind-of@^4.0.0, kind-of@^5.0.0, kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
@@ -2488,12 +2465,7 @@ minimatch@^3.0.4, minimatch@~3.0.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
-minimist@^1.1.3, minimist@^1.2.0:
+minimist@0.0.8, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==


### PR DESCRIPTION
- kind-of: low severity Vulnerable versions: >= 6.0.0, < 6.0.3 Patched
version: 6.0.3 Versions of kind-of 6.x prior to 6.0.3 are vulnerable to
a Validation Bypass. A maliciously crafted object can alter the result
of the type check, allowing attackers to bypass the type checking
validation.
- Minimist: low severity Vulnerable versions: >= 1.0.0, < 1.2.3 Patched
version: 1.2.3 Affected versions of minimist are vulnerable to prototype
pollution. Arguments are not properly sanitized, allowing an attacker to
modify the prototype of Object, causing the addition or modification of
an existing property that will exist on all objects.

Signed-off-by: David Deal <dealako@gmail.com>