### PR TITLE
Resolved Foundation Query Issues

### DIFF
--- a/cla-backend-go/project/repository.go
+++ b/cla-backend-go/project/repository.go
@@ -306,8 +306,9 @@ func (repo *repo) GetClaGroupsByFoundationSFID(ctx context.Context, foundationSF
 		utils.XREQUESTID:  ctx.Value(utils.XREQUESTID),
 		"foundationSFID":  foundationSFID,
 		"loadRepoDetails": loadRepoDetails,
-		"tableName":       repo.claGroupTable}
-	log.WithFields(f).Debugf("loading project by foundation SFID")
+		"tableName":       repo.claGroupTable,
+	}
+	log.WithFields(f).Debugf("loading CLA Group by foundation SFID - using foundation_sfid field...")
 
 	// This is the key we want to match
 	condition := expression.Key("foundation_sfid").Equal(expression.Value(foundationSFID))

--- a/cla-backend-go/project/service.go
+++ b/cla-backend-go/project/service.go
@@ -341,7 +341,7 @@ func (s service) SignedAtFoundationLevel(ctx context.Context, foundationSFID str
 	if pcgErr != nil {
 		return false, pcgErr
 	}
-	log.WithFields(f).Debugf("loaded %d CLA Group entries", len(entries))
+	log.WithFields(f).Debugf("loaded %d CLA Group entries signed at foundation level...", len(entries))
 
 	// Check for number of claGroups for foundation
 	foundationLevelCLAGroup := false
@@ -352,6 +352,7 @@ func (s service) SignedAtFoundationLevel(ctx context.Context, foundationSFID str
 		}
 	}
 
+	log.WithFields(f).Debugf("returning %t for signed at foundation level for: %s", foundationLevelCLAGroup, foundationSFID)
 	return foundationLevelCLAGroup, nil
 }
 


### PR DESCRIPTION
- When searching by foundation, we need to first consult the Project CLA
Group Mapping table entries for the CLA Groups - then load each CLA
group. Previous logic was only looking at the CLA Group table foundation
SFID (v1) value.

Signed-off-by: David Deal <dealako@gmail.com>