### PR TITLE
Revert "Bump urllib3 from 1.25.9 to 1.26.5 in /cla-backend"

### DIFF
--- a/cla-backend/requirements.txt
+++ b/cla-backend/requirements.txt
@@ -53,7 +53,7 @@ six==1.13.0
 soupsieve==1.9.5
 termcolor==1.1.0
 typed-ast==1.4.1
-urllib3==1.26.5
+urllib3==1.25.9
 vintage==0.4.1
 wcwidth==0.1.7
 Werkzeug==0.15.5


### PR DESCRIPTION
Reverts communitybridge/easycla#2972 - this change breaks the python build due to incompatible urllib3 versions.