### PR TITLE
[#2366] When designating someone else to be a CLA Manager in the contributor console, it doesn't allow a period ('.') in the name

### DIFF
--- a/cla-backend-go/swagger/cla.v2.yaml
+++ b/cla-backend-go/swagger/cla.v2.yaml
@@ -2273,7 +2273,7 @@ paths:
                 type: string
                 description: Proposed CLA Manager name
                 example: "Harold Wanyama"
-                pattern: "^[a-zA-Z0-9]+(([',. -][0-9a-zA-Z ])?[0-9a-zA-Z]*)*$"
+                pattern: "^[a-zA-Z]+(([',. -][a-zA-Z ])?[a-zA-Z.]*)*$"
                 minLength: 1
                 maxLength: 60
       responses:


### PR DESCRIPTION
Added swagger validation for name pattern.

Signed-off-by: Rinkesh Bhutwala rbhutwal@proximabiz.com

