### PR TITLE
Resolved Issues Raised by Project Service Swagger Model Updates

### DIFF
--- a/cla-backend-go/events/service.go
+++ b/cla-backend-go/events/service.go
@@ -255,11 +255,11 @@ func (s *service) loadSFProject(ctx context.Context, args *LogEventArgs) error {
 		args.ProjectName = project.Name
 
 		// Try to load and set the parent information
-		if project.Parent != "" {
-			log.WithFields(f).Debugf("loading salesforce project parent by ID: %s...", project.Parent)
-			parentProject, parentProjectErr := project_service.GetClient().GetProject(project.Parent)
+		if utils.StringValue(project.Parent) != "" {
+			log.WithFields(f).Debugf("loading salesforce project parent by ID: %s...", utils.StringValue(project.Parent))
+			parentProject, parentProjectErr := project_service.GetClient().GetProject(utils.StringValue(project.Parent))
 			if parentProjectErr != nil || parentProject == nil {
-				log.WithFields(f).Warnf("failed to load salesforce project parent by ID: %s", project.Parent)
+				log.WithFields(f).Warnf("failed to load salesforce project parent by ID: %s", utils.StringValue(project.Parent))
 				return nil
 			}
 			var parentProjectName, parentProjectID string
@@ -271,7 +271,7 @@ func (s *service) loadSFProject(ctx context.Context, args *LogEventArgs) error {
 				parentProjectID = project.ID
 			}
 			log.WithFields(f).Debugf("loaded salesforce project by parent ID: %s - resulting in ID: %s with name: %s",
-				project.Parent, parentProjectID, parentProjectName)
+				utils.StringValue(project.Parent), parentProjectID, parentProjectName)
 			args.ParentProjectSFID = parentProjectID
 			args.ParentProjectName = parentProjectName
 		} else if project.Foundation != nil {

--- a/cla-backend-go/tests/project_helpers_test.go
+++ b/cla-backend-go/tests/project_helpers_test.go
@@ -20,14 +20,14 @@ const (
 
 func TestIsProjectHasRootParentNoParent(t *testing.T) {
 	project := &models.ProjectOutputDetailed{}
-	project.Parent = ""
+	project.Parent = utils.StringRef("")
 	project.Foundation = nil
 	assert.True(t, utils.IsProjectHasRootParent(project), "Project Has Root Parent - Empty Parent")
 }
 
 func TestIsProjectHasRootParentLF(t *testing.T) {
 	project := &models.ProjectOutputDetailed{}
-	project.Parent = testProjectParentID
+	project.Parent = utils.StringRef(testProjectParentID)
 	project.Foundation = &models.Foundation{
 		ID:      testProjectID,
 		LogoURL: testProjectLogo,
@@ -38,7 +38,7 @@ func TestIsProjectHasRootParentLF(t *testing.T) {
 
 func TestIsProjectHasRootParentLFProjectsLLC(t *testing.T) {
 	project := &models.ProjectOutputDetailed{}
-	project.Parent = testProjectParentID
+	project.Parent = utils.StringRef(testProjectParentID)
 	project.Foundation = &models.Foundation{
 		ID:      testProjectID,
 		LogoURL: testProjectLogo,
@@ -49,7 +49,7 @@ func TestIsProjectHasRootParentLFProjectsLLC(t *testing.T) {
 
 func TestIsProjectHasRootParentNonLF(t *testing.T) {
 	project := &models.ProjectOutputDetailed{}
-	project.Parent = testProjectParentID
+	project.Parent = utils.StringRef(testProjectParentID)
 	project.Foundation = &models.Foundation{
 		ID:      testProjectID,
 		LogoURL: testProjectLogo,
@@ -60,7 +60,7 @@ func TestIsProjectHasRootParentNonLF(t *testing.T) {
 
 func TestIsStandaloneProject(t *testing.T) {
 	project := &models.ProjectOutputDetailed{}
-	project.Parent = ""
+	project.Parent = utils.StringRef("")
 	project.Foundation = nil
 	project.Projects = []*models.ProjectOutput{}
 	assert.True(t, utils.IsStandaloneProject(project), "Standalone Project with No Parent with No Children")
@@ -68,7 +68,7 @@ func TestIsStandaloneProject(t *testing.T) {
 
 func TestLFParent(t *testing.T) {
 	project := &models.ProjectOutputDetailed{}
-	project.Parent = testProjectParentID
+	project.Parent = utils.StringRef(testProjectParentID)
 	project.Foundation = &models.Foundation{
 		ID:      testProjectID,
 		LogoURL: testProjectLogo,
@@ -80,7 +80,7 @@ func TestLFParent(t *testing.T) {
 
 func TestLFProjectsLLCParent(t *testing.T) {
 	project := &models.ProjectOutputDetailed{}
-	project.Parent = testProjectParentID
+	project.Parent = utils.StringRef(testProjectParentID)
 	project.Foundation = &models.Foundation{
 		ID:      testProjectID,
 		LogoURL: testProjectLogo,
@@ -92,7 +92,7 @@ func TestLFProjectsLLCParent(t *testing.T) {
 
 func TestLFParentWithChildren(t *testing.T) {
 	project := &models.ProjectOutputDetailed{}
-	project.Parent = testProjectParentID
+	project.Parent = utils.StringRef(testProjectParentID)
 	project.Foundation = &models.Foundation{
 		ID:      testProjectID,
 		LogoURL: testProjectLogo,
@@ -104,7 +104,7 @@ func TestLFParentWithChildren(t *testing.T) {
 
 func TestLFProjectsLLCParentWithChildren(t *testing.T) {
 	project := &models.ProjectOutputDetailed{}
-	project.Parent = testProjectParentID
+	project.Parent = utils.StringRef(testProjectParentID)
 	project.Foundation = &models.Foundation{
 		ID:      testProjectID,
 		LogoURL: testProjectLogo,
@@ -140,7 +140,7 @@ func TestLFProjectsLLCParentWithChildren(t *testing.T) {
 
 func TestIsProjectHaveChildrenNoChildren(t *testing.T) {
 	project := &models.ProjectOutputDetailed{}
-	project.Parent = testProjectParentID
+	project.Parent = utils.StringRef(testProjectParentID)
 	project.Foundation = nil
 	project.Projects = []*models.ProjectOutput{}
 	assert.False(t, utils.IsProjectHaveChildren(project), "Project has no children")
@@ -148,7 +148,7 @@ func TestIsProjectHaveChildrenNoChildren(t *testing.T) {
 
 func TestIsProjectHaveChildrenWithChildren(t *testing.T) {
 	project := &models.ProjectOutputDetailed{}
-	project.Parent = testProjectParentID
+	project.Parent = utils.StringRef(testProjectParentID)
 	project.Foundation = nil
 	child := &models.ProjectOutput{
 		ProjectCommon:     models.ProjectCommon{},

--- a/cla-backend-go/utils/conversion.go
+++ b/cla-backend-go/utils/conversion.go
@@ -11,6 +11,11 @@ func StringValue(input *string) string {
 	return *input
 }
 
+// StringRef function convert string to string reference
+func StringRef(input string) *string {
+	return &input
+}
+
 // Int64Value function convert int64 pointer to string
 func Int64Value(input *int64) int64 {
 	if input == nil {

--- a/cla-backend-go/utils/project_helpers.go
+++ b/cla-backend-go/utils/project_helpers.go
@@ -7,13 +7,13 @@ import "github.com/communitybridge/easycla/cla-backend-go/v2/project-service/mod
 
 // IsProjectHasRootParent determines if the a given project has a root parent. A root parent is a parent that is empty parent or the parent is TLF or LFProjects
 func IsProjectHasRootParent(project *models.ProjectOutputDetailed) bool {
-	return project.Parent == "" || (project.Foundation != nil && (project.Foundation.Name == TheLinuxFoundation || project.Foundation.Name == LFProjectsLLC))
+	return StringValue(project.Parent) == "" || (project.Foundation != nil && (project.Foundation.Name == TheLinuxFoundation || project.Foundation.Name == LFProjectsLLC))
 }
 
 // IsStandaloneProject determines if a given project is a standalone project. A standalone project is a project with no parent or the parent is TLF/LFProjects and does not have any children
 func IsStandaloneProject(project *models.ProjectOutputDetailed) bool {
 	// standalone: No parent or parent is TLF/LFProjects....and no children
-	return (project.Parent == "" ||
+	return (StringValue(project.Parent) == "" ||
 		(project.Foundation != nil && (project.Foundation.Name == TheLinuxFoundation || project.Foundation.Name == LFProjectsLLC))) &&
 		len(project.Projects) == 0
 }

--- a/cla-backend-go/v2/cla_groups/handlers.go
+++ b/cla-backend-go/v2/cla_groups/handlers.go
@@ -306,15 +306,15 @@ func Configure(api *operations.EasyclaAPI, service Service, v1ProjectService v1P
 				}
 				var parentProject *v2ProjectServiceModels.ProjectOutputDetailed
 				// Handle the ONAP edge case
-				if project.Parent != "" {
-					parentProject, projectErr = psc.GetProject(project.Parent)
+				if utils.StringValue(project.Parent) != "" {
+					parentProject, projectErr = psc.GetProject(utils.StringValue(project.Parent))
 					if parentProject == nil || projectErr != nil {
-						msg := fmt.Sprintf("Failed to get parent: %s", project.Parent)
+						msg := fmt.Sprintf("Failed to get parent: %s", utils.StringValue(project.Parent))
 						log.WithFields(f).Warnf(msg)
 						return cla_group.NewEnrollProjectsBadRequest().WithXRequestID(reqID).WithPayload(utils.ErrorResponseBadRequest(reqID, msg))
 					}
 				}
-				if (project.Parent != "" && !utils.IsProjectCategory(project, parentProject)) || (utils.IsProjectHasRootParent(project) && project.ProjectType == utils.ProjectTypeProjectGroup) {
+				if (utils.StringValue(project.Parent) != "" && !utils.IsProjectCategory(project, parentProject)) || (utils.IsProjectHasRootParent(project) && project.ProjectType == utils.ProjectTypeProjectGroup) {
 					msg := fmt.Sprintf("Unable to enroll salesforce foundation project: %s in project level cla-group.", projectSFID)
 					return cla_group.NewEnrollProjectsBadRequest().WithXRequestID(reqID).WithPayload(utils.ErrorResponseBadRequest(reqID, msg))
 				}

--- a/cla-backend-go/v2/cla_groups/helpers.go
+++ b/cla-backend-go/v2/cla_groups/helpers.go
@@ -159,7 +159,7 @@ func (s *service) validateClaGroupInput(ctx context.Context, input *models.Creat
 
 	// Is our parent the LF project?
 	log.WithFields(f).Debugf("looking up LF parent project record...")
-	isLFParent, err := psc.IsTheLinuxFoundation(foundationProjectDetails.Parent)
+	isLFParent, err := psc.IsTheLinuxFoundation(utils.StringValue(foundationProjectDetails.Parent))
 	if err != nil {
 		log.WithFields(f).WithError(err).Warnf("validation failure - unable to lookup %s or %s project", utils.TheLinuxFoundation, utils.LFProjectsLLC)
 		return false, err
@@ -168,7 +168,7 @@ func (s *service) validateClaGroupInput(ctx context.Context, input *models.Creat
 	// If the foundation details in the platform project service indicates that this foundation has no parent or no
 	// children/sub-project... (stand alone project situation)
 	log.WithFields(f).Debug("checking to see if we have a standalone project...")
-	if (foundationProjectDetails.Parent == "" || isLFParent) && len(foundationProjectDetails.Projects) == 0 {
+	if (utils.StringValue(foundationProjectDetails.Parent) == "" || isLFParent) && len(foundationProjectDetails.Projects) == 0 {
 		log.WithFields(f).Debug("we have a standalone project...")
 		// Did the user actually pass in any projects?  If none - add the foundation ID to the list and return to
 		// indicate it is a "standalone project"
@@ -251,7 +251,7 @@ func (s *service) validateEnrollProjectsInput(ctx context.Context, foundationSFI
 
 		if projectTree != nil && projectTree.Parent != nil && (!isLFParent && (foundationProjectDetails.ProjectType == utils.ProjectTypeProjectGroup && projectDetails.ProjectType != utils.ProjectTypeProjectGroup)) {
 			msg := fmt.Sprintf("input validation failure - foundationSFID: %s , foundationType: %s , projectSFID: %s , projectType: %s ",
-				foundationProjectDetails.Parent, foundationProjectDetails.ProjectType, projectSFID, projectDetails.ProjectType)
+				utils.StringValue(foundationProjectDetails.Parent), foundationProjectDetails.ProjectType, projectSFID, projectDetails.ProjectType)
 			log.WithFields(f).Warnf(msg)
 			return fmt.Errorf(msg)
 		}
@@ -331,7 +331,7 @@ func (s *service) validateUnenrollProjectsInput(ctx context.Context, foundationS
 
 	// Is our parent the LF project?
 	log.WithFields(f).Debugf("looking up LF parent project record...")
-	isLFParent, err := psc.IsTheLinuxFoundation(foundationProjectDetails.Parent)
+	isLFParent, err := psc.IsTheLinuxFoundation(utils.StringValue(foundationProjectDetails.Parent))
 	if err != nil {
 		log.WithFields(f).WithError(err).Warnf("validation failure - unable to lookup %s or %s project", utils.TheLinuxFoundation, utils.LFProjectsLLC)
 		return err
@@ -343,13 +343,12 @@ func (s *service) validateUnenrollProjectsInput(ctx context.Context, foundationS
 			return err
 		}
 
-		if foundationProjectDetails.Parent != "" && (!isLFParent && (foundationProjectDetails.ProjectType == utils.ProjectTypeProjectGroup && projectDetails.ProjectType != utils.ProjectTypeProjectGroup)) {
+		if utils.StringValue(foundationProjectDetails.Parent) != "" && (!isLFParent && (foundationProjectDetails.ProjectType == utils.ProjectTypeProjectGroup && projectDetails.ProjectType != utils.ProjectTypeProjectGroup)) {
 			msg := fmt.Sprintf("input validation failure - foundationSFID: %s , foundationType: %s , projectSFID: %s , projectType: %s ",
-				foundationProjectDetails.Parent, foundationProjectDetails.ProjectType, projectSFID, projectDetails.ProjectType)
+				utils.StringValue(foundationProjectDetails.Parent), foundationProjectDetails.ProjectType, projectSFID, projectDetails.ProjectType)
 			log.WithFields(f).Warnf(msg)
 			return fmt.Errorf(msg)
 		}
-
 	}
 
 	// Check to see if all the provided enrolled projects are part of this foundation

--- a/cla-backend-go/v2/cla_groups/service.go
+++ b/cla-backend-go/v2/cla_groups/service.go
@@ -386,7 +386,7 @@ func (s *service) ListClaGroupsForFoundationOrProject(ctx context.Context, proje
 	var parentDetails *v2ProjectServiceModels.ProjectOutputDetailed
 	var parentDetailErr error
 
-	if sfProjectModelDetails.Parent != "" {
+	if utils.StringValue(sfProjectModelDetails.Parent) != "" {
 		var parentSFID string
 		// Use utility function that considers TLF and LF Projects, LLC
 		parentSFID, parentDetailErr = v2ProjectService.GetClient().GetParentProject(projectOrFoundationSFID)

--- a/cla-backend-go/v2/github_organizations/service.go
+++ b/cla-backend-go/v2/github_organizations/service.go
@@ -102,7 +102,7 @@ func (s service) GetGithubOrganizations(ctx context.Context, projectSFID string)
 	if utils.IsProjectHasRootParent(projectServiceRecord) {
 		parentProjectSFID = projectSFID
 	} else {
-		parentProjectSFID = projectServiceRecord.Parent
+		parentProjectSFID = utils.StringValue(projectServiceRecord.Parent)
 	}
 	f["parentProjectSFID"] = parentProjectSFID
 	log.WithFields(f).Debug("located parentProjectID...")
@@ -290,11 +290,11 @@ func (s service) AddGithubOrganization(ctx context.Context, projectSFID string, 
 	}
 
 	var parentProjectSFID string
-	if project.Parent == "" || (project.Foundation != nil &&
+	if utils.StringValue(project.Parent) == "" || (project.Foundation != nil &&
 		(project.Foundation.Name == utils.TheLinuxFoundation || project.Foundation.Name == utils.LFProjectsLLC)) {
 		parentProjectSFID = projectSFID
 	} else {
-		parentProjectSFID = project.Parent
+		parentProjectSFID = utils.StringValue(project.Parent)
 	}
 	f["parentProjectSFID"] = parentProjectSFID
 	log.WithFields(f).Debug("located parentProjectID...")

--- a/cla-backend-go/v2/project-service/client.go
+++ b/cla-backend-go/v2/project-service/client.go
@@ -145,7 +145,7 @@ func (pmm *Client) GetParentProject(projectSFID string) (string, error) {
 	existingModel, exists := projectServiceModels[projectSFID]
 	if exists {
 		log.WithFields(f).Debugf("cache hit - cache size: %d", len(projectServiceModels))
-		return existingModel.Parent, nil
+		return utils.StringValue(existingModel.Parent), nil
 	}
 	log.WithFields(f).Debugf("cache miss - cache size: %d", len(projectServiceModels))
 
@@ -161,14 +161,14 @@ func (pmm *Client) GetParentProject(projectSFID string) (string, error) {
 	log.WithFields(f).Debugf("added project model to cache - cache size: %d", len(projectServiceModels))
 
 	// Do they have a parent?
-	if projectModel.Parent == "" || (projectModel.Foundation != nil &&
+	if utils.StringValue(projectModel.Parent) == "" || (projectModel.Foundation != nil &&
 		(projectModel.Foundation.Name == utils.TheLinuxFoundation || projectModel.Foundation.Name == utils.LFProjectsLLC)) {
 		log.WithFields(f).Debugf("no parent for projectSFID or %s or %s is the parent...", utils.TheLinuxFoundation, utils.LFProjectsLLC)
 		return projectSFID, nil
 	}
 
-	log.WithFields(f).Debugf("returning parent projectSFID: %s", projectModel.Parent)
-	return projectModel.Parent, nil
+	log.WithFields(f).Debugf("returning parent projectSFID: %s", utils.StringValue(projectModel.Parent))
+	return utils.StringValue(projectModel.Parent), nil
 }
 
 // GetParentProjectModel returns the parent project model if there is a parent, otherwise returns nil
@@ -190,20 +190,20 @@ func (pmm *Client) GetParentProjectModel(projectSFID string) (*models.ProjectOut
 		log.WithFields(f).Debugf("cache hit - cache size: %d", len(projectServiceModels))
 
 		// Parent in the cache?
-		existingParentModel, exists = projectServiceModels[existingModel.Parent]
+		existingParentModel, exists = projectServiceModels[utils.StringValue(existingModel.Parent)]
 		if exists {
 			return existingParentModel, nil
 		}
 
 		// Parent project not in the cache - lookup
-		parentProjectModel, err := pmm.GetProject(existingModel.Parent)
+		parentProjectModel, err := pmm.GetProject(utils.StringValue(existingModel.Parent))
 		if err != nil {
-			log.WithFields(f).WithError(err).Warnf("unable to lookup parentProjectModel projectSFID: '%s'", existingModel.Parent)
+			log.WithFields(f).WithError(err).Warnf("unable to lookup parentProjectModel projectSFID: '%s'", utils.StringValue(existingModel.Parent))
 			return nil, err
 		}
 
 		// Update our cache for next time
-		projectServiceModels[existingModel.Parent] = parentProjectModel
+		projectServiceModels[utils.StringValue(existingModel.Parent)] = parentProjectModel
 		log.WithFields(f).Debugf("added project model to cache - cache size: %d", len(projectServiceModels))
 
 		return parentProjectModel, nil
@@ -221,27 +221,27 @@ func (pmm *Client) GetParentProjectModel(projectSFID string) (*models.ProjectOut
 	log.WithFields(f).Debugf("added project model to cache - cache size: %d", len(projectServiceModels))
 
 	// Do they have a parent?
-	if projectModel.Parent == "" || (projectModel.Foundation != nil &&
+	if utils.StringValue(projectModel.Parent) == "" || (projectModel.Foundation != nil &&
 		(projectModel.Foundation.Name == utils.TheLinuxFoundation || projectModel.Foundation.Name == utils.LFProjectsLLC)) {
 		log.WithFields(f).Debugf("no parent for projectSFID or %s or %s is the parent...", utils.TheLinuxFoundation, utils.LFProjectsLLC)
 		return nil, nil
 	}
 
 	// Parent in the cache?
-	existingParentModel, exists = projectServiceModels[projectModel.Parent]
+	existingParentModel, exists = projectServiceModels[utils.StringValue(projectModel.Parent)]
 	if exists {
 		return existingParentModel, nil
 	}
 
 	// Parent project not in the cache - lookup
-	parentProjectModel, err := pmm.GetProject(projectModel.Parent)
+	parentProjectModel, err := pmm.GetProject(utils.StringValue(projectModel.Parent))
 	if err != nil {
-		log.WithFields(f).WithError(err).Warnf("unable to lookup parentProjectModel projectSFID: '%s'", projectModel.Parent)
+		log.WithFields(f).WithError(err).Warnf("unable to lookup parentProjectModel projectSFID: '%s'", utils.StringValue(projectModel.Parent))
 		return nil, err
 	}
 
 	// Update our cache for next time
-	projectServiceModels[existingModel.Parent] = parentProjectModel
+	projectServiceModels[utils.StringValue(existingModel.Parent)] = parentProjectModel
 	log.WithFields(f).Debugf("added project model to cache - cache size: %d", len(projectServiceModels))
 
 	return parentProjectModel, nil
@@ -286,13 +286,13 @@ func (pmm *Client) IsParentTheLinuxFoundation(projectSFID string) (bool, error) 
 		return false, err
 	}
 
-	if projectModel.Parent == "" {
+	if utils.StringValue(projectModel.Parent) == "" {
 		return false, nil
 	}
 
-	parentProjectModel, err := pmm.GetProject(projectModel.Parent)
+	parentProjectModel, err := pmm.GetProject(utils.StringValue(projectModel.Parent))
 	if err != nil {
-		log.WithFields(f).Warnf("unable to lookup parent project by ID: %s error: %+v", projectModel.Parent, err)
+		log.WithFields(f).Warnf("unable to lookup parent project by ID: %s error: %+v", utils.StringValue(projectModel.Parent), err)
 		return false, err
 	}
 

--- a/cla-backend-go/v2/project/handlers.go
+++ b/cla-backend-go/v2/project/handlers.go
@@ -316,10 +316,10 @@ func Configure(api *operations.EasyclaAPI, service v1Project.Service, v2Service 
 
 		// Lookup the parent info, if it's available
 		var parentName string
-		if sfProject.Parent != "" {
-			sfParentProject, err := psc.GetProject(sfProject.Parent)
+		if utils.StringValue(sfProject.Parent) != "" {
+			sfParentProject, err := psc.GetProject(utils.StringValue(sfProject.Parent))
 			if err != nil {
-				log.WithFields(f).WithError(err).Warnf("unable to load parant project by ID: %s", sfProject.Parent)
+				log.WithFields(f).WithError(err).Warnf("unable to load parant project by ID: %s", utils.StringValue(sfProject.Parent))
 			}
 
 			if sfParentProject != nil {
@@ -334,18 +334,18 @@ func Configure(api *operations.EasyclaAPI, service v1Project.Service, v2Service 
 
 func buildSFProjectSummary(sfProject *v2ProjectServiceModels.ProjectOutputDetailed, parentName string) *models.SfProjectSummary {
 	return &models.SfProjectSummary{
-		EntityName:  sfProject.EntityName,
+		EntityName:  utils.StringValue(sfProject.EntityName),
 		EntityType:  sfProject.EntityType,
 		Funding:     sfProject.Funding,
 		ID:          sfProject.ID,
 		LfSupported: sfProject.LFSponsored,
 		Name:        sfProject.Name,
-		ParentID:    sfProject.Parent,
+		ParentID:    utils.StringValue(sfProject.Parent),
 		ParentName:  parentName,
 		Slug:        sfProject.Slug,
 		Status:      sfProject.Status,
 		Type:        sfProject.Type,
-		IsStandalone: (sfProject.Type != utils.ProjectTypeProjectGroup) && (sfProject.Parent == "" || (sfProject.Foundation != nil &&
+		IsStandalone: (sfProject.Type != utils.ProjectTypeProjectGroup) && (utils.StringValue(sfProject.Parent) == "" || (sfProject.Foundation != nil &&
 			(sfProject.Foundation.Name == utils.TheLinuxFoundation || sfProject.Foundation.Name == utils.LFProjectsLLC))),
 	}
 }

--- a/cla-backend-go/v2/repositories/service.go
+++ b/cla-backend-go/v2/repositories/service.go
@@ -90,11 +90,11 @@ func (s *service) AddGithubRepositories(ctx context.Context, projectSFID string,
 	}
 
 	var parentProjectSFID string
-	if project.Parent == "" || (project.Foundation != nil &&
+	if utils.StringValue(project.Parent) == "" || (project.Foundation != nil &&
 		(project.Foundation.Name == utils.TheLinuxFoundation || project.Foundation.Name == utils.LFProjectsLLC)) {
 		parentProjectSFID = projectSFID
 	} else {
-		parentProjectSFID = project.Parent
+		parentProjectSFID = utils.StringValue(project.Parent)
 	}
 
 	allMappings, err := s.projectsClaGroupsRepo.GetProjectsIdsForClaGroup(ctx, aws.StringValue(input.ClaGroupID))
@@ -252,7 +252,7 @@ func (s *service) ListProjectRepositories(ctx context.Context, projectSFID strin
 		return nil, err
 	}
 	f["projectName"] = projectModel.Name
-	if projectModel.Parent != "" {
+	if utils.StringValue(projectModel.Parent) != "" {
 		f["projectParentSFID"] = projectModel.Parent
 	}
 	log.WithFields(f).Debug("loaded project from the project service")

--- a/cla-backend-go/v2/sign/service.go
+++ b/cla-backend-go/v2/sign/service.go
@@ -173,7 +173,7 @@ func (s *service) RequestCorporateSignature(ctx context.Context, lfUsername stri
 	}
 
 	var claGroupID string
-	if project.Parent == "" || (project.Foundation != nil &&
+	if utils.StringValue(project.Parent) == "" || (project.Foundation != nil &&
 		(project.Foundation.Name == utils.TheLinuxFoundation || project.Foundation.Name == utils.LFProjectsLLC)) {
 		// this is root project
 		cgmlist, perr := s.projectClaGroupsRepo.GetProjectsIdsForFoundation(ctx, utils.StringValue(input.ProjectSfid))


### PR DESCRIPTION
- project.Parent and project.EntityName was changed to optional, making
the generated type to change from string to *string. Updated logic that
reviews this field and dereferences the value as needed.

Signed-off-by: David Deal <dealako@gmail.com>