### PR TITLE
Added cla-signature-query-default Feature Flag

### DIFF
--- a/cla-backend-go/config/config.go
+++ b/cla-backend-go/config/config.go
@@ -29,6 +29,11 @@ type Config struct {
 	// EnableCLAServiceForParent is a configuration flag to indicate if we should set the enable_services=[CLA] attribute on the parent project object in the project service when a child project is associated with a CLA group. This determines the v2 project console experience/behavior."
 	EnableCLAServiceForParent bool `json:"enable_cla_service_for_parent"`
 
+	// SignatureQueryDefault is a flag to indicate how a default signature query should return data - show only 'active' signatures or 'all' signatures when no other query signed/approved params are provided
+	SignatureQueryDefault string `json:"signature_query_default"`
+	// SignatureQueryDefaultValue the default value for the SignatureQueryDefault configuration value
+	SignatureQueryDefaultValue string `json:"signature_query_default_value"`
+
 	// SFDC
 
 	// GitHub

--- a/cla-backend-go/config/ssm.go
+++ b/cla-backend-go/config/ssm.go
@@ -45,6 +45,7 @@ func loadSSMConfig(awsSession *session.Session, stage string) Config { //nolint
 		"stage":        stage,
 	}
 	config := Config{}
+	config.SignatureQueryDefaultValue = "all"
 
 	ssmClient := ssm.New(awsSession)
 
@@ -94,6 +95,7 @@ func loadSSMConfig(awsSession *session.Session, stage string) Config { //nolint
 		fmt.Sprintf("cla-lfx-metrics-report-sqs-url-%s", stage),
 		fmt.Sprintf("cla-lfx-metrics-report-enabled-%s", stage),
 		fmt.Sprintf("cla-enable-services-for-parent-%s", stage),
+		fmt.Sprintf("cla-signature-query-default-%s", stage),
 		fmt.Sprintf("cla-platform-api-gw-%s", stage),
 	}
 
@@ -220,6 +222,12 @@ func loadSSMConfig(awsSession *session.Session, stage string) Config { //nolint
 				config.EnableCLAServiceForParent = false
 			} else {
 				config.EnableCLAServiceForParent = boolVal
+			}
+		case fmt.Sprintf("cla-signature-query-default-%s", stage):
+			if resp.value == "" {
+				config.SignatureQueryDefault = config.SignatureQueryDefaultValue
+			} else {
+				config.SignatureQueryDefault = resp.value
 			}
 		}
 	}

--- a/cla-backend-go/signatures/repository.go
+++ b/cla-backend-go/signatures/repository.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/communitybridge/easycla/cla-backend-go/config"
+
 	"github.com/LF-Engineering/lfx-kit/auth"
 	"github.com/sirupsen/logrus"
 
@@ -473,6 +475,13 @@ func (repo repository) GetIndividualSignature(ctx context.Context, claGroupID, u
 		filter = addConditionToFilter(filter, searchTermExpression, &filterAdded)
 	}
 
+	// If no query option was provided for approved and signed and our configuration default is to only show active signatures then we add the required query filters
+	if approved == nil && signed == nil && config.GetConfig().SignatureQueryDefault == utils.SignatureQueryDefaultActive {
+		filterAdded = true
+		filter = addConditionToFilter(filter, expression.Name("signature_approved").Equal(expression.Value(true)), &filterAdded)
+		filter = addConditionToFilter(filter, expression.Name("signature_signed").Equal(expression.Value(true)), &filterAdded)
+	}
+
 	builder := expression.NewBuilder().
 		WithKeyCondition(condition).
 		WithFilter(filter).
@@ -576,6 +585,13 @@ func (repo repository) GetCorporateSignature(ctx context.Context, claGroupID, co
 		log.WithFields(f).Debugf("adding signature_signed filter: %t", aws.BoolValue(signed))
 		searchTermExpression := expression.Name("signature_signed").Equal(expression.Value(aws.BoolValue(signed)))
 		filter = addConditionToFilter(filter, searchTermExpression, &filterAdded)
+	}
+
+	// If no query option was provided for approved and signed and our configuration default is to only show active signatures then we add the required query filters
+	if approved == nil && signed == nil && config.GetConfig().SignatureQueryDefault == utils.SignatureQueryDefaultActive {
+		filterAdded = true
+		filter = addConditionToFilter(filter, expression.Name("signature_approved").Equal(expression.Value(true)), &filterAdded)
+		filter = addConditionToFilter(filter, expression.Name("signature_signed").Equal(expression.Value(true)), &filterAdded)
 	}
 
 	builder := expression.NewBuilder().
@@ -805,6 +821,13 @@ func (repo repository) GetProjectSignatures(ctx context.Context, params signatur
 		filter = addConditionToFilter(filter, searchTermExpression, &filterAdded)
 	}
 
