### PR TITLE
Resolved PCC-968 - Return 409 Conflict when Duplicate CLA Name Occurs

### DIFF
--- a/cla-backend-go/swagger/cla.v2.yaml
+++ b/cla-backend-go/swagger/cla.v2.yaml
@@ -411,6 +411,8 @@ paths:
           $ref: '#/responses/forbidden'
         '404':
           $ref: '#/responses/not-found'
+        '409':
+          $ref: '#/responses/conflict'
         '500':
           $ref: '#/responses/internal-server-error'
       tags:

--- a/cla-backend-go/v2/cla_groups/handlers.go
+++ b/cla-backend-go/v2/cla_groups/handlers.go
@@ -164,6 +164,11 @@ func Configure(api *operations.EasyclaAPI, service Service, v1ProjectService v1P
 
 		claGroup, err := service.UpdateCLAGroup(ctx, authUser, claGroupModel, params.Body, utils.StringValue(params.XUSERNAME))
 		if err != nil {
+			// Return a 409 conflict if we have a duplicate name
+			if _, ok := err.(*utils.CLAGroupNameConflict); ok {
+				return cla_group.NewUpdateClaGroupConflict().WithXRequestID(reqID).WithPayload(
+					utils.ErrorResponseConflictWithError(reqID, err.Error(), err))
+			}
 			log.WithFields(f).WithError(err).Warn("unable to update the CLA Group Name and/or Description - update failed")
 			return cla_group.NewUpdateClaGroupBadRequest().WithXRequestID(reqID).WithPayload(
 				utils.ErrorResponseBadRequestWithError(reqID, fmt.Sprintf("unable to update CLA Group by ID: %s", params.ClaGroupID), err))


### PR DESCRIPTION
- Updated swagger spec to include 409 conflict response error
- Added logic to trap for conflict specific error and return 409

Signed-off-by: David Deal <dealako@gmail.com>