### PR TITLE
[#2872] removing extra cla_group.updated event which is confusing for UI

### DIFF
--- a/cla-backend-go/v2/cla_groups/handlers.go
+++ b/cla-backend-go/v2/cla_groups/handlers.go
@@ -385,16 +385,6 @@ func Configure(api *operations.EasyclaAPI, service Service, v1ProjectService v1P
 				utils.ErrorResponseInternalServerErrorWithError(reqID, fmt.Sprintf("unable to unenroll projects for CLA Group ID: %s", params.ClaGroupID), err))
 		}
 
-		eventsService.LogEvent(&events.LogEventArgs{
-			EventType:     events.CLAGroupUpdated,
-			ClaGroupModel: cg,
-			LfUsername:    authUser.UserName,
-			EventData: &events.CLAGroupUpdatedEventData{
-				OldClaGroupName:        cg.ProjectName,
-				OldClaGroupDescription: cg.ProjectDescription,
-			},
-		})
-
 		return cla_group.NewUnenrollProjectsOK().WithXRequestID(reqID)
 	})
 


### PR DESCRIPTION
we already set log events for unenrolled project there's no need to do it for cla group since it's confusing on the UI

addresses ~[#2872]