### PR TITLE
Resolved #2816 Issue with Foundation Query and Unique CLA Groups

### DIFF
--- a/cla-backend-go/v2/cla_groups/helpers.go
+++ b/cla-backend-go/v2/cla_groups/helpers.go
@@ -680,3 +680,27 @@ func isFoundationIDInList(foundationSFID string, projectsSFIDs []string) bool {
 	}
 	return false
 }
+
+// getUniqueCLAGroupIDs logic to extract the unique
+func getUniqueCLAGroupIDs(projectCLAGroupMappings []*projects_cla_groups.ProjectClaGroup) []string {
+	// to ensure we get the distinct count
+	claGroupsMap := map[string]bool{}
+	for _, projectCLAGroupModel := range projectCLAGroupMappings {
+		// ensure that following goroutine gets a copy of projectSFID
+		projectCLAGroupClaGroupID := projectCLAGroupModel.ClaGroupID
+		// No need to re-process the same CLA group
+		if _, ok := claGroupsMap[projectCLAGroupClaGroupID]; ok {
+			continue
+		}
+
+		// Add entry into our map - so we know not to re-process this CLA Group
+		claGroupsMap[projectCLAGroupClaGroupID] = true
+	}
+
+	keys := make([]string, 0, len(claGroupsMap))
+	for k := range claGroupsMap {
+		keys = append(keys, k)
+	}
+
+	return keys
+}


### PR DESCRIPTION
- Resolved issue of looping over unique CLA Groups when querying for
foundations. Bug caused timeout/channel blocking due to a mismatch of
channels vs looping iterations.

Signed-off-by: David Deal <dealako@gmail.com>