### PR TITLE
Resolved #2748 - Remove GitHub User ID From Contributor Approval Email

### DIFF
--- a/cla-backend-go/v2/cla_manager/service.go
+++ b/cla-backend-go/v2/cla_manager/service.go
@@ -1213,10 +1213,6 @@ func getFormattedUserDetails(model *v1Models.User) string {
 		details = append(details, fmt.Sprintf("GitHub User Name: %s", model.GithubUsername))
 	}
 
-	if model.GithubID != "" {
-		details = append(details, fmt.Sprintf("GitHub ID: %s", model.GithubID))
-	}
-
 	if model.LfUsername != "" {
 		details = append(details, fmt.Sprintf("LF Login: %s", model.LfUsername))
 	}
@@ -1229,7 +1225,7 @@ func getFormattedUserDetails(model *v1Models.User) string {
 		details = append(details, fmt.Sprintf("Emails: %s", strings.Join(model.Emails, ", ")))
 	}
 
-	return strings.Join(details, ",")
+	return strings.Join(details, ", ")
 }
 
 // isSigned is a helper function to check if project/claGroup is signed


### PR DESCRIPTION
Resolved #2748 - Remove GitHub User ID From Contributor Approval Email Request

- Removed GitHub ID from email content
- Added horizontal spacing to comma-separated list

Signed-off-by: David Deal <dealako@gmail.com>