### PR TITLE
Resolved #2433 Which Adds A CLA Group Setup Completion Pct

### DIFF
--- a/cla-backend-go/swagger/cla.v2.yaml
+++ b/cla-backend-go/swagger/cla.v2.yaml
@@ -4685,6 +4685,13 @@ definitions:
         type: string
         example: 'https://cla-signature-files-dev.s3.amazonaws.com/contract-group/b1e86e26-d8c8-4fd8-9f8d-5c723d5dac9f/template/ccla.pdf'
         x-omitempty: false
+      setup_completion_pct:
+        description: the CLA Group setup complete percentage, values range from 0-100 inclusive
+        type: integer
+        minimum: 0
+        maximum: 100
+        example: 100
+        x-omitempty: false
 
   cla-group-project:
     type: object

--- a/cla-backend-go/utils/conversion.go
+++ b/cla-backend-go/utils/conversion.go
@@ -19,6 +19,11 @@ func Int64Value(input *int64) int64 {
 	return *input
 }
 
+// Int64 returns a pointer to the int64 value passed in.
+func Int64(v int64) *int64 {
+	return &v
+}
+
 // BoolValue function convert boolean pointer to boolean
 func BoolValue(input *bool) bool {
 	if input == nil {

--- a/cla-backend-go/v2/cla_groups/service.go
+++ b/cla-backend-go/v2/cla_groups/service.go
@@ -489,6 +489,13 @@ func (s *service) ListClaGroupsForFoundationOrProject(ctx context.Context, proje
 			log.WithFields(f).WithError(docErr).Warn("problem determining current CCLA for this CLA Group")
 		}
 
+		// Well, if we have a CLA Group definition, let's say we're 80% done.
+		setupPct := 80
+		// If we have a CLA Group setup and have at least one repository assigned to the CLA Group...then we're done
+		if v1ClaGroup.RootProjectRepositoriesCount > 0 {
+			setupPct = 100
+		}
+
 		cg := &models.ClaGroupSummary{
 			CclaEnabled:         v1ClaGroup.ProjectCCLAEnabled,
 			CclaRequiresIcla:    v1ClaGroup.ProjectCCLARequiresICLA,
@@ -503,6 +510,7 @@ func (s *service) ListClaGroupsForFoundationOrProject(ctx context.Context, proje
 			// Add root_project_repositories_count to repositories_count initially
 			RepositoriesCount:            v1ClaGroup.RootProjectRepositoriesCount,
 			RootProjectRepositoriesCount: v1ClaGroup.RootProjectRepositoriesCount,
+			SetupCompletionPct:           utils.Int64(int64(setupPct)),
 		}
 
 		// How many SF projects are associated with this CLA Group?

--- a/cla-backend/cla/models/dynamo_models.py
+++ b/cla-backend/cla/models/dynamo_models.py
@@ -3531,7 +3531,7 @@ class GitHubOrg(model_interfaces.GitHubOrg):  # pylint: disable=too-many-public-
     def set_note(self, note):
         self.model.note = note
 
-    def get_organization_by_sfid(self, sfid):
+    def get_organization_by_sfid(self, sfid) -> List:
         organization_generator = self.model.organization_sfid_index.query(sfid)
         organizations = []
         for org_model in organization_generator:


### PR DESCRIPTION
- Updated swagger model to include the `setup_completion_pct` attribute, type integer ranging from 0-100
- Added CLA Group completion pct value to response payload - we CLA Group is created, but without a being assigned a repository, the completion pct is 80%. When the CLA Group is created and has one or more repositories the completion percentage is 100%.

Signed-off-by: David Deal <dealako@gmail.com>