### PR TITLE
Resolved [#1172] LF Operations Permissions

### DIFF
--- a/cla-backend-go/utils/signature_utils.go
+++ b/cla-backend-go/utils/signature_utils.go
@@ -7,11 +7,15 @@ import (
 	"github.com/LF-Engineering/lfx-kit/auth"
 	v1Models "github.com/communitybridge/easycla/cla-backend-go/gen/models"
 	log "github.com/communitybridge/easycla/cla-backend-go/logging"
+	"github.com/sirupsen/logrus"
 )
 
 // CurrentUserInACL is a helper function to determine if the current logged in user is in the specified CLA Manager list
 func CurrentUserInACL(authUser *auth.User, managers []v1Models.User) bool {
-	log.Debugf("checking if user: %+v is in the Signature ACL: %+v", authUser, managers)
+	f := logrus.Fields{
+		"functionName": "utils.CurrentUserInACL",
+	}
+	log.WithFields(f).Debugf("checking if user: %+v is in the Signature ACL: %+v", authUser, managers)
 	var inACL = false
 	for _, manager := range managers {
 		if manager.LfUsername == authUser.UserName {
@@ -20,5 +24,6 @@ func CurrentUserInACL(authUser *auth.User, managers []v1Models.User) bool {
 		}
 	}
 
+	log.WithFields(f).Debugf("user in acl: %t", inACL)
 	return inACL
 }

--- a/cla-backend-go/utils/utils_user_auth_lambda.go
+++ b/cla-backend-go/utils/utils_user_auth_lambda.go
@@ -9,39 +9,55 @@ import (
 	"github.com/LF-Engineering/lfx-kit/auth"
 )
 
+const (
+	// ALLOW_ADMIN_SCOPE indicates that a given permissions check allows for admins to access to that resource
+	ALLOW_ADMIN_SCOPE = true // nolint
+	// DISALLOW_ADMIN_SCOPE indicates that a given permissions check does not allow for admins to access to that resource
+	DISALLOW_ADMIN_SCOPE = false // nolint
+)
+
 // IsUserAdmin helper function for determining if the user is an admin
 func IsUserAdmin(user *auth.User) bool {
 	return user.Admin
 }
 
 // IsUserAuthorizedForOrganization helper function for determining if the user is authorized for this company
-func IsUserAuthorizedForOrganization(user *auth.User, companySFID string) bool {
-	// Previously, we checked for user.Admin - admins should be in a separate role
-	// Previously, we checked for user.Allowed, which is currently not used (future flag that is currently not implemented)
+func IsUserAuthorizedForOrganization(user *auth.User, companySFID string, adminScopeAllowed bool) bool {
+
+	if adminScopeAllowed && user.Admin {
+		return true
+	}
+
 	return user.IsUserAuthorizedForOrganizationScope(companySFID)
 }
 
 // IsUserAuthorizedForProjectTree helper function for determining if the user is authorized for this project hierarchy/tree
-func IsUserAuthorizedForProjectTree(user *auth.User, projectSFID string) bool {
-	// Previously, we checked for user.Admin - admins should be in a separate role
-	// Previously, we checked for user.Allowed, which is currently not used (future flag that is currently not implemented)
+func IsUserAuthorizedForProjectTree(user *auth.User, projectSFID string, adminScopeAllowed bool) bool {
+
+	if adminScopeAllowed && user.Admin {
+		return true
+	}
+
 	return user.IsUserAuthorized(auth.Project, projectSFID, true)
 }
 
 // IsUserAuthorizedForProject helper function for determining if the user is authorized for this project
-func IsUserAuthorizedForProject(user *auth.User, projectSFID string) bool {
-	// Previously, we checked for user.Admin - admins should be in a separate role
-	// Previously, we checked for user.Allowed, which is currently not used (future flag that is currently not implemented)
+func IsUserAuthorizedForProject(user *auth.User, projectSFID string, adminScopeAllowed bool) bool {
+
+	if adminScopeAllowed && user.Admin {
+		return true
+	}
+
 	return user.IsUserAuthorizedForProjectScope(projectSFID)
 }
 
 // IsUserAuthorizedForAnyProjects helper function for determining if the user is authorized for any of the specified projects
-func IsUserAuthorizedForAnyProjects(user *auth.User, projectSFIDs []string) bool {
+func IsUserAuthorizedForAnyProjects(user *auth.User, projectSFIDs []string, adminScopeAllowed bool) bool {
 	for _, projectSFID := range projectSFIDs {
-		if IsUserAuthorizedForProjectTree(user, projectSFID) {
+		if IsUserAuthorizedForProjectTree(user, projectSFID, adminScopeAllowed) {
 			return true
 		}
-		if IsUserAuthorizedForProject(user, projectSFID) {
+		if IsUserAuthorizedForProject(user, projectSFID, adminScopeAllowed) {
 			return true
 		}
 	}
@@ -50,18 +66,22 @@ func IsUserAuthorizedForAnyProjects(user *auth.User, projectSFIDs []string) bool
 }
 
 // IsUserAuthorizedForProjectOrganization helper function for determining if the user is authorized for this project organization scope
-func IsUserAuthorizedForProjectOrganization(user *auth.User, projectSFID, companySFID string) bool {
-	// Previously, we checked for user.Allowed, which is currently not used (future flag that is currently not implemented)
+func IsUserAuthorizedForProjectOrganization(user *auth.User, projectSFID, companySFID string, adminScopeAllowed bool) bool {
+
+	if adminScopeAllowed && user.Admin {
+		return true
+	}
+
 	return user.IsUserAuthorizedByProject(projectSFID, companySFID)
 }
 
 // IsUserAuthorizedForAnyProjectOrganization helper function for determining if the user is authorized for any of the specified projects with scope of project + organization
-func IsUserAuthorizedForAnyProjectOrganization(user *auth.User, projectSFIDs []string, companySFID string) bool {
+func IsUserAuthorizedForAnyProjectOrganization(user *auth.User, projectSFIDs []string, companySFID string, adminScopeAllowed bool) bool {
 	for _, projectSFID := range projectSFIDs {
-		if IsUserAuthorizedForProjectOrganizationTree(user, projectSFID, companySFID) {
+		if IsUserAuthorizedForProjectOrganizationTree(user, projectSFID, companySFID, adminScopeAllowed) {
 			return true
 		}
-		if IsUserAuthorizedForProjectOrganization(user, projectSFID, companySFID) {
+		if IsUserAuthorizedForProjectOrganization(user, projectSFID, companySFID, adminScopeAllowed) {
 			return true
 		}
 	}
@@ -70,8 +90,11 @@ func IsUserAuthorizedForAnyProjectOrganization(user *auth.User, projectSFIDs []s
 }
 
 // IsUserAuthorizedForProjectOrganizationTree helper function for determining if the user is authorized for this project organization scope and nested projects/orgs
-func IsUserAuthorizedForProjectOrganizationTree(user *auth.User, projectSFID, companySFID string) bool {
-	// Previously, we checked for user.Admin - admins should be in a separate role
-	// Previously, we checked for user.Allowed, which is currently not used (future flag that is currently not implemented)
+func IsUserAuthorizedForProjectOrganizationTree(user *auth.User, projectSFID, companySFID string, adminScopeAllowed bool) bool {
+
+	if adminScopeAllowed && user.Admin {
+		return true
+	}
+
 	return user.IsUserAuthorized(auth.ProjectOrganization, projectSFID+"|"+companySFID, true)
 }

--- a/cla-backend-go/utils/utils_user_auth_standalone.go
+++ b/cla-backend-go/utils/utils_user_auth_standalone.go
@@ -13,6 +13,13 @@ import (
 	log "github.com/communitybridge/easycla/cla-backend-go/logging"
 )
 
+const (
+	// ALLOW_ADMIN_SCOPE indicates that a given permissions check allows for admins to access to that resource
+	ALLOW_ADMIN_SCOPE = true // nolint
+	// DISALLOW_ADMIN_SCOPE indicates that a given permissions check does not allow for admins to access to that resource
+	DISALLOW_ADMIN_SCOPE = false // nolint
+)
+
 // IsUserAdmin helper function for determining if the user is an admin
 func IsUserAdmin(user *auth.User) bool {
 	return user.Admin
@@ -35,21 +42,27 @@ func skipPermissionChecks() bool {
 }
 
 // IsUserAuthorizedForOrganization helper function for determining if the user is authorized for this company
-func IsUserAuthorizedForOrganization(user *auth.User, companySFID string) bool {
+func IsUserAuthorizedForOrganization(user *auth.User, companySFID string, adminScopeAllowed bool) bool {
 	// If we are running locally and want to disable permission checks
 	if skipPermissionChecks() {
 		return true
 	}
 
-	// Previously, we checked for user.Admin - admins should be in a separate role
-	// Previously, we checked for user.Allowed, which is currently not used (future flag that is currently not implemented)
+	if adminScopeAllowed && user.Admin {
+		return true
+	}
+
 	return user.IsUserAuthorizedForOrganizationScope(companySFID)
 }
 
 // IsUserAuthorizedForProjectTree helper function for determining if the user is authorized for this project hierarchy/tree
-func IsUserAuthorizedForProjectTree(user *auth.User, projectSFID string) bool {
+func IsUserAuthorizedForProjectTree(user *auth.User, projectSFID string, adminScopeAllowed bool) bool {
 	// If we are running locally and want to disable permission checks
 	if skipPermissionChecks() {
+		return true
+	}
+
+	if adminScopeAllowed && user.Admin {
 		return true
 	}
 
@@ -59,9 +72,13 @@ func IsUserAuthorizedForProjectTree(user *auth.User, projectSFID string) bool {
 }
 
 // IsUserAuthorizedForProject helper function for determining if the user is authorized for this project
-func IsUserAuthorizedForProject(user *auth.User, projectSFID string) bool {
+func IsUserAuthorizedForProject(user *auth.User, projectSFID string, adminScopeAllowed bool) bool {
 	// If we are running locally and want to disable permission checks
 	if skipPermissionChecks() {
+		return true
+	}
+
+	if adminScopeAllowed && user.Admin {
 		return true
 	}
 
@@ -71,17 +88,17 @@ func IsUserAuthorizedForProject(user *auth.User, projectSFID string) bool {
 }
 
 // IsUserAuthorizedForAnyProjects helper function for determining if the user is authorized for any of the specified projects
-func IsUserAuthorizedForAnyProjects(user *auth.User, projectSFIDs []string) bool {
+func IsUserAuthorizedForAnyProjects(user *auth.User, projectSFIDs []string, adminScopeAllowed bool) bool {
 	// If we are running locally and want to disable permission checks
 	if skipPermissionChecks() {
 		return true
 	}
 
 	for _, projectSFID := range projectSFIDs {
-		if IsUserAuthorizedForProjectTree(user, projectSFID) {
+		if IsUserAuthorizedForProjectTree(user, projectSFID, adminScopeAllowed) {
 			return true
 		}
-		if IsUserAuthorizedForProject(user, projectSFID) {
+		if IsUserAuthorizedForProject(user, projectSFID, adminScopeAllowed) {
 			return true
 		}
 	}
@@ -90,9 +107,13 @@ func IsUserAuthorizedForAnyProjects(user *auth.User, projectSFIDs []string) bool
 }
 
 // IsUserAuthorizedForProjectOrganization helper function for determining if the user is authorized for this project organization scope
-func IsUserAuthorizedForProjectOrganization(user *auth.User, projectSFID, companySFID string) bool {
+func IsUserAuthorizedForProjectOrganization(user *auth.User, projectSFID, companySFID string, adminScopeAllowed bool) bool {
 	// If we are running locally and want to disable permission checks
 	if skipPermissionChecks() {
+		return true
+	}
+
+	if adminScopeAllowed && user.Admin {
 		return true
 	}
 
@@ -101,17 +122,17 @@ func IsUserAuthorizedForProjectOrganization(user *auth.User, projectSFID, compan
 }
 
 // IsUserAuthorizedForAnyProjectOrganization helper function for determining if the user is authorized for any of the specified projects with scope of project + organization
-func IsUserAuthorizedForAnyProjectOrganization(user *auth.User, projectSFIDs []string, companySFID string) bool {
+func IsUserAuthorizedForAnyProjectOrganization(user *auth.User, projectSFIDs []string, companySFID string, adminScopeAllowed bool) bool {
 	// If we are running locally and want to disable permission checks
 	if skipPermissionChecks() {
 		return true
 	}
 
 	for _, projectSFID := range projectSFIDs {
-		if IsUserAuthorizedForProjectOrganizationTree(user, projectSFID, companySFID) {
+		if IsUserAuthorizedForProjectOrganizationTree(user, projectSFID, companySFID, adminScopeAllowed) {
 			return true
 		}
-		if IsUserAuthorizedForProjectOrganization(user, projectSFID, companySFID) {
+		if IsUserAuthorizedForProjectOrganization(user, projectSFID, companySFID, adminScopeAllowed) {
 			return true
 		}
 	}
@@ -120,9 +141,13 @@ func IsUserAuthorizedForAnyProjectOrganization(user *auth.User, projectSFIDs []s
 }
 
 // IsUserAuthorizedForProjectOrganizationTree helper function for determining if the user is authorized for this project organization scope and nested projects/orgs
-func IsUserAuthorizedForProjectOrganizationTree(user *auth.User, projectSFID, companySFID string) bool {
+func IsUserAuthorizedForProjectOrganizationTree(user *auth.User, projectSFID, companySFID string, adminScopeAllowed bool) bool {
 	// If we are running locally and want to disable permission checks
 	if skipPermissionChecks() {
+		return true
+	}
+
+	if adminScopeAllowed && user.Admin {
 		return true
 	}
 

--- a/cla-backend-go/v2/cla_groups/handlers.go
+++ b/cla-backend-go/v2/cla_groups/handlers.go
@@ -425,7 +425,7 @@ func Configure(api *operations.EasyclaAPI, service Service, v1ProjectService v1P
 
 		// Check permissions
 		log.WithFields(f).Debugf("checking permissions for %s", strings.Join(projectSFIDs, ","))
-		if !utils.IsUserAuthorizedForAnyProjects(authUser, projectSFIDs) {
+		if !utils.IsUserAuthorizedForAnyProjects(authUser, projectSFIDs, utils.ALLOW_ADMIN_SCOPE) {
 			msg := fmt.Sprintf("user %s does not have access to list projects with project scope of: %s", authUser.UserName, params.ProjectSFID)
 			log.WithFields(f).Warn(msg)
 			return cla_group.NewListClaGroupsUnderFoundationForbidden().WithXRequestID(reqID).WithPayload(utils.ErrorResponseForbidden(reqID, msg))
@@ -508,7 +508,7 @@ func isUserHaveAccessToCLAProject(ctx context.Context, authUser *auth.User, proj
 	}
 
 	log.WithFields(f).Debug("testing if user has access to project SFID")
-	if utils.IsUserAuthorizedForProject(authUser, projectSFID) {
+	if utils.IsUserAuthorizedForProject(authUser, projectSFID, utils.ALLOW_ADMIN_SCOPE) {
 		return true
 	}
 
@@ -525,11 +525,11 @@ func isUserHaveAccessToCLAProject(ctx context.Context, authUser *auth.User, proj
 
 	f["foundationSFID"] = projectCLAGroupModel.FoundationSFID
 	log.WithFields(f).Debug("testing if user has access to parent foundation...")
-	if utils.IsUserAuthorizedForProjectTree(authUser, projectCLAGroupModel.FoundationSFID) {
+	if utils.IsUserAuthorizedForProjectTree(authUser, projectCLAGroupModel.FoundationSFID, utils.ALLOW_ADMIN_SCOPE) {
 		log.WithFields(f).Debug("user has access to parent foundation tree...")
 		return true
 	}
-	if utils.IsUserAuthorizedForProject(authUser, projectCLAGroupModel.FoundationSFID) {
+	if utils.IsUserAuthorizedForProject(authUser, projectCLAGroupModel.FoundationSFID, utils.ALLOW_ADMIN_SCOPE) {
 		log.WithFields(f).Debug("user has access to parent foundation...")
 		return true
 	}
@@ -546,7 +546,7 @@ func isUserHaveAccessToCLAProject(ctx context.Context, authUser *auth.User, proj
 	projectSFIDs := getProjectIDsFromModels(f, projectCLAGroupModel.FoundationSFID, projectCLAGroupModels)
 	f["projectIDs"] = strings.Join(projectSFIDs, ",")
 	log.WithFields(f).Debug("testing if user has access to any projects")
-	if utils.IsUserAuthorizedForAnyProjects(authUser, projectSFIDs) {
+	if utils.IsUserAuthorizedForAnyProjects(authUser, projectSFIDs, utils.ALLOW_ADMIN_SCOPE) {
 		log.WithFields(f).Debug("user has access to at least of of the projects...")
 		return true
 	}

--- a/cla-backend-go/v2/cla_manager/handlers.go
+++ b/cla-backend-go/v2/cla_manager/handlers.go
@@ -41,7 +41,7 @@ func Configure(api *operations.EasyclaAPI, service Service, LfxPortalURL string,
 		reqID := utils.GetRequestID(params.XREQUESTID)
 		ctx := context.WithValue(context.Background(), utils.XREQUESTID, reqID) // nolint
 		utils.SetAuthUserProperties(authUser, params.XUSERNAME, params.XEMAIL)
-		if !utils.IsUserAuthorizedForProjectOrganizationTree(authUser, params.ProjectSFID, params.CompanySFID) {
+		if !utils.IsUserAuthorizedForProjectOrganizationTree(authUser, params.ProjectSFID, params.CompanySFID, utils.DISALLOW_ADMIN_SCOPE) {
 			return cla_manager.NewCreateCLAManagerForbidden().WithXRequestID(reqID).WithPayload(&models.ErrorResponse{
 				Code: "403",
 				Message: fmt.Sprintf("EasyCLA - 403 Forbidden - user %s does not have access to CreateCLAManager with Project|Organization scope of %s | %s",
@@ -80,7 +80,7 @@ func Configure(api *operations.EasyclaAPI, service Service, LfxPortalURL string,
 		reqID := utils.GetRequestID(params.XREQUESTID)
 		ctx := context.WithValue(context.Background(), utils.XREQUESTID, reqID) // nolint
 		utils.SetAuthUserProperties(authUser, params.XUSERNAME, params.XEMAIL)
-		if !utils.IsUserAuthorizedForProjectOrganizationTree(authUser, params.ProjectSFID, params.CompanySFID) {
+		if !utils.IsUserAuthorizedForProjectOrganizationTree(authUser, params.ProjectSFID, params.CompanySFID, utils.DISALLOW_ADMIN_SCOPE) {
 			return cla_manager.NewDeleteCLAManagerForbidden().WithXRequestID(reqID).WithPayload(&models.ErrorResponse{
 				Code: "403",
 				Message: fmt.Sprintf("EasyCLA - 403 Forbidden - user %s does not have access to DeleteCLAManager with Project|Organization scope of %s | %s",
@@ -115,6 +115,8 @@ func Configure(api *operations.EasyclaAPI, service Service, LfxPortalURL string,
 			"ProjectSFID":    params.ProjectSFID,
 			"authUser":       *params.XUSERNAME,
 		}
+
+		// Note: anyone create assign a CLA manager designee...no permissions checks
 		log.WithFields(f).Debugf("processing CLA Manager Desginee request")
 		utils.SetAuthUserProperties(authUser, params.XUSERNAME, params.XEMAIL)
 		claManagerDesignee, err := service.CreateCLAManagerDesignee(ctx, params.CompanySFID, params.ProjectSFID, params.Body.UserEmail.String())
@@ -153,6 +155,8 @@ func Configure(api *operations.EasyclaAPI, service Service, LfxPortalURL string,
 				"Email":          params.Body.UserEmail.String(),
 				"authUser":       *params.XUSERNAME,
 			}
+
+			// Note: anyone create assign a CLA manager designee...no permissions checks
 			log.WithFields(f).Debugf("processing CLA Manager Designee by group request")
 
 			log.WithFields(f).Debugf("getting project IDs for CLA group")
@@ -276,7 +280,7 @@ func Configure(api *operations.EasyclaAPI, service Service, LfxPortalURL string,
 		}
 		log.WithFields(f).Debugf("processing CLA Manager request")
 		utils.SetAuthUserProperties(authUser, params.XUSERNAME, params.XEMAIL)
-		if !utils.IsUserAuthorizedForOrganization(authUser, params.CompanySFID) {
+		if !utils.IsUserAuthorizedForOrganization(authUser, params.CompanySFID, utils.ALLOW_ADMIN_SCOPE) {
 			return cla_manager.NewCreateCLAManagerRequestForbidden().WithXRequestID(reqID).WithPayload(&models.ErrorResponse{
 				Code: "403",
 				Message: fmt.Sprintf("EasyCLA - 403 Forbidden - user %s does not have access to CreateCLAManagerRequest with Project|Organization scope of %s | %s",

--- a/cla-backend-go/v2/company/handlers.go
+++ b/cla-backend-go/v2/company/handlers.go
@@ -42,7 +42,7 @@ func Configure(api *operations.EasyclaAPI, service Service, v1CompanyRepo v1Comp
 			}
 
 			log.WithFields(f).Debug("checking permissions")
-			if !utils.IsUserAuthorizedForOrganization(authUser, params.CompanySFID) {
+			if !utils.IsUserAuthorizedForOrganization(authUser, params.CompanySFID, utils.ALLOW_ADMIN_SCOPE) {
 				return company.NewGetCompanyProjectClaManagersForbidden().WithXRequestID(reqID).WithPayload(&models.ErrorResponse{
 					Code: "403",
 					Message: fmt.Sprintf("EasyCLA - 403 Forbidden - user %s does not have access to Get Company Project CLA Managers with Organization scope of %s",
@@ -118,7 +118,7 @@ func Configure(api *operations.EasyclaAPI, service Service, v1CompanyRepo v1Comp
 			}
 
 			log.WithFields(f).Debug("checking permissions")
-			if !utils.IsUserAuthorizedForOrganization(authUser, params.CompanySFID) {
+			if !utils.IsUserAuthorizedForOrganization(authUser, params.CompanySFID, utils.ALLOW_ADMIN_SCOPE) {
 				return company.NewGetCompanyProjectActiveClaForbidden().WithXRequestID(reqID).WithPayload(&models.ErrorResponse{
 					Code: "403",
 					Message: fmt.Sprintf("EasyCLA - 403 Forbidden - user %s does not have access to CreateCLAManager with Project|Organization scope of %s | %s",
@@ -332,7 +332,7 @@ func Configure(api *operations.EasyclaAPI, service Service, v1CompanyRepo v1Comp
 			}
 
 			// finally, we can check permissions for the delete operation
-			if !utils.IsUserAuthorizedForOrganization(authUser, companyModel.CompanyExternalID) {
+			if !utils.IsUserAuthorizedForOrganization(authUser, companyModel.CompanyExternalID, utils.ALLOW_ADMIN_SCOPE) {
 				msg := fmt.Sprintf(" user %s does not have access to company %s with Organization scope of %s",
 					authUser.UserName, companyModel.CompanyName, companyModel.CompanyExternalID)
 				log.Warn(msg)
@@ -387,7 +387,7 @@ func Configure(api *operations.EasyclaAPI, service Service, v1CompanyRepo v1Comp
 
 			// finally, we can check permissions for the delete operation
 			log.WithFields(f).Debug("checking permissions")
-			if !utils.IsUserAuthorizedForOrganization(authUser, companyModel.CompanyExternalID) {
+			if !utils.IsUserAuthorizedForOrganization(authUser, companyModel.CompanyExternalID, utils.ALLOW_ADMIN_SCOPE) {
 				msg := fmt.Sprintf(" user %s does not have access to company %s with Organization scope of %s",
 					authUser.UserName, companyModel.CompanyName, companyModel.CompanyExternalID)
 				log.WithFields(f).Warn(msg)
@@ -512,31 +512,31 @@ func isUserHaveAccessToCLAProjectOrganization(ctx context.Context, authUser *aut
 	}
 
 	log.WithFields(f).Debug("testing if user has access to project SFID...")
-	if utils.IsUserAuthorizedForProject(authUser, projectSFID) {
+	if utils.IsUserAuthorizedForProject(authUser, projectSFID, utils.ALLOW_ADMIN_SCOPE) {
 		log.WithFields(f).Debug("user has access to project SFID...")
 		return true
 	}
 
 	log.WithFields(f).Debug("testing if user has access to project SFID tree...")
-	if utils.IsUserAuthorizedForProjectTree(authUser, projectSFID) {
+	if utils.IsUserAuthorizedForProjectTree(authUser, projectSFID, utils.ALLOW_ADMIN_SCOPE) {
 		log.WithFields(f).Debug("user has access to project SFID tree...")
 		return true
 	}
 
 	log.WithFields(f).Debug("testing if user has access to project SFID and organization SFID...")
-	if utils.IsUserAuthorizedForProjectOrganization(authUser, projectSFID, organizationSFID) {
+	if utils.IsUserAuthorizedForProjectOrganization(authUser, projectSFID, organizationSFID, utils.ALLOW_ADMIN_SCOPE) {
 		log.WithFields(f).Debug("user has access to project SFID and organization SFID...")
 		return true
 	}
 
 	log.WithFields(f).Debug("testing if user has access to project SFID and organization SFID tree...")
-	if utils.IsUserAuthorizedForProjectOrganizationTree(authUser, projectSFID, organizationSFID) {
+	if utils.IsUserAuthorizedForProjectOrganizationTree(authUser, projectSFID, organizationSFID, utils.ALLOW_ADMIN_SCOPE) {
 		log.WithFields(f).Debug("user has access to project SFID and organization SFID tree...")
 		return true
 	}
 
 	log.WithFields(f).Debug("testing if user has access to organization SFID...")
-	if utils.IsUserAuthorizedForOrganization(authUser, organizationSFID) {
+	if utils.IsUserAuthorizedForOrganization(authUser, organizationSFID, utils.ALLOW_ADMIN_SCOPE) {
 		log.WithFields(f).Debug("user has access to organization SFID...")
 		return true
 	}
@@ -558,24 +558,24 @@ func isUserHaveAccessToCLAProjectOrganization(ctx context.Context, authUser *aut
 	// Check the foundation permissions
 	f["foundationSFID"] = projectCLAGroupModel.FoundationSFID
 	log.WithFields(f).Debug("testing if user has access to parent foundation...")
-	if utils.IsUserAuthorizedForProject(authUser, projectCLAGroupModel.FoundationSFID) {
+	if utils.IsUserAuthorizedForProject(authUser, projectCLAGroupModel.FoundationSFID, utils.ALLOW_ADMIN_SCOPE) {
 		log.WithFields(f).Debug("user has access to parent foundation...")
 		return true
 	}
 	log.WithFields(f).Debug("testing if user has access to parent foundation truee...")
-	if utils.IsUserAuthorizedForProjectTree(authUser, projectCLAGroupModel.FoundationSFID) {
+	if utils.IsUserAuthorizedForProjectTree(authUser, projectCLAGroupModel.FoundationSFID, utils.ALLOW_ADMIN_SCOPE) {
 		log.WithFields(f).Debug("user has access to parent foundation tree...")
 		return true
 	}
 
 	log.WithFields(f).Debug("testing if user has access to foundation SFID and organization SFID...")
-	if utils.IsUserAuthorizedForProjectOrganization(authUser, projectCLAGroupModel.FoundationSFID, organizationSFID) {
+	if utils.IsUserAuthorizedForProjectOrganization(authUser, projectCLAGroupModel.FoundationSFID, organizationSFID, utils.ALLOW_ADMIN_SCOPE) {
 		log.WithFields(f).Debug("user has access to foundation SFID and organization SFID...")
 		return true
 	}
 
 	log.WithFields(f).Debug("testing if user has access to foundation SFID and organization SFID tree...")
-	if utils.IsUserAuthorizedForProjectOrganizationTree(authUser, projectCLAGroupModel.FoundationSFID, organizationSFID) {
+	if utils.IsUserAuthorizedForProjectOrganizationTree(authUser, projectCLAGroupModel.FoundationSFID, organizationSFID, utils.ALLOW_ADMIN_SCOPE) {
 		log.WithFields(f).Debug("user has access to foundation SFID and organization SFID tree...")
 		return true
 	}
@@ -591,7 +591,7 @@ func isUserHaveAccessToCLAProjectOrganization(ctx context.Context, authUser *aut
 	projectSFIDs := getProjectIDsFromModels(f, projectCLAGroupModel.FoundationSFID, projectCLAGroupModels)
 	f["projectIDs"] = strings.Join(projectSFIDs, ",")
 	log.WithFields(f).Debug("testing if user has access to any cla group project + organization")
-	if utils.IsUserAuthorizedForAnyProjectOrganization(authUser, projectSFIDs, organizationSFID) {
+	if utils.IsUserAuthorizedForAnyProjectOrganization(authUser, projectSFIDs, organizationSFID, utils.ALLOW_ADMIN_SCOPE) {
 		log.WithFields(f).Debug("user has access to at least of of the projects...")
 		return true
 	}

--- a/cla-backend-go/v2/events/handlers.go
+++ b/cla-backend-go/v2/events/handlers.go
@@ -89,7 +89,7 @@ func Configure(api *operations.EasyclaAPI, service v1Events.Service, v1CompanyRe
 			}
 
 			log.WithFields(f).Debug("checking permission...")
-			if !utils.IsUserAuthorizedForProjectTree(authUser, params.FoundationSFID) {
+			if !utils.IsUserAuthorizedForProjectTree(authUser, params.FoundationSFID, utils.ALLOW_ADMIN_SCOPE) {
 				msg := fmt.Sprintf("user %s does not have access to Get Foundation Events for foundation %s.", authUser.UserName, params.FoundationSFID)
 				log.WithFields(f).Warn(msg)
 				return WriteResponse(http.StatusForbidden, runtime.JSONMime, runtime.JSONProducer(), utils.ErrorResponseForbidden(reqID, msg))
@@ -120,7 +120,7 @@ func Configure(api *operations.EasyclaAPI, service v1Events.Service, v1CompanyRe
 			}
 
 			log.WithFields(f).Debug("checking permission...")
-			if !utils.IsUserAuthorizedForProjectTree(authUser, params.FoundationSFID) {
+			if !utils.IsUserAuthorizedForProjectTree(authUser, params.FoundationSFID, utils.ALLOW_ADMIN_SCOPE) {
 				msg := fmt.Sprintf("user %s does not have access to Get Foundation Events for foundation %s.", authUser.UserName, params.FoundationSFID)
 				log.WithFields(f).Warn(msg)
 				return events.NewGetRecentEventsForbidden().WithPayload(utils.ErrorResponseForbidden(reqID, msg))
@@ -165,7 +165,7 @@ func Configure(api *operations.EasyclaAPI, service v1Events.Service, v1CompanyRe
 			}
 
 			log.WithFields(f).Debug("checking permission...")
-			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID) {
+			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID, utils.ALLOW_ADMIN_SCOPE) {
 				msg := fmt.Sprintf("user %s does not have access to Get Project Events for foundation %s.", authUser.UserName, params.ProjectSFID)
 				log.WithFields(f).Warn(msg)
 				return WriteResponse(http.StatusForbidden, runtime.JSONMime, runtime.JSONProducer(), &models.ErrorResponse{
@@ -217,7 +217,7 @@ func Configure(api *operations.EasyclaAPI, service v1Events.Service, v1CompanyRe
 			}
 
 			log.WithFields(f).Debug("checking permission...")
-			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID) {
+			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID, utils.ALLOW_ADMIN_SCOPE) {
 				msg := fmt.Sprintf("user %s does not have access to Get Project Events for foundation %s.", authUser.UserName, params.ProjectSFID)
 				log.WithFields(f).Warn(msg)
 				return events.NewGetRecentEventsForbidden().WithPayload(utils.ErrorResponseForbidden(reqID, msg))
@@ -281,7 +281,7 @@ func Configure(api *operations.EasyclaAPI, service v1Events.Service, v1CompanyRe
 				"projectSFID":    params.ProjectSFID,
 				"companySFID":    params.CompanySFID,
 			}
-			if !utils.IsUserAuthorizedForOrganization(authUser, params.CompanySFID) {
+			if !utils.IsUserAuthorizedForOrganization(authUser, params.CompanySFID, utils.ALLOW_ADMIN_SCOPE) {
 				return events.NewGetCompanyProjectEventsForbidden().WithPayload(&models.ErrorResponse{
 					Code: "403",
 					Message: fmt.Sprintf("EasyCLA - 403 Forbidden - user %s does not have access to GetCompanyProject Events with Organization scope of %s",

--- a/cla-backend-go/v2/gerrits/handlers.go
+++ b/cla-backend-go/v2/gerrits/handlers.go
@@ -49,7 +49,7 @@ func Configure(api *operations.EasyclaAPI, v1Service v1Gerrits.Service, projectS
 				})
 			}
 			// verify user have access to the project
-			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID) {
+			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID, utils.ALLOW_ADMIN_SCOPE) {
 				return gerrits.NewDeleteGerritForbidden().WithXRequestID(reqID).WithPayload(&models.ErrorResponse{
 					Code: "403",
 					Message: fmt.Sprintf("EasyCLA - 403 Forbidden - user %s does not have access to DeleteGerrit with Project scope of %s",
@@ -84,7 +84,7 @@ func Configure(api *operations.EasyclaAPI, v1Service v1Gerrits.Service, projectS
 			utils.SetAuthUserProperties(authUser, params.XUSERNAME, params.XEMAIL)
 
 			// verify user have access to the project
-			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID) {
+			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID, utils.ALLOW_ADMIN_SCOPE) {
 				return gerrits.NewAddGerritForbidden().WithXRequestID(reqID).WithPayload(&models.ErrorResponse{
 					Code: "403",
 					Message: fmt.Sprintf("EasyCLA - 403 Forbidden - user %s does not have access to AddGerrit with Project scope of %s",
@@ -150,7 +150,7 @@ func Configure(api *operations.EasyclaAPI, v1Service v1Gerrits.Service, projectS
 			utils.SetAuthUserProperties(authUser, params.XUSERNAME, params.XEMAIL)
 
 			// verify user have access to the project
-			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID) {
+			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID, utils.ALLOW_ADMIN_SCOPE) {
 				return gerrits.NewListGerritsForbidden().WithXRequestID(reqID).WithPayload(&models.ErrorResponse{
 					Code: "403",
 					Message: fmt.Sprintf("EasyCLA - 403 Forbidden - user %s does not have access to ListGerrits with Project scope of %s",

--- a/cla-backend-go/v2/github_organizations/handlers.go
+++ b/cla-backend-go/v2/github_organizations/handlers.go
@@ -37,7 +37,7 @@ func Configure(api *operations.EasyclaAPI, service Service, eventService events.
 				"projectSFID":    params.ProjectSFID,
 			}
 
-			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID) {
+			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID, utils.ALLOW_ADMIN_SCOPE) {
 				msg := fmt.Sprintf("user %s does not have access to Get Project GitHub Organizations with Project scope of %s",
 					authUser.UserName, params.ProjectSFID)
 				log.WithFields(f).Debug(msg)
@@ -77,7 +77,7 @@ func Configure(api *operations.EasyclaAPI, service Service, eventService events.
 				"projectSFID":    params.ProjectSFID,
 			}
 
-			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID) {
+			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID, utils.ALLOW_ADMIN_SCOPE) {
 				msg := fmt.Sprintf("user %s does not have access to Add Project GitHub Organizations with Project scope of %s",
 					authUser.UserName, params.ProjectSFID)
 				log.WithFields(f).Debug(msg)
@@ -146,7 +146,7 @@ func Configure(api *operations.EasyclaAPI, service Service, eventService events.
 			utils.SetAuthUserProperties(authUser, params.XUSERNAME, params.XEMAIL)
 			ctx := context.WithValue(context.Background(), utils.XREQUESTID, reqID) // nolint
 
-			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID) {
+			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID, utils.ALLOW_ADMIN_SCOPE) {
 				return github_organizations.NewDeleteProjectGithubOrganizationForbidden().WithPayload(&models.ErrorResponse{
 					Code: "403",
 					Message: fmt.Sprintf("EasyCLA - 403 Forbidden - user %s does not have access to Delete Project GitHub Organizations with Project scope of %s",
@@ -185,7 +185,7 @@ func Configure(api *operations.EasyclaAPI, service Service, eventService events.
 			utils.SetAuthUserProperties(authUser, params.XUSERNAME, params.XEMAIL)
 			ctx := context.WithValue(context.Background(), utils.XREQUESTID, reqID) // nolint
 
-			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID) {
+			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID, utils.ALLOW_ADMIN_SCOPE) {
 				return github_organizations.NewUpdateProjectGithubOrganizationConfigForbidden().WithPayload(&models.ErrorResponse{
 					Code: "403",
 					Message: fmt.Sprintf("EasyCLA - 403 Forbidden - user %s does not have access to Update Project GitHub Organizations with Project scope of %s",

--- a/cla-backend-go/v2/metrics/handlers.go
+++ b/cla-backend-go/v2/metrics/handlers.go
@@ -96,7 +96,7 @@ func Configure(api *operations.EasyclaAPI, service Service, v1CompanyRepo v1Comp
 			reqID := utils.GetRequestID(params.XREQUESTID)
 			ctx := context.WithValue(context.Background(), utils.XREQUESTID, reqID) // nolint
 			utils.SetAuthUserProperties(authUser, params.XUSERNAME, params.XEMAIL)
-			if !utils.IsUserAuthorizedForOrganization(authUser, params.CompanySFID) {
+			if !utils.IsUserAuthorizedForOrganization(authUser, params.CompanySFID, utils.ALLOW_ADMIN_SCOPE) {
 				return metrics.NewListCompanyProjectMetricsForbidden().WithXRequestID(reqID).WithPayload(&models.ErrorResponse{
 					Code: "403",
 					Message: fmt.Sprintf("EasyCLA - 403 Forbidden - user %s does not have access to List Company Project Metrics with Organization scope of %s",

--- a/cla-backend-go/v2/project/handlers.go
+++ b/cla-backend-go/v2/project/handlers.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 
-	project_service "github.com/communitybridge/easycla/cla-backend-go/v2/project-service"
+	projectService "github.com/communitybridge/easycla/cla-backend-go/v2/project-service"
 	v2ProjectServiceModels "github.com/communitybridge/easycla/cla-backend-go/v2/project-service/models"
 
 	"github.com/sirupsen/logrus"
@@ -73,7 +73,7 @@ func Configure(api *operations.EasyclaAPI, service v1Project.Service, v2Service 
 			return project.NewGetProjectByIDNotFound().WithXRequestID(reqID)
 		}
 
-		if !utils.IsUserAuthorizedForProjectTree(user, claGroupModel.ProjectExternalID) {
+		if !utils.IsUserAuthorizedForProjectTree(user, claGroupModel.ProjectExternalID, utils.ALLOW_ADMIN_SCOPE) {
 			return project.NewGetProjectByIDForbidden().WithXRequestID(reqID).WithPayload(&models.ErrorResponse{
 				Code: "403",
 				Message: fmt.Sprintf("EasyCLA - 403 Forbidden - user %s does not have access to Get Project By ID with Project scope of %s",
@@ -94,7 +94,7 @@ func Configure(api *operations.EasyclaAPI, service v1Project.Service, v2Service 
 		reqID := utils.GetRequestID(params.XREQUESTID)
 		ctx := context.WithValue(context.Background(), utils.XREQUESTID, reqID) // nolint
 		utils.SetAuthUserProperties(user, params.XUSERNAME, params.XEMAIL)
-		if !utils.IsUserAuthorizedForProjectTree(user, params.ExternalID) {
+		if !utils.IsUserAuthorizedForProjectTree(user, params.ExternalID, utils.ALLOW_ADMIN_SCOPE) {
 			return project.NewGetProjectsByExternalIDForbidden().WithXRequestID(reqID).WithPayload(&models.ErrorResponse{
 				Code: "403",
 				Message: fmt.Sprintf("EasyCLA - 403 Forbidden - user %s does not have access to Get Projects By External ID with Project scope of %s",
@@ -142,7 +142,7 @@ func Configure(api *operations.EasyclaAPI, service v1Project.Service, v2Service 
 			return project.NewGetProjectByNameNotFound().WithXRequestID(reqID)
 		}
 
-		if !utils.IsUserAuthorizedForProjectTree(user, claGroupModel.ProjectExternalID) {
+		if !utils.IsUserAuthorizedForProjectTree(user, claGroupModel.ProjectExternalID, utils.ALLOW_ADMIN_SCOPE) {
 			return project.NewGetProjectByNameForbidden().WithXRequestID(reqID).WithPayload(&models.ErrorResponse{
 				Code: "403",
 				Message: fmt.Sprintf("EasyCLA - 403 Forbidden - user %s does not have access to Get Project By Name with Project scope of %s",
@@ -179,7 +179,7 @@ func Configure(api *operations.EasyclaAPI, service v1Project.Service, v2Service 
 			return project.NewDeleteProjectByIDBadRequest().WithXRequestID(reqID).WithPayload(errorResponse(reqID, err))
 		}
 
-		if !utils.IsUserAuthorizedForProjectTree(user, claGroupModel.ProjectExternalID) {
+		if !utils.IsUserAuthorizedForProjectTree(user, claGroupModel.ProjectExternalID, utils.ALLOW_ADMIN_SCOPE) {
 			return project.NewDeleteProjectByIDForbidden().WithXRequestID(reqID).WithPayload(&models.ErrorResponse{
 				Code: "403",
 				Message: fmt.Sprintf("EasyCLA - 403 Forbidden - user %s does not have access to Delete Project By ID with Project scope of %s",
@@ -217,7 +217,7 @@ func Configure(api *operations.EasyclaAPI, service v1Project.Service, v2Service 
 			}
 			return project.NewUpdateProjectNotFound().WithXRequestID(reqID).WithPayload(errorResponse(reqID, err))
 		}
-		if !utils.IsUserAuthorizedForProjectTree(user, claGroupModel.ProjectExternalID) {
+		if !utils.IsUserAuthorizedForProjectTree(user, claGroupModel.ProjectExternalID, utils.ALLOW_ADMIN_SCOPE) {
 			return project.NewUpdateProjectForbidden().WithXRequestID(reqID).WithPayload(&models.ErrorResponse{
 				Code: "403",
 				Message: fmt.Sprintf("EasyCLA - 403 Forbidden - user %s does not have access to Update Project By ID with Project scope of %s",
@@ -281,7 +281,7 @@ func Configure(api *operations.EasyclaAPI, service v1Project.Service, v2Service 
 		}
 
 		// No auth checks - anyone including contributors can request
-		psc := project_service.GetClient()
+		psc := projectService.GetClient()
 		sfProject, err := psc.GetProject(params.ProjectSFID)
 		if err != nil {
 			log.WithFields(f).WithError(err).Warn("unable to lookup SF project by ID")
@@ -319,6 +319,6 @@ func buildSFProjectSummary(sfProject *v2ProjectServiceModels.ProjectOutputDetail
 		Slug:         sfProject.Slug,
 		Status:       sfProject.Status,
 		Type:         sfProject.Type,
-		IsStandalone: ((sfProject.Type != utils.ProjectTypeProjectGroup) && (sfProject.Parent == "" || sfProject.Parent == utils.TheLinuxFoundation)),
+		IsStandalone: (sfProject.Type != utils.ProjectTypeProjectGroup) && (sfProject.Parent == "" || sfProject.Parent == utils.TheLinuxFoundation),
 	}
 }

--- a/cla-backend-go/v2/repositories/handlers.go
+++ b/cla-backend-go/v2/repositories/handlers.go
@@ -42,7 +42,7 @@ func Configure(api *operations.EasyclaAPI, service Service, eventService events.
 				"projectSFID":    params.ProjectSFID,
 			}
 
-			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID) {
+			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID, utils.ALLOW_ADMIN_SCOPE) {
 				msg := fmt.Sprintf("user %s does not have access to Get GitHub Repositories with Project scope of %s",
 					authUser.UserName, params.ProjectSFID)
 				log.WithFields(f).Debug(msg)
@@ -90,7 +90,7 @@ func Configure(api *operations.EasyclaAPI, service Service, eventService events.
 				"projectSFID":    params.ProjectSFID,
 			}
 
-			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID) {
+			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID, utils.ALLOW_ADMIN_SCOPE) {
 				msg := fmt.Sprintf("user %s does not have access to Add GitHub Repositories with Project scope of %s",
 					authUser.UserName, params.ProjectSFID)
 				log.WithFields(f).Debug(msg)
@@ -147,7 +147,7 @@ func Configure(api *operations.EasyclaAPI, service Service, eventService events.
 				"repositoryID":   params.RepositoryID,
 			}
 
-			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID) {
+			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID, utils.ALLOW_ADMIN_SCOPE) {
 				msg := fmt.Sprintf("user %s does not have access to Delete GitHub Repositories with Project scope of %s",
 					authUser.UserName, params.ProjectSFID)
 				log.WithFields(f).Debug(msg)
@@ -205,7 +205,7 @@ func Configure(api *operations.EasyclaAPI, service Service, eventService events.
 				"repositoryID":   params.RepositoryID,
 			}
 
-			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID) {
+			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID, utils.ALLOW_ADMIN_SCOPE) {
 				msg := fmt.Sprintf("user %s does not have access to Query Protected Branch GitHub Repositories with Project scope of %s",
 					authUser.UserName, params.ProjectSFID)
 				log.WithFields(f).Debug(msg)
@@ -259,7 +259,7 @@ func Configure(api *operations.EasyclaAPI, service Service, eventService events.
 				"repositoryID":   params.RepositoryID,
 			}
 
-			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID) {
+			if !utils.IsUserAuthorizedForProjectTree(authUser, params.ProjectSFID, utils.ALLOW_ADMIN_SCOPE) {
 				msg := fmt.Sprintf("user %s does not have access to Update Protected Branch GitHub Repositories with Project scope of %s",
 					authUser.UserName, params.ProjectSFID)
 				log.WithFields(f).Debug(msg)

--- a/cla-backend-go/v2/sign/handlers.go
+++ b/cla-backend-go/v2/sign/handlers.go
@@ -28,7 +28,7 @@ func Configure(api *operations.EasyclaAPI, service Service) {
 			reqID := utils.GetRequestID(params.XREQUESTID)
 			ctx := context.WithValue(context.Background(), utils.XREQUESTID, reqID) // nolint
 			utils.SetAuthUserProperties(user, params.XUSERNAME, params.XEMAIL)
-			if !utils.IsUserAuthorizedForProjectOrganizationTree(user, utils.StringValue(params.Input.ProjectSfid), utils.StringValue(params.Input.CompanySfid)) {
+			if !utils.IsUserAuthorizedForProjectOrganizationTree(user, utils.StringValue(params.Input.ProjectSfid), utils.StringValue(params.Input.CompanySfid), utils.DISALLOW_ADMIN_SCOPE) {
 				return sign.NewRequestCorporateSignatureForbidden().WithPayload(&models.ErrorResponse{
 					Code: "403",
 					Message: fmt.Sprintf("EasyCLA - 403 Forbidden - user %s does not have access to Request Corporate Signature with Project|Organization scope of %s | %s",


### PR DESCRIPTION
- LF Operations has a scope of admin or developer which both have the user.Admin flag set to true on the auth model. This PR includes changes to allow the handler to invoke the permission checks with or without admin (LF-Operations) scope permissions. This allows for protected API endpoints, such as the CLA Manager endpoints to be reserved for only cla-manager roles.

Signed-off-by: David Deal <dealako@gmail.com>