### PR TITLE
Resolved [#2814] CCLA Signature Signed On Date Not Showing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,12 +32,20 @@ If applicable, add screenshots to help explain your problem.
 Please complete the following information:
 
 * Environment:
+  - [ ] ALL
   - [ ] DEV
   - [ ] STAGING
   - [ ] PROD 
 * Browser:
   - [ ] Chrome/Brave
   - [ ] Firefox
+  - [ ] Opera
+  - [ ] Vivaldi
+  - [ ] LibreWolf
+  - [ ] SRware Iron
+  - [ ] Dissenter
+  - [ ] Slimjet
+  - [ ] Midori
   - [ ] Edge
   - [ ] Lynx
 * Version: v1.0.XX

--- a/cla-backend-go/signatures/converters.go
+++ b/cla-backend-go/signatures/converters.go
@@ -56,6 +56,13 @@ func (repo repository) buildProjectSignatureModels(ctx context.Context, results 
 			claType = utils.ClaTypeICLA
 		}
 
+		// Use the signedOn field if possible, for older signatures that are missing it, use the date created value as the default/fallback
+		signedOn := dbSignature.DateCreated
+		if dbSignature.SignedOn != "" {
+			signedOn = dbSignature.SignedOn
+		}
+		signedOn = utils.FormatTimeString(signedOn)
+
 		sig := &models.Signature{
 			SignatureID:                 dbSignature.SignatureID,
 			ClaType:                     claType,
@@ -81,7 +88,7 @@ func (repo repository) buildProjectSignatureModels(ctx context.Context, results 
 			UserName:                    dbSignature.UserName,
 			UserLFID:                    dbSignature.UserLFUsername,
 			UserGHID:                    dbSignature.UserGithubUsername,
-			SignedOn:                    dbSignature.SignedOn,
+			SignedOn:                    signedOn,
 			SignatoryName:               dbSignature.SignatoryName,
 			UserDocusignName:            dbSignature.UserDocusignName,
 			UserDocusignDateSigned:      dbSignature.UserDocusignDateSigned,

--- a/cla-backend-go/utils/utils.go
+++ b/cla-backend-go/utils/utils.go
@@ -12,6 +12,9 @@ import (
 	"time"
 	"unicode/utf8"
 
+	log "github.com/communitybridge/easycla/cla-backend-go/logging"
+	"github.com/sirupsen/logrus"
+
 	"github.com/gofrs/uuid"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -37,6 +40,22 @@ func FmtDuration(d time.Duration) string {
 
 // TimeToString returns time in the RFC3339 format
 func TimeToString(t time.Time) string {
+	return t.UTC().Format(time.RFC3339)
+}
+
+// FormatTimeString converts the time string into the "standard" RFC3339 format
+func FormatTimeString(timeStr string) string {
+	f := logrus.Fields{
+		"functionName": "utils.utils.FormatTimeString",
+		"timeStr":      timeStr,
+	}
+
+	t, err := ParseDateTime(timeStr)
+	if err != nil {
+		log.WithFields(f).Warnf("unable to convert the time string: %s into a standard form.", timeStr)
+		return timeStr
+	}
+
 	return t.UTC().Format(time.RFC3339)
 }
 


### PR DESCRIPTION
- Added/updated signedOn date logic to use docusign date if available,
  if missing, use the created date (generally close to the same value)

Signed-off-by: David Deal <dealako@gmail.com>