+	// If no query option was provided for approved and signed and our configuration default is to only show active signatures then we add the required query filters
+	if params.Approved == nil && params.Signed == nil && config.GetConfig().SignatureQueryDefault == utils.SignatureQueryDefaultActive {
+		filterAdded = true
+		filter = addConditionToFilter(filter, expression.Name("signature_approved").Equal(expression.Value(true)), &filterAdded)
+		filter = addConditionToFilter(filter, expression.Name("signature_signed").Equal(expression.Value(true)), &filterAdded)
+	}
+
 	if filterAdded {
 		builder = builder.WithFilter(filter)
 	}
@@ -1012,6 +1035,13 @@ func (repo repository) CreateProjectSummaryReport(ctx context.Context, params si
 		filter = addConditionToFilter(filter, searchTermExpression, &filterAdded)
 	}
 
+	// If no query option was provided for approved and signed and our configuration default is to only show active signatures then we add the required query filters
+	if params.Approved == nil && params.Signed == nil && config.GetConfig().SignatureQueryDefault == utils.SignatureQueryDefaultActive {
+		filterAdded = true
+		filter = addConditionToFilter(filter, expression.Name("signature_approved").Equal(expression.Value(true)), &filterAdded)
+		filter = addConditionToFilter(filter, expression.Name("signature_signed").Equal(expression.Value(true)), &filterAdded)
+	}
+
 	if len(params.Body) > 0 {
 		// expression.Name("Color").In(expression.Value("red"), expression.Value("green"), expression.Value("blue"))
 		var referenceIDExpressions []expression.OperandBuilder
@@ -1201,6 +1231,13 @@ func (repo repository) GetProjectCompanySignatures(ctx context.Context, companyI
 		log.WithFields(f).Debugf("adding signature_signed filter: %t", aws.BoolValue(signed))
 		searchTermExpression := expression.Name("signature_signed").Equal(expression.Value(aws.BoolValue(signed)))
 		filter = addConditionToFilter(filter, searchTermExpression, &filterAdded)
+	}
+
+	// If no query option was provided for approved and signed and our configuration default is to only show active signatures then we add the required query filters
+	if approved == nil && signed == nil && config.GetConfig().SignatureQueryDefault == utils.SignatureQueryDefaultActive {
+		filterAdded = true
+		filter = addConditionToFilter(filter, expression.Name("signature_approved").Equal(expression.Value(true)), &filterAdded)
+		filter = addConditionToFilter(filter, expression.Name("signature_signed").Equal(expression.Value(true)), &filterAdded)
 	}
 
 	limit := int64(10)
@@ -2919,6 +2956,13 @@ func (repo repository) GetClaGroupICLASignatures(ctx context.Context, claGroupID
 		log.WithFields(f).Debugf("adding signature_signed filter: %t", aws.BoolValue(signed))
 		searchTermExpression := expression.Name("signature_signed").Equal(expression.Value(aws.BoolValue(signed)))
 		filter = addConditionToFilter(filter, searchTermExpression, &filterAdded)
+	}
+
+	// If no query option was provided for approved and signed and our configuration default is to only show active signatures then we add the required query filters
+	if approved == nil && signed == nil && config.GetConfig().SignatureQueryDefault == utils.SignatureQueryDefaultActive {
+		filterAdded = true
+		filter = addConditionToFilter(filter, expression.Name("signature_approved").Equal(expression.Value(true)), &filterAdded)
+		filter = addConditionToFilter(filter, expression.Name("signature_signed").Equal(expression.Value(true)), &filterAdded)
 	}
 
 	if searchTerm != nil {

--- a/cla-backend-go/utils/constants.go
+++ b/cla-backend-go/utils/constants.go
@@ -167,3 +167,13 @@ const RemoveApprovals = "RemoveApprovals"
 
 //GitHubUsernameCriteria represents criteria based on GH username
 const GitHubUsernameCriteria = "GitHubUsername"
+
+// SignatureQueryDefaultAll the signature query default active value - A flag to indicate how a default signature
+// query should return data - show only 'active' signatures or 'all' signatures when no other query signed/approved
+// params are provided
+const SignatureQueryDefaultAll = "all"
+
+// SignatureQueryDefaultActive the signature query default active value - A flag to indicate how a default signature
+// query should return data - show only 'active' signatures or 'all' signatures when no other query signed/approved
+// params are provided
+const SignatureQueryDefaultActive = "active"


### PR DESCRIPTION
- Added cla-signature-query-default parameter - A flag to indicate how
a default signature query should return data - show only 'active'
signatures or 'all' signatures when no other query signed/approved
params are provided

Signed-off-by: David Deal <dealako@gmail.com>