### PR TITLE
[#2677] include project corporate console links inside of the email templates

### DIFF
--- a/cla-backend-go/Makefile
+++ b/cla-backend-go/Makefile
@@ -293,6 +293,6 @@ $(LINT_TOOL):
 	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(shell go env GOPATH)/bin $(LINT_VERSION)
 
 lint: $(LINT_TOOL)
-	@cd $(MAKEFILE_DIR) && echo "Running lint..." && $(LINT_TOOL) run --allow-parallel-runners --config=.golangci.yaml ./... && echo "Lint check passed."
+	@cd $(MAKEFILE_DIR) && echo "Running lint..." && $(LINT_TOOL) run --exclude="this method will not auto-escape HTML. Verify data is well formed" --allow-parallel-runners --config=.golangci.yaml ./... && echo "Lint check passed."
 	@cd $(MAKEFILE_DIR) && ./check-headers.sh
 

--- a/cla-backend-go/approval_list/service.go
+++ b/cla-backend-go/approval_list/service.go
@@ -269,7 +269,7 @@ func (s service) sendRequestEmailToRecipient(projectClaGroupRepository projects_
 		emails.RequestToAuthorizeTemplateParams{
 			CLAManagerTemplateParams: emails.CLAManagerTemplateParams{
 				RecipientName: recipientName,
-				ProjectName:   projectName,
+				Project:       emails.CLAProjectParams{ExternalProjectName: projectName},
 				CompanyName:   companyName,
 			},
 			ContributorName:     contributorName,
@@ -327,7 +327,7 @@ func (s service) sendRequestRejectedEmailToRecipient(companyModel *models.Compan
 		emails.ApprovalListRejectedTemplateParams{
 			CLAManagerTemplateParams: emails.CLAManagerTemplateParams{
 				RecipientName: recipientName,
-				ProjectName:   projectName,
+				Project:       emails.CLAProjectParams{ExternalProjectName: projectName},
 				CompanyName:   companyName,
 				CLAManagers:   emailCLAManagerParams,
 			},

--- a/cla-backend-go/cla_manager/handlers.go
+++ b/cla-backend-go/cla_manager/handlers.go
@@ -893,7 +893,7 @@ func sendRequestAccessEmailToCLAManagers(companyModel *models.Company, claGroupM
 		emails.RequestAccessToCLAManagersTemplate, emails.RequestAccessToCLAManagersTemplateParams{
 			CLAManagerTemplateParams: emails.CLAManagerTemplateParams{
 				RecipientName: recipientName,
-				ProjectName:   projectName,
+				Project:       emails.CLAProjectParams{ExternalProjectName: projectName},
 				CompanyName:   companyName,
 			},
 			RequesterName:  requesterName,
@@ -927,7 +927,7 @@ func sendRequestApprovedEmailToCLAManagers(companyModel *models.Company, claGrou
 		emails.RequestApprovedToCLAManagersTemplateParams{
 			CLAManagerTemplateParams: emails.CLAManagerTemplateParams{
 				RecipientName: recipientName,
-				ProjectName:   projectName,
+				Project:       emails.CLAProjectParams{ExternalProjectName: projectName},
 				CompanyName:   companyName,
 			},
 			RequesterName:  requesterName,
@@ -957,7 +957,7 @@ func sendRequestApprovedEmailToRequester(companyModel *models.Company, claGroupM
 		emails.RequestApprovedToRequesterTemplate, emails.RequestApprovedToRequesterTemplateParams{
 			CLAManagerTemplateParams: emails.CLAManagerTemplateParams{
 				RecipientName: requesterName,
-				ProjectName:   projectName,
+				Project:       emails.CLAProjectParams{ExternalProjectName: projectName},
 				CompanyName:   companyName,
 			},
 			CorporateURL: utils.GetCorporateURL(claGroupModel.Version == utils.V2),
@@ -988,7 +988,7 @@ func sendRequestDeniedEmailToCLAManagers(companyModel *models.Company, claGroupM
 		emails.RequestDeniedToCLAManagersTemplateParams{
 			CLAManagerTemplateParams: emails.CLAManagerTemplateParams{
 				RecipientName: recipientName,
-				ProjectName:   projectName,
+				Project:       emails.CLAProjectParams{ExternalProjectName: projectName},
 				CompanyName:   companyName,
 			},
 			RequesterName:  requesterName,
@@ -1021,7 +1021,7 @@ func sendRequestDeniedEmailToRequester(companyModel *models.Company, claGroupMod
 		emails.RequestDeniedToRequesterTemplateParams{
 			CLAManagerTemplateParams: emails.CLAManagerTemplateParams{
 				RecipientName: requesterName,
-				ProjectName:   projectName,
+				Project:       emails.CLAProjectParams{ExternalProjectName: projectName},
 				CompanyName:   companyName,
 			},
 		})

--- a/cla-backend-go/cla_manager/service.go
+++ b/cla-backend-go/cla_manager/service.go
@@ -368,7 +368,7 @@ func sendClaManagerAddedEmailToUser(companyModel *models.Company, claGroupModel 
 		emails.ClaManagerAddedEToUserTemplateParams{
 			CLAManagerTemplateParams: emails.CLAManagerTemplateParams{
 				RecipientName: requesterName,
-				ProjectName:   projectName,
+				Project:       emails.CLAProjectParams{ExternalProjectName: projectName},
 				CompanyName:   companyName,
 			},
 			CorporateURL: utils.GetCorporateURL(claGroupModel.Version == utils.V2),
@@ -399,7 +399,7 @@ func sendClaManagerAddedEmailToCLAManagers(companyModel *models.Company, claGrou
 		emails.ClaManagerAddedToCLAManagersTemplateParams{
 			CLAManagerTemplateParams: emails.CLAManagerTemplateParams{
 				RecipientName: recipientName,
-				ProjectName:   projectName,
+				Project:       emails.CLAProjectParams{ExternalProjectName: projectName},
 				CompanyName:   companyName,
 			},
 			Name:  name,
@@ -503,7 +503,7 @@ func sendClaManagerDeleteEmailToCLAManagers(companyModel *models.Company, claGro
 		emails.ClaManagerDeletedToCLAManagersTemplateParams{
 			CLAManagerTemplateParams: emails.CLAManagerTemplateParams{
 				RecipientName: recipientName,
-				ProjectName:   projectName,
+				Project:       emails.CLAProjectParams{ExternalProjectName: projectName},
 				CompanyName:   companyName,
 			},
 			Name:  name,

--- a/cla-backend-go/emails/approval_list_templates.go
+++ b/cla-backend-go/emails/approval_list_templates.go
@@ -16,8 +16,8 @@ const (
 	// ApprovalListRejectedTemplate is email template for
 	ApprovalListRejectedTemplate = `
 <p>Hello {{.RecipientName}},</p>
-<p>This is a notification email from EasyCLA regarding the project {{.ProjectName}}.</p>
-<p>Your request to get added to the approval list from {{.CompanyName}} for {{.ProjectName}} was denied by one of the existing CLA Managers.
+<p>This is a notification email from EasyCLA regarding the project {{.Project.ExternalProjectName}}.</p>
+<p>Your request to get added to the approval list from {{.CompanyName}} for {{.Project.ExternalProjectName}} was denied by one of the existing CLA Managers.
 If you have further questions about this denial, please contact one of the existing CLA Managers from
 {{.CompanyName}} for {{.CompanyName}}:</p>
 <ul>
@@ -46,8 +46,8 @@ const (
 <p>Hello {{.RecipientName}},</p>
 <p>This is a notification email from EasyCLA regarding the project {{.GetProjectNameOrFoundation}} and CLA Group {{.CLAGroupName}}.</p>
 <p>{{.ContributorName}} ({{.ContributorEmail}}) has requested to be added to the Approved List as an authorized contributor from
-{{.CompanyName}} to the project {{.ProjectName}}. You are receiving this message as a CLA Manager from {{.CompanyName}} for
-{{.ProjectName}}.</p>
+{{.CompanyName}} to the project {{.Project.ExternalProjectName}}. You are receiving this message as a CLA Manager from {{.CompanyName}} for
+{{.Project.ExternalProjectName}}.</p>
 {{if .OptionalMessage}}
 <p>{{.ContributorName}} included the following message in the request:</p>
 <br/><p>{{.OptionalMessage}}</p><br/>
@@ -56,7 +56,7 @@ const (
 <a href="https://{{.CorporateConsoleURL}}#/company/{{.CompanyID}}" target="_blank">log into the EasyCLA Corporate
 Console</a>, where you can approve this user's request by selecting the 'Manage Approved List' and adding the
 contributor's email, the contributor's entire email domain, their GitHub ID or the entire GitHub Organization for the
-repository. This will permit them to begin contributing to {{.ProjectName}} on behalf of {{.CompanyName}}.</p>
+repository. This will permit them to begin contributing to {{.Project.ExternalProjectName}} on behalf of {{.CompanyName}}.</p>
 <p>If you are not certain whether to add them to the Approved List, please reach out to them directly to discuss.</p>
 `
 )

--- a/cla-backend-go/emails/approval_list_templates_test.go
+++ b/cla-backend-go/emails/approval_list_templates_test.go
@@ -14,7 +14,7 @@ func TestApprovalListRejectedTemplate(t *testing.T) {
 	params := ApprovalListRejectedTemplateParams{
 		CLAManagerTemplateParams: CLAManagerTemplateParams{
 			RecipientName: "JohnsClaManager",
-			ProjectName:   "JohnsProject",
+			Project:       CLAProjectParams{ExternalProjectName: "JohnsProject"},
 			CompanyName:   "JohnsCompany",
 			CLAManagers: []ClaManagerInfoParams{
 				{LfUsername: "LFUserName", Email: "LFEmail"},
@@ -34,11 +34,10 @@ func TestApprovalListRejectedTemplate(t *testing.T) {
 func TestRequestToAuthorizeTemplate(t *testing.T) {
 	params := RequestToAuthorizeTemplateParams{
 		CLAManagerTemplateParams: CLAManagerTemplateParams{
-			RecipientName:       "JohnsClaManager",
-			ProjectName:         "JohnsProject",
-			CLAGroupName:        "JohnsProject",
-			ExternalProjectName: "JohnsProjectExternal",
-			CompanyName:         "JohnsCompany",
+			RecipientName: "JohnsClaManager",
+			Project:       CLAProjectParams{ExternalProjectName: "JohnsProjectExternal"},
+			CLAGroupName:  "JohnsProject",
+			CompanyName:   "JohnsCompany",
 			CLAManagers: []ClaManagerInfoParams{
 				{LfUsername: "LFUserName", Email: "LFEmail"},
 			},
@@ -56,7 +55,7 @@ func TestRequestToAuthorizeTemplate(t *testing.T) {
 	assert.Contains(t, result, "regarding the project JohnsProjectExternal and CLA Group JohnsProject")
 	assert.Contains(t, result, "ContributorNameValue (ContributorEmailValue) has requested")
 	assert.Contains(t, result, "<a href=\"https://CorporateConsoleURLValue#/company/CompanyIDValue\" target=\"_blank\">")
-	assert.Contains(t, result, "contributing to JohnsProject on behalf of JohnsCompany")
+	assert.Contains(t, result, "contributing to JohnsProjectExternal on behalf of JohnsCompany")
 
 	params.OptionalMessage = "OptionalMessageValue"
 	result, err = RenderTemplate(utils.V1, RequestToAuthorizeTemplateName, RequestToAuthorizeTemplate,

--- a/cla-backend-go/emails/cla_manager_templates.go
+++ b/cla-backend-go/emails/cla_manager_templates.go
@@ -5,45 +5,6 @@ package emails
 
 import "github.com/communitybridge/easycla/cla-backend-go/projects_cla_groups"
 
-// ClaManagerInfoParams represents the CLAManagerInfo used inside of the Email Templates
-type ClaManagerInfoParams struct {
-	LfUsername string
-	Email      string
-}
-
-// CLAManagerTemplateParams includes the params for the CLAManagerTemplateParams
-type CLAManagerTemplateParams struct {
-	RecipientName string
-	CLAGroupName  string
-	// ProjectName is same as CLAGroupName in this context it's a legacy naming
-	// convention we used to have so we keep it here, for the actual project name
-	// we'll be using ExternalProjectName
-	ProjectName         string
-	ExternalProjectName string
-	CompanyName         string
-	FoundationName      string
-	CLAManagers         []ClaManagerInfoParams
-	// ChildProjectCount indicates how many childProjects are under this CLAGroup
-	// this is important for some of the email rendering knowing if claGroup has
-	// multiple children
-	ChildProjectCount int
-}
-
-// GetProjectNameOrFoundation returns if the foundationName is set it gets back
-// the foundation Name otherwise the ProjectName is  returned
-func (claParams CLAManagerTemplateParams) GetProjectNameOrFoundation() string {
-	if claParams.ChildProjectCount == 0 {
-		return claParams.ExternalProjectName
-	}
-
-	// if multiple return the foundation if present
-	if claParams.FoundationName != "" {
-		return claParams.FoundationName
-	}
-	//default to project name if nothing works
-	return claParams.ExternalProjectName
-}
-
 // RemovedCLAManagerTemplateParams is email params for RemovedCLAManagerTemplate
 type RemovedCLAManagerTemplateParams struct {
 	CLAManagerTemplateParams
@@ -56,7 +17,7 @@ const (
 	RemovedCLAManagerTemplate = `
 <p>Hello {{.RecipientName}},</p>
 <p>This is a notification email from EasyCLA regarding the project {{.GetProjectNameOrFoundation}} and CLA Group {{.CLAGroupName}}.</p>
-<p>You have been removed as a CLA Manager from {{.CompanyName}} for the project {{.ProjectName}}.</p>
+<p>You have been removed as a CLA Manager from {{.CompanyName}} for the project {{.Project.ExternalProjectName}}.</p>
 <p>If you have further questions about this, please contact one of the existing managers from
 {{.CompanyName}}:</p>
 <ul>
@@ -97,14 +58,14 @@ const (
 	// RequestAccessToCLAManagersTemplate is email template for
 	RequestAccessToCLAManagersTemplate = `
 <p>Hello {{.RecipientName}},</p>
-<p>This is a notification email from EasyCLA regarding the project {{.ProjectName}}.</p>
-<p>You are currently listed as a CLA Manager from {{.CompanyName}} for the project {{.ProjectName}}. This means that you are able to maintain the
-list of employees allowed to contribute to {{.ProjectName}} on behalf of your company, as well as view and manage the list of
-your company’s CLA Managers for {{.ProjectName}}.</p>
-<p>{{.RequesterName}} ({{.RequesterEmail}}) has requested to be added as another CLA Manager from {{.CompanyName}} for {{.ProjectName}}. This would permit them to maintain the
+<p>This is a notification email from EasyCLA regarding the project {{.Project.ExternalProjectName}}.</p>
+<p>You are currently listed as a CLA Manager from {{.CompanyName}} for the project {{.Project.ExternalProjectName}}. This means that you are able to maintain the
+list of employees allowed to contribute to {{.Project.ExternalProjectName}} on behalf of your company, as well as view and manage the list of
+your company’s CLA Managers for {{.Project.ExternalProjectName}}.</p>
+<p>{{.RequesterName}} ({{.RequesterEmail}}) has requested to be added as another CLA Manager from {{.CompanyName}} for {{.Project.ExternalProjectName}}. This would permit them to maintain the
 lists of approved contributors and CLA Managers as well.</p>
 <p>If you want to permit this, please log into the <a href="{{.CorporateURL}}" target="_blank">EasyCLA Corporate Console</a>,
-select your company, then select the {{.ProjectName}} project. From the CLA Manager requests, you can approve this user as an
+select your company, then select the {{.Project.ExternalProjectName}} project. From the CLA Manager requests, you can approve this user as an
 additional CLA Manager.</p>
 `
 )
@@ -122,10 +83,10 @@ const (
 	// RequestApprovedToCLAManagersTemplate is email template for
 	RequestApprovedToCLAManagersTemplate = `
 <p>Hello {{.RecipientName}},</p>
-<p>This is a notification email from EasyCLA regarding the project {{.ProjectName}}.</p>
-<p>The following user has been approved as a CLA Manager from {{.CompanyName}} for the project {{.ProjectName}}. This means that they can now
-maintain the list of employees allowed to contribute to {{.ProjectName}} on behalf of your company, as well as view and manage the
-list of company’s CLA Managers for {{.ProjectName}}.</p>
+<p>This is a notification email from EasyCLA regarding the project {{.Project.ExternalProjectName}}.</p>
+<p>The following user has been approved as a CLA Manager from {{.CompanyName}} for the project {{.Project.ExternalProjectName}}. This means that they can now
+maintain the list of employees allowed to contribute to {{.Project.ExternalProjectName}} on behalf of your company, as well as view and manage the
+list of company’s CLA Managers for {{.Project.ExternalProjectName}}.</p>
 <ul>
 <li>{{.RequesterName}} ({{.RequesterEmail}})</li>
 </ul>
@@ -144,12 +105,12 @@ const (
 	// RequestApprovedToRequesterTemplate is email template for
 	RequestApprovedToRequesterTemplate = `
 <p>Hello {{.RecipientName}},</p>
-<p>This is a notification email from EasyCLA regarding the project {{.ProjectName}}.</p>
-<p>You have now been approved as a CLA Manager from {{.CompanyName}} for the project {{.ProjectName}}.  This means that you can now maintain the
-list of employees allowed to contribute to {{.ProjectName}} on behalf of your company, as well as view and manage the list of your
-company’s CLA Managers for {{.ProjectName}}.</p>
+<p>This is a notification email from EasyCLA regarding the project {{.Project.ExternalProjectName}}.</p>
+<p>You have now been approved as a CLA Manager from {{.CompanyName}} for the project {{.Project.ExternalProjectName}}.  This means that you can now maintain the
+list of employees allowed to contribute to {{.Project.ExternalProjectName}} on behalf of your company, as well as view and manage the list of your
+company’s CLA Managers for {{.Project.ExternalProjectName}}.</p>
 <p> To get started, please log into the <a href="{{.CorporateURL}}" target="_blank">EasyCLA Corporate Console</a>, and select your
-company and then the project {{.ProjectName}}. From here you will be able to edit the list of approved employees and CLA Managers.</p>
+company and then the project {{.Project.ExternalProjectName}}. From here you will be able to edit the list of approved employees and CLA Managers.</p>
 `
 )
 
@@ -166,9 +127,9 @@ const (
 	// RequestDeniedToCLAManagersTemplate is email template for
 	RequestDeniedToCLAManagersTemplate = `
 <p>Hello {{.RecipientName}},</p>
-<p>This is a notification email from EasyCLA regarding the project {{.ProjectName}}.</p>
-<p>The following user has been denied as a CLA Manager from {{.CompanyName}} for the project {{.ProjectName}}. This means that they will not
-be able to maintain the list of employees allowed to contribute to {{.ProjectName}} on behalf of your company.</p>
+<p>This is a notification email from EasyCLA regarding the project {{.Project.ExternalProjectName}}.</p>
+<p>The following user has been denied as a CLA Manager from {{.CompanyName}} for the project {{.Project.ExternalProjectName}}. This means that they will not
+be able to maintain the list of employees allowed to contribute to {{.Project.ExternalProjectName}} on behalf of your company.</p>
 <ul>
 <li>{{.RequesterName}} ({{.RequesterEmail}})</li>
 </ul>
@@ -186,9 +147,9 @@ const (
 	// RequestDeniedToRequesterTemplate is email template for
 	RequestDeniedToRequesterTemplate = `
 <p>Hello {{.RecipientName}},</p>
-<p>This is a notification email from EasyCLA regarding the project {{.ProjectName}}.</p>
-<p>You have been denied as a CLA Manager from {{.CompanyName}} for the project {{.ProjectName}}. This means that you can not maintain the
-list of employees allowed to contribute to {{.ProjectName}} on behalf of your company.</p>
+<p>This is a notification email from EasyCLA regarding the project {{.Project.ExternalProjectName}}.</p>
+<p>You have been denied as a CLA Manager from {{.CompanyName}} for the project {{.Project.ExternalProjectName}}. This means that you can not maintain the
+list of employees allowed to contribute to {{.Project.ExternalProjectName}} on behalf of your company.</p>
 `
 )
 
@@ -204,12 +165,12 @@ const (
 	// ClaManagerAddedEToUserTemplate is email template for
 	ClaManagerAddedEToUserTemplate = `
 <p>Hello {{.RecipientName}},</p>
-<p>This is a notification email from EasyCLA regarding the project {{.ProjectName}}.</p>
-<p>You have been added as a CLA Manager from {{.CompanyName}} for the project {{.ProjectName}}.  This means that you can now maintain the
-list of employees allowed to contribute to {{.ProjectName}} on behalf of your company, as well as view and manage the list of your
-company’s CLA Managers for {{.ProjectName}}.</p>
+<p>This is a notification email from EasyCLA regarding the project {{.Project.ExternalProjectName}}.</p>
+<p>You have been added as a CLA Manager from {{.CompanyName}} for the project {{.Project.ExternalProjectName}}.  This means that you can now maintain the
+list of employees allowed to contribute to {{.Project.ExternalProjectName}} on behalf of your company, as well as view and manage the list of your
+company’s CLA Managers for {{.Project.ExternalProjectName}}.</p>
 <p> To get started, please log into the <a href="{{.CorporateURL}}" target="_blank">EasyCLA Corporate Console</a>, and select your
-company and then the project {{.ProjectName}}. From here you will be able to edit the list of approved employees and CLA Managers.</p>
+company and then the project {{.Project.ExternalProjectName}}. From here you will be able to edit the list of approved employees and CLA Managers.</p>
 `
 )
 
@@ -226,10 +187,10 @@ const (
 	// ClaManagerAddedToCLAManagersTemplate is email template for
 	ClaManagerAddedToCLAManagersTemplate = `
 <p>Hello {{.RecipientName}},</p>
-<p>This is a notification email from EasyCLA regarding the project {{.ProjectName}}.</p>
-<p>The following user has been added as a CLA Manager from {{.CompanyName}} for the project {{.ProjectName}}. This means that they can now
-maintain the list of employees allowed to contribute to {{.ProjectName}} on behalf of your company, as well as view and manage the
-list of company’s CLA Managers for {{.ProjectName}}.</p>
+<p>This is a notification email from EasyCLA regarding the project {{.Project.ExternalProjectName}}.</p>
+<p>The following user has been added as a CLA Manager from {{.CompanyName}} for the project {{.Project.ExternalProjectName}}. This means that they can now
+maintain the list of employees allowed to contribute to {{.Project.ExternalProjectName}} on behalf of your company, as well as view and manage the
+list of company’s CLA Managers for {{.Project.ExternalProjectName}}.</p>
 <ul>
 <li>{{.Name}} ({{.Email}})</li>
 </ul>
@@ -249,7 +210,7 @@ const (
 	// ClaManagerDeletedToCLAManagersTemplate is template for
 	ClaManagerDeletedToCLAManagersTemplate = `
 <p>Hello {{.RecipientName}},</p>
-<p>This is a notification email from EasyCLA regarding the project {{.ProjectName}}.</p>
-<p>{{.Name}} ({{.Email}}) has been removed as a CLA Manager from {{.CompanyName}} for the project {{.ProjectName}}.</p>
+<p>This is a notification email from EasyCLA regarding the project {{.Project.ExternalProjectName}}.</p>
+<p>{{.Name}} ({{.Email}}) has been removed as a CLA Manager from {{.CompanyName}} for the project {{.Project.ExternalProjectName}}.</p>
 `
 )

--- a/cla-backend-go/emails/cla_manager_templates_test.go
+++ b/cla-backend-go/emails/cla_manager_templates_test.go
@@ -13,10 +13,10 @@ import (
 func TestRemovedCLAManagerTemplate(t *testing.T) {
 	params := RemovedCLAManagerTemplateParams{
 		CLAManagerTemplateParams: CLAManagerTemplateParams{
-			RecipientName:       "JohnsClaManager",
-			ProjectName:         "JohnsProject",
-			ExternalProjectName: "JohnsProjectExternal",
-			CompanyName:         "JohnsCompany",
+			RecipientName: "JohnsClaManager",
+			Project:       CLAProjectParams{ExternalProjectName: "JohnsProjectExternal"},
+			CLAGroupName:  "JohnsProject",
+			CompanyName:   "JohnsCompany",
 			CLAManagers: []ClaManagerInfoParams{
 				{LfUsername: "LFUserName", Email: "LFEmail"},
 			},
@@ -33,7 +33,7 @@ func TestRemovedCLAManagerTemplate(t *testing.T) {
 
 	// even if the foundation is set we should show the project name
 	// because 0 child projects under the claGroup
-	params.CLAManagerTemplateParams.FoundationName = "CNCF"
+	params.CLAManagerTemplateParams.Project.FoundationName = "CNCF"
 	result, err = RenderTemplate(utils.V1, RemovedCLAManagerTemplateName, RemovedCLAManagerTemplate,
 		params)
 	assert.NoError(t, err)
@@ -52,10 +52,10 @@ func TestRemovedCLAManagerTemplate(t *testing.T) {
 func TestRequestAccessToCLAManagersTemplate(t *testing.T) {
 	params := RequestAccessToCLAManagersTemplateParams{
 		CLAManagerTemplateParams: CLAManagerTemplateParams{
-			RecipientName:       "JohnsClaManager",
-			ProjectName:         "JohnsProject",
-			ExternalProjectName: "JohnsProjectExternal",
-			CompanyName:         "JohnsCompany",
+			RecipientName: "JohnsClaManager",
+			Project:       CLAProjectParams{ExternalProjectName: "JohnsProjectExternal"},
+			CLAGroupName:  "JohnsProject",
+			CompanyName:   "JohnsCompany",
 		},
 		RequesterName:  "RequesterName",
 		RequesterEmail: "RequesterEmail",
@@ -73,17 +73,17 @@ func TestRequestAccessToCLAManagersTemplate(t *testing.T) {
 	assert.Contains(t, result, "RequesterName (RequesterEmail) has requested")
 	assert.Contains(t, result, "another CLA Manager from JohnsCompany for JohnsProject")
 	assert.Contains(t, result, "<a href=\"http://CorporateURL.com\" target=\"_blank\">")
-	assert.Contains(t, result, "then select the JohnsProject project")
+	assert.Contains(t, result, "then select the JohnsProjectExternal project")
 
 }
 
 func TestRequestApprovedToCLAManagersTemplate(t *testing.T) {
 	params := RequestApprovedToCLAManagersTemplateParams{
 		CLAManagerTemplateParams: CLAManagerTemplateParams{
-			RecipientName:       "JohnsClaManager",
-			ProjectName:         "JohnsProject",
-			ExternalProjectName: "JohnsProjectExternal",
-			CompanyName:         "JohnsCompany",
+			RecipientName: "JohnsClaManager",
+			Project:       CLAProjectParams{ExternalProjectName: "JohnsProjectExternal"},
+			CLAGroupName:  "JohnsProject",
+			CompanyName:   "JohnsCompany",
 		},
 		RequesterName:  "RequesterName",
 		RequesterEmail: "RequesterEmail",
@@ -103,10 +103,10 @@ func TestRequestApprovedToCLAManagersTemplate(t *testing.T) {
 func TestRequestApprovedToRequesterTemplateParams(t *testing.T) {
 	params := RequestApprovedToRequesterTemplateParams{
 		CLAManagerTemplateParams: CLAManagerTemplateParams{
-			RecipientName:       "JohnsClaManager",
-			ProjectName:         "JohnsProject",
-			ExternalProjectName: "JohnsProjectExternal",
-			CompanyName:         "JohnsCompany",
+			RecipientName: "JohnsClaManager",
+			Project:       CLAProjectParams{ExternalProjectName: "JohnsProjectExternal"},
+			CLAGroupName:  "JohnsProject",
+			CompanyName:   "JohnsCompany",
 		},
 		CorporateURL: "http://CorporateURL.com",
 	}
@@ -126,10 +126,10 @@ func TestRequestApprovedToRequesterTemplateParams(t *testing.T) {
 func TestRequestDeniedToCLAManagersTemplate(t *testing.T) {
 	params := RequestDeniedToCLAManagersTemplateParams{
 		CLAManagerTemplateParams: CLAManagerTemplateParams{
-			RecipientName:       "JohnsClaManager",
-			ProjectName:         "JohnsProject",
-			ExternalProjectName: "JohnsProjectExternal",
-			CompanyName:         "JohnsCompany",
+			RecipientName: "JohnsClaManager",
+			Project:       CLAProjectParams{ExternalProjectName: "JohnsProjectExternal"},
+			CLAGroupName:  "JohnsProject",
+			CompanyName:   "JohnsCompany",
 		},
 		RequesterName:  "RequesterName",
 		RequesterEmail: "RequesterEmail",
@@ -148,10 +148,10 @@ func TestRequestDeniedToCLAManagersTemplate(t *testing.T) {
 func TestRequestDeniedToRequesterTemplate(t *testing.T) {
 	params := RequestDeniedToRequesterTemplateParams{
 		CLAManagerTemplateParams: CLAManagerTemplateParams{
-			RecipientName:       "JohnsClaManager",
-			ProjectName:         "JohnsProject",
-			ExternalProjectName: "JohnsProjectExternal",
-			CompanyName:         "JohnsCompany",
+			RecipientName: "JohnsClaManager",
+			Project:       CLAProjectParams{ExternalProjectName: "JohnsProjectExternal"},
+			CLAGroupName:  "JohnsProject",
+			CompanyName:   "JohnsCompany",
 		},
 	}
 
@@ -167,10 +167,10 @@ func TestRequestDeniedToRequesterTemplate(t *testing.T) {
 func TestClaManagerAddedEToUserTemplate(t *testing.T) {
 	params := ClaManagerAddedEToUserTemplateParams{
 		CLAManagerTemplateParams: CLAManagerTemplateParams{
-			RecipientName:       "JohnsClaManager",
-			ProjectName:         "JohnsProject",
-			ExternalProjectName: "JohnsProjectExternal",
-			CompanyName:         "JohnsCompany",
+			RecipientName: "JohnsClaManager",
+			Project:       CLAProjectParams{ExternalProjectName: "JohnsProjectExternal"},
+			CLAGroupName:  "JohnsProject",
+			CompanyName:   "JohnsCompany",
 		},
 		CorporateURL: "http://CorporateURL.com",
 	}
@@ -190,10 +190,10 @@ func TestClaManagerAddedEToUserTemplate(t *testing.T) {
 func TestClaManagerAddedToCLAManagersTemplate(t *testing.T) {
 	params := ClaManagerAddedToCLAManagersTemplateParams{
 		CLAManagerTemplateParams: CLAManagerTemplateParams{
-			RecipientName:       "JohnsClaManager",
-			ProjectName:         "JohnsProject",
-			ExternalProjectName: "JohnsProjectExternal",
-			CompanyName:         "JohnsCompany",
+			RecipientName: "JohnsClaManager",
+			Project:       CLAProjectParams{ExternalProjectName: "JohnsProjectExternal"},
+			CLAGroupName:  "JohnsProject",
+			CompanyName:   "JohnsCompany",
 		},
 		Name:  "John",
 		Email: "john@example.com",
@@ -214,10 +214,10 @@ func TestClaManagerAddedToCLAManagersTemplate(t *testing.T) {
 func TestClaManagerDeletedToCLAManagersTemplate(t *testing.T) {
 	params := ClaManagerDeletedToCLAManagersTemplateParams{
 		CLAManagerTemplateParams: CLAManagerTemplateParams{
-			RecipientName:       "JohnsClaManager",
-			ProjectName:         "JohnsProject",
-			ExternalProjectName: "JohnsProjectExternal",
-			CompanyName:         "JohnsCompany",
+			RecipientName: "JohnsClaManager",
+			Project:       CLAProjectParams{ExternalProjectName: "JohnsProjectExternal"},
+			CLAGroupName:  "JohnsProject",
+			CompanyName:   "JohnsCompany",
 		},
 		Name:  "John",
 		Email: "john@example.com",

--- a/cla-backend-go/emails/params.go
+++ b/cla-backend-go/emails/params.go
@@ -1,0 +1,85 @@
+// Copyright The Linux Foundation and each contributor to CommunityBridge.
+// SPDX-License-Identifier: MIT
+
+package emails
+
+import (
+	"fmt"
+	"html/template"
+	"net/url"
+	"path"
+
+	log "github.com/communitybridge/easycla/cla-backend-go/logging"
+)
+
+// ClaManagerInfoParams represents the CLAManagerInfo used inside of the Email Templates
+type ClaManagerInfoParams struct {
+	LfUsername string
+	Email      string
+}
+
+// CLAProjectParams is useful struct which keeps cla group project info and also
+// know how to render it's corporate console url
+type CLAProjectParams struct {
+	ExternalProjectName     string
+	ProjectSFID             string
+	FoundationName          string
+	FoundationSFID          string
+	SignedAtFoundationLevel bool
+	CorporateConsole        string
+}
+
+// GetProjectFullURL has the logic how to return back it's full url in corporate console
+// it checks at SignedAtFoundationLevel flag as well for this specific kind of projects
+func (p CLAProjectParams) GetProjectFullURL() template.HTML {
+	if p.CorporateConsole == "" {
+		return template.HTML(p.ExternalProjectName)
+	}
+
+	u, err := url.Parse(p.CorporateConsole)
+	if err != nil {
+		log.Warnf("couldn't parse the console url, probably wrong configuration used : %s : %v", p.CorporateConsole, err)
+		// at least return the project name so we don't have broken email
+		return template.HTML(p.ExternalProjectName)
+	}
+
+	var projectConsolePathURL string
+	fullURLHtml := `<a href="%s" target="_blank">%s</a>`
+	if p.SignedAtFoundationLevel {
+		u.Path = path.Join(u.Path, "foundation", p.FoundationSFID, "cla")
+		projectConsolePathURL = u.String()
+	} else {
+		u.Path = path.Join(u.Path, "foundation", p.FoundationSFID, "project", p.ProjectSFID, "cla")
+		projectConsolePathURL = u.String()
+	}
+
+	return template.HTML(fmt.Sprintf(fullURLHtml, projectConsolePathURL, p.ExternalProjectName))
+}
+
+// CLAManagerTemplateParams includes the params for the CLAManagerTemplateParams
+type CLAManagerTemplateParams struct {
+	RecipientName string
+	CompanyName   string
+	CLAGroupName  string
+	Project       CLAProjectParams
+	CLAManagers   []ClaManagerInfoParams
+	// ChildProjectCount indicates how many childProjects are under this CLAGroup
+	// this is important for some of the email rendering knowing if claGroup has
+	// multiple children
+	ChildProjectCount int
+}
+
+// GetProjectNameOrFoundation returns if the foundationName is set it gets back
+// the foundation Name otherwise the ProjectName is  returned
+func (claParams CLAManagerTemplateParams) GetProjectNameOrFoundation() string {
+	if claParams.ChildProjectCount == 0 {
+		return claParams.Project.ExternalProjectName
+	}
+
+	// if multiple return the foundation if present
+	if claParams.Project.FoundationName != "" {
+		return claParams.Project.FoundationName
+	}
+	//default to project name if nothing works
+	return claParams.Project.ExternalProjectName
+}

--- a/cla-backend-go/emails/params_test.go
+++ b/cla-backend-go/emails/params_test.go
@@ -1,0 +1,58 @@
+// Copyright The Linux Foundation and each contributor to CommunityBridge.
+// SPDX-License-Identifier: MIT
+
+package emails
+
+import (
+	"html/template"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCLAProjectParams_GetProjectFullURL(t *testing.T) {
+	testCases := []struct {
+		name          string
+		projectParams CLAProjectParams
+		result        template.HTML
+	}{
+		{
+			name: "empty url",
+			projectParams: CLAProjectParams{
+				ExternalProjectName: "JohnsProject",
+			},
+			result: template.HTML("JohnsProject"),
+		},
+		{
+			name: "foundation level project",
+			projectParams: CLAProjectParams{
+				ExternalProjectName:     "JohnsProject",
+				ProjectSFID:             "projectSFIDValue",
+				FoundationName:          "CNCF",
+				FoundationSFID:          "FoundationSFIDValue",
+				SignedAtFoundationLevel: true,
+				CorporateConsole:        "https://corporate.dev.lfcla.com",
+			},
+			result: template.HTML(`<a href="https://corporate.dev.lfcla.com/foundation/FoundationSFIDValue/cla" target="_blank">JohnsProject</a>`),
+		},
+		{
+			name: "standalone project",
+			projectParams: CLAProjectParams{
+				ExternalProjectName:     "JohnsProject",
+				ProjectSFID:             "projectSFIDValue",
+				FoundationName:          "CNCF",
+				FoundationSFID:          "FoundationSFIDValue",
+				SignedAtFoundationLevel: false,
+				CorporateConsole:        "https://corporate.dev.lfcla.com",
+			},
+			result: template.HTML(`<a href="https://corporate.dev.lfcla.com/foundation/FoundationSFIDValue/project/projectSFIDValue/cla" target="_blank">JohnsProject</a>`),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(tt *testing.T) {
+			resul := tc.projectParams.GetProjectFullURL()
+			assert.Equal(tt, tc.result, resul)
+		})
+	}
+}

--- a/cla-backend-go/emails/v2_cla_manager_templates_test.go
+++ b/cla-backend-go/emails/v2_cla_manager_templates_test.go
@@ -14,7 +14,7 @@ func TestV2ContributorApprovalRequestTemplate(t *testing.T) {
 	params := V2ContributorApprovalRequestTemplateParams{
 		CLAManagerTemplateParams: CLAManagerTemplateParams{
 			RecipientName: "JohnsClaManager",
-			ProjectName:   "JohnsProject",
+			Project:       CLAProjectParams{ExternalProjectName: "JohnsProject"},
 			CLAGroupName:  "JohnsCLAGroupName",
 			CompanyName:   "JohnsCompany",
 		},
@@ -47,13 +47,17 @@ func TestV2OrgAdminTemplate(t *testing.T) {
 	params := V2OrgAdminTemplateParams{
 		CLAManagerTemplateParams: CLAManagerTemplateParams{
 			RecipientName: "JohnsClaManager",
-			ProjectName:   "JohnsProject",
-			CLAGroupName:  "JohnsCLAGroupName",
-			CompanyName:   "JohnsCompany",
+			Project: CLAProjectParams{
+				ExternalProjectName: "JohnsProject",
+				ProjectSFID:         "ProjectSFIDValue",
+				FoundationSFID:      "FoundationSFIDValue",
+				CorporateConsole:    "http://CorporateConsole.com",
+			},
+			CLAGroupName: "JohnsCLAGroupName",
+			CompanyName:  "JohnsCompany",
 		},
 		SenderName:       "SenderNameValue",
 		SenderEmail:      "SenderEmailValue",
-		ProjectList:      []string{"Project1", "Project2"},
 		CorporateConsole: "http://CorporateConsole.com",
 	}
 
@@ -64,21 +68,23 @@ func TestV2OrgAdminTemplate(t *testing.T) {
 	assert.Contains(t, result, "signing process for JohnsCompany")
 	assert.Contains(t, result, "SenderNameValue SenderEmailValue has identified you")
 	assert.Contains(t, result, "Corporate CLA for JohnsCompany")
-	assert.Contains(t, result, "<li>Project1</li>")
-	assert.Contains(t, result, "<li>Project2</li>")
+	assert.Contains(t, result, "<li>JohnsProject</li>")
 	assert.Contains(t, result, "can login to this portal (http://CorporateConsole.com)")
-	assert.Contains(t, result, "sign the CLA for this project JohnsProject")
+	assert.Contains(t, result, `sign the CLA for this project <a href="http://CorporateConsole.com/foundation/FoundationSFIDValue/project/ProjectSFIDValue/cla" target="_blank">JohnsProject</a>`)
 }
 
 func TestV2ContributorToOrgAdminTemplate(t *testing.T) {
 	params := V2ContributorToOrgAdminTemplateParams{
 		CLAManagerTemplateParams: CLAManagerTemplateParams{
 			RecipientName: "JohnsClaManager",
-			ProjectName:   "JohnsProject",
+			Project:       CLAProjectParams{ExternalProjectName: "JohnsProject"},
 			CLAGroupName:  "JohnsCLAGroupName",
 			CompanyName:   "JohnsCompany",
 		},
-		ProjectNames:     []string{"Project1", "Project2"},
+		Projects: []CLAProjectParams{
+			{ExternalProjectName: "Project1", ProjectSFID: "ProjectSFID1", FoundationSFID: "FoundationSFID1", CorporateConsole: "http://CorporateConsole.com"},
+			{ExternalProjectName: "Project2", ProjectSFID: "ProjectSFID2", FoundationSFID: "FoundationSFID2", CorporateConsole: "http://CorporateConsole.com"},
+		},
 		UserDetails:      "UserDetailsValue",
 		CorporateConsole: "http://CorporateConsole.com",
 	}
@@ -91,20 +97,24 @@ func TestV2ContributorToOrgAdminTemplate(t *testing.T) {
 	assert.Contains(t, result, "sign CLA for organization: JohnsCompany")
 	assert.Contains(t, result, "<p>UserDetailsValue</p>")
 	assert.Contains(t, result, "Kindly login to this portal http://CorporateConsole.com")
-	assert.Contains(t, result, "CLA for any of the projects Project1,Project2")
+	assert.Contains(t, result, `CLA for any of the projects <a href="http://CorporateConsole.com/foundation/FoundationSFID1/project/ProjectSFID1/cla" target="_blank">Project1</a>,<a href="http://CorporateConsole.com/foundation/FoundationSFID2/project/ProjectSFID2/cla" target="_blank">Project2</a>`)
 }
 
 func TestV2CLAManagerDesigneeCorporateTemplate(t *testing.T) {
 	params := V2CLAManagerDesigneeCorporateTemplateParams{
 		CLAManagerTemplateParams: CLAManagerTemplateParams{
 			RecipientName: "JohnsClaManager",
-			ProjectName:   "JohnsProject",
-			CLAGroupName:  "JohnsCLAGroupName",
-			CompanyName:   "JohnsCompany",
+			Project: CLAProjectParams{
+				ExternalProjectName: "JohnsProject",
+				FoundationSFID:      "FoundationSFIDValue",
+				ProjectSFID:         "ProjectSFIDValue",
+				CorporateConsole:    "http://CorporateConsole.com",
+			},
+			CLAGroupName: "JohnsCLAGroupName",
+			CompanyName:  "JohnsCompany",
 		},
 		SenderName:       "SenderNameValue",
 		SenderEmail:      "SenderEmailValue",
-		ProjectList:      []string{"Project1", "Project2"},
 		CorporateConsole: "http://CorporateConsole.com",
 	}
 
@@ -115,16 +125,18 @@ func TestV2CLAManagerDesigneeCorporateTemplate(t *testing.T) {
 	assert.Contains(t, result, "CLA setup and signing process for JohnsCompany")
 	assert.Contains(t, result, "SenderNameValue SenderEmailValue has identified you")
 	assert.Contains(t, result, "Corporate CLA for JohnsCompany")
-	assert.Contains(t, result, "<li>Project1</li>")
-	assert.Contains(t, result, "<li>Project2</li>")
+	assert.Contains(t, result, "<li>JohnsProject</li>")
 	assert.Contains(t, result, "can login to this portal (http://CorporateConsole.com)")
-	assert.Contains(t, result, "sign the CLA for this project JohnsProject")
+	assert.Contains(t, result, `sign the CLA for this project <a href="http://CorporateConsole.com/foundation/FoundationSFIDValue/project/ProjectSFIDValue/cla" target="_blank">JohnsProject</a>`)
 }
 
 func TestV2ToCLAManagerDesigneeTemplate(t *testing.T) {
 	params := V2ToCLAManagerDesigneeTemplateParams{
-		RecipientName:    "JohnsClaManager",
-		ProjectNames:     []string{"Project1", "Project2"},
+		RecipientName: "JohnsClaManager",
+		Projects: []CLAProjectParams{
+			{ExternalProjectName: "Project1", ProjectSFID: "ProjectSFID1", FoundationSFID: "FoundationSFID1", CorporateConsole: "http://CorporateConsole.com"},
+			{ExternalProjectName: "Project2", ProjectSFID: "ProjectSFID2", FoundationSFID: "FoundationSFID2", CorporateConsole: "http://CorporateConsole.com"},
+		},
 		ContributorID:    "ContributorIDValue",
 		ContributorName:  "ContributorNameValue",
 		CorporateConsole: "http://CorporateConsole.com",
@@ -137,9 +149,11 @@ func TestV2ToCLAManagerDesigneeTemplate(t *testing.T) {
 	assert.Contains(t, result, "regarding the projects Project1, Project2")
 	assert.Contains(t, result, "<p> ContributorIDValue (ContributorNameValue) </p>")
 	assert.Contains(t, result, "Kindly login to this portal http://CorporateConsole.com")
-	assert.Contains(t, result, "CLA for one of the projects Project1, Project2")
+	assert.Contains(t, result, `CLA for one of the project(s) <a href="http://CorporateConsole.com/foundation/FoundationSFID1/project/ProjectSFID1/cla" target="_blank">Project1</a>,<a href="http://CorporateConsole.com/foundation/FoundationSFID2/project/ProjectSFID2/cla" target="_blank">Project2</a>`)
 
-	params.ProjectNames = []string{"Project1"}
+	params.Projects = []CLAProjectParams{
+		{ExternalProjectName: "Project1", ProjectSFID: "ProjectSFID1", FoundationSFID: "FoundationSFID1", CorporateConsole: "http://CorporateConsole.com"},
+	}
 	result, err = RenderTemplate(utils.V1, V2ToCLAManagerDesigneeTemplateName, V2ToCLAManagerDesigneeTemplate,
 		params)
 	assert.NoError(t, err)
@@ -147,18 +161,22 @@ func TestV2ToCLAManagerDesigneeTemplate(t *testing.T) {
 	assert.Contains(t, result, "regarding the project Project1")
 	assert.Contains(t, result, "<p> ContributorIDValue (ContributorNameValue) </p>")
 	assert.Contains(t, result, "Kindly login to this portal http://CorporateConsole.com")
-	assert.Contains(t, result, "CLA for one of the project Project1")
+	assert.Contains(t, result, `CLA for one of the project(s) <a href="http://CorporateConsole.com/foundation/FoundationSFID1/project/ProjectSFID1/cla" target="_blank">Project1</a>`)
 
 }
 
 func TestV2DesigneeToUserWithNoLFIDTemplate(t *testing.T) {
 	params := V2DesigneeToUserWithNoLFIDTemplateParams{
 		CLAManagerTemplateParams: CLAManagerTemplateParams{
-			RecipientName:       "JohnsClaManager",
-			ProjectName:         "JohnsProject",
-			ExternalProjectName: "JohnsProjectExternal",
-			CLAGroupName:        "JohnsCLAGroupName",
-			CompanyName:         "JohnsCompany",
+			RecipientName: "JohnsClaManager",
+			Project: CLAProjectParams{
+				ExternalProjectName:     "JohnsProjectExternal",
+				CorporateConsole:        "https://corporate.dev.lfcla.com",
+				FoundationSFID:          "FoundationSFIDValue",
+				SignedAtFoundationLevel: true,
+			},
+			CLAGroupName: "JohnsCLAGroupName",
+			CompanyName:  "JohnsCompany",
 		},
 		RequesterUserName: "RequesterUserNameValue",
 		RequesterEmail:    "RequesterEmailValue",
@@ -170,17 +188,17 @@ func TestV2DesigneeToUserWithNoLFIDTemplate(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, result, "Hello JohnsClaManager,")
 	assert.Contains(t, result, "The following contributor would like to contribute to JohnsProjectExternal on behalf of your organization: JohnsCompany.")
-	assert.Contains(t, result, "you will be redirected to this portal https://corporate.dev.lfcla.com where you can sign the CLA for the project JohnsProjectExternal")
+	assert.Contains(t, result, "you will be redirected to this portal https://corporate.dev.lfcla.com ")
+	assert.Contains(t, result, `where you can sign the CLA for the project <a href="https://corporate.dev.lfcla.com/foundation/FoundationSFIDValue/cla" target="_blank">JohnsProjectExternal</a>`)
 }
 
 func TestV2CLAManagerToUserWithNoLFIDTemplate(t *testing.T) {
 	params := V2CLAManagerToUserWithNoLFIDTemplateParams{
 		CLAManagerTemplateParams: CLAManagerTemplateParams{
-			RecipientName:       "JohnsClaManager",
-			ProjectName:         "JohnsProject",
-			ExternalProjectName: "JohnsProjectExternal",
-			CLAGroupName:        "JohnsCLAGroupName",
-			CompanyName:         "JohnsCompany",
+			RecipientName: "JohnsClaManager",
+			Project:       CLAProjectParams{ExternalProjectName: "JohnsProjectExternal"},
+			CLAGroupName:  "JohnsCLAGroupName",
+			CompanyName:   "JohnsCompany",
 		},
 		RequesterUserName: "RequesterUserNameValue",
 		RequesterEmail:    "RequesterEmailValue",

--- a/cla-backend-go/v2/cla_manager/handlers.go
+++ b/cla-backend-go/v2/cla_manager/handlers.go
@@ -328,7 +328,7 @@ func Configure(api *operations.EasyclaAPI, service Service, v1CompanyService v1C
 		}
 
 		claManagerDesignee, err := service.CreateCLAManagerRequest(ctx, params.Body.ContactAdmin, v1CompanyModel.CompanyID, params.ProjectSFID, params.Body.UserEmail.String(),
-			*params.Body.FullName, authUser, LfxPortalURL)
+			*params.Body.FullName, authUser, LfxPortalURL, CorporateConsoleV2URL)
 
 		if err != nil {
 			statusCode := buildErrorStatusCode(err)


### PR DESCRIPTION
include project corporate console links inside of the email templates + support the extra fetching of the data and the rendering

addresses ~[#2677]