### PR TITLE
[#2817] closing docraptor body is handled elsewhere

### DIFF
--- a/cla-backend-go/docraptor/client.go
+++ b/cla-backend-go/docraptor/client.go
@@ -72,12 +72,5 @@ func (dc Client) CreatePDF(html string, claType string) (io.ReadCloser, error) {
 		log.WithFields(f).WithError(err).Warn("problem with API call to docraptor")
 		return nil, err
 	}
-	defer func() {
-		closeErr := resp.Body.Close()
-		if closeErr != nil {
-			log.WithFields(f).WithError(closeErr).Warn("error closing response body")
-		}
-	}()
-
 	return resp.Body, nil
 }


### PR DESCRIPTION
closing docraptor body is handled elsewhere, doing it here breaks the code