### PR TITLE
Project Service - Use Foundation ID for Parent

### DIFF
--- a/cla-backend-go/events/service.go
+++ b/cla-backend-go/events/service.go
@@ -255,11 +255,11 @@ func (s *service) loadSFProject(ctx context.Context, args *LogEventArgs) error {
 		args.ProjectName = project.Name
 
 		// Try to load and set the parent information
-		if utils.StringValue(project.Parent) != "" {
-			log.WithFields(f).Debugf("loading salesforce project parent by ID: %s...", utils.StringValue(project.Parent))
-			parentProject, parentProjectErr := project_service.GetClient().GetProject(utils.StringValue(project.Parent))
+		if project.Foundation != nil && project.Foundation.ID != "" {
+			log.WithFields(f).Debugf("loading salesforce project parent by ID: %s...", project.Foundation.ID)
+			parentProject, parentProjectErr := project_service.GetClient().GetProject(project.Foundation.ID)
 			if parentProjectErr != nil || parentProject == nil {
-				log.WithFields(f).Warnf("failed to load salesforce project parent by ID: %s", utils.StringValue(project.Parent))
+				log.WithFields(f).Warnf("failed to load salesforce project parent by ID: %s", project.Foundation.ID)
 				return nil
 			}
 			var parentProjectName, parentProjectID string
@@ -271,7 +271,7 @@ func (s *service) loadSFProject(ctx context.Context, args *LogEventArgs) error {
 				parentProjectID = project.ID
 			}
 			log.WithFields(f).Debugf("loaded salesforce project by parent ID: %s - resulting in ID: %s with name: %s",
-				utils.StringValue(project.Parent), parentProjectID, parentProjectName)
+				project.Foundation.ID, parentProjectID, parentProjectName)
 			args.ParentProjectSFID = parentProjectID
 			args.ParentProjectName = parentProjectName
 		} else if project.Foundation != nil {
@@ -293,7 +293,7 @@ func (s *service) loadLFUser(ctx context.Context, args *LogEventArgs) error {
 	}
 
 	if args == nil {
-		return errors.New(("unable to load lf user data - args is nil"))
+		return errors.New("unable to load lf user data - args is nil")
 	}
 
 	if args.LfUsername != "" {

--- a/cla-backend-go/tests/project_helpers_test.go
+++ b/cla-backend-go/tests/project_helpers_test.go
@@ -13,21 +13,18 @@ import (
 )
 
 const (
-	testProjectParentID = "abc1234"
-	testProjectID       = "def13456"
-	testProjectLogo     = "testlogurl.com"
+	testProjectID   = "def13456"
+	testProjectLogo = "testlogurl.com"
 )
 
 func TestIsProjectHasRootParentNoParent(t *testing.T) {
 	project := &models.ProjectOutputDetailed{}
-	project.Parent = utils.StringRef("")
 	project.Foundation = nil
 	assert.True(t, utils.IsProjectHasRootParent(project), "Project Has Root Parent - Empty Parent")
 }
 
 func TestIsProjectHasRootParentLF(t *testing.T) {
 	project := &models.ProjectOutputDetailed{}
-	project.Parent = utils.StringRef(testProjectParentID)
 	project.Foundation = &models.Foundation{
 		ID:      testProjectID,
 		LogoURL: testProjectLogo,
@@ -38,7 +35,6 @@ func TestIsProjectHasRootParentLF(t *testing.T) {
 
 func TestIsProjectHasRootParentLFProjectsLLC(t *testing.T) {
 	project := &models.ProjectOutputDetailed{}
-	project.Parent = utils.StringRef(testProjectParentID)
 	project.Foundation = &models.Foundation{
 		ID:      testProjectID,
 		LogoURL: testProjectLogo,
@@ -49,7 +45,6 @@ func TestIsProjectHasRootParentLFProjectsLLC(t *testing.T) {
 
 func TestIsProjectHasRootParentNonLF(t *testing.T) {
 	project := &models.ProjectOutputDetailed{}
-	project.Parent = utils.StringRef(testProjectParentID)
 	project.Foundation = &models.Foundation{
 		ID:      testProjectID,
 		LogoURL: testProjectLogo,
@@ -60,7 +55,6 @@ func TestIsProjectHasRootParentNonLF(t *testing.T) {
 
 func TestIsStandaloneProject(t *testing.T) {
 	project := &models.ProjectOutputDetailed{}
-	project.Parent = utils.StringRef("")
 	project.Foundation = nil
 	project.Projects = []*models.ProjectOutput{}
 	assert.True(t, utils.IsStandaloneProject(project), "Standalone Project with No Parent with No Children")
@@ -68,7 +62,6 @@ func TestIsStandaloneProject(t *testing.T) {
 
 func TestLFParent(t *testing.T) {
 	project := &models.ProjectOutputDetailed{}
-	project.Parent = utils.StringRef(testProjectParentID)
 	project.Foundation = &models.Foundation{
 		ID:      testProjectID,
 		LogoURL: testProjectLogo,
@@ -80,7 +73,6 @@ func TestLFParent(t *testing.T) {
 
 func TestLFProjectsLLCParent(t *testing.T) {
 	project := &models.ProjectOutputDetailed{}
-	project.Parent = utils.StringRef(testProjectParentID)
 	project.Foundation = &models.Foundation{
 		ID:      testProjectID,
 		LogoURL: testProjectLogo,
@@ -92,7 +84,6 @@ func TestLFProjectsLLCParent(t *testing.T) {
 
 func TestLFParentWithChildren(t *testing.T) {
 	project := &models.ProjectOutputDetailed{}
-	project.Parent = utils.StringRef(testProjectParentID)
 	project.Foundation = &models.Foundation{
 		ID:      testProjectID,
 		LogoURL: testProjectLogo,
@@ -104,7 +95,6 @@ func TestLFParentWithChildren(t *testing.T) {
 
 func TestLFProjectsLLCParentWithChildren(t *testing.T) {
 	project := &models.ProjectOutputDetailed{}
-	project.Parent = utils.StringRef(testProjectParentID)
 	project.Foundation = &models.Foundation{
 		ID:      testProjectID,
 		LogoURL: testProjectLogo,
@@ -140,7 +130,6 @@ func TestLFProjectsLLCParentWithChildren(t *testing.T) {
 
 func TestIsProjectHaveChildrenNoChildren(t *testing.T) {
 	project := &models.ProjectOutputDetailed{}
-	project.Parent = utils.StringRef(testProjectParentID)
 	project.Foundation = nil
 	project.Projects = []*models.ProjectOutput{}
 	assert.False(t, utils.IsProjectHaveChildren(project), "Project has no children")
@@ -148,7 +137,6 @@ func TestIsProjectHaveChildrenNoChildren(t *testing.T) {
 
 func TestIsProjectHaveChildrenWithChildren(t *testing.T) {
 	project := &models.ProjectOutputDetailed{}
-	project.Parent = utils.StringRef(testProjectParentID)
 	project.Foundation = nil
 	child := &models.ProjectOutput{
 		ProjectCommon:     models.ProjectCommon{},

--- a/cla-backend-go/utils/project_helpers.go
+++ b/cla-backend-go/utils/project_helpers.go
@@ -5,15 +5,28 @@ package utils
 
 import "github.com/communitybridge/easycla/cla-backend-go/v2/project-service/models"
 
+// GetProjectParentSFID returns the project parent SFID if available, otherwise returns empty string
+func GetProjectParentSFID(project *models.ProjectOutputDetailed) string {
+	if project == nil || project.Foundation == nil || project.Foundation.ID == "" {
+		return ""
+	}
+	return project.Foundation.ID
+}
+
+// IsProjectHaveParent returns true if the specified project has a parent
+func IsProjectHaveParent(project *models.ProjectOutputDetailed) bool {
+	return project != nil && project.Foundation != nil && project.Foundation.ID != "" && project.Foundation.Name != ""
+}
+
 // IsProjectHasRootParent determines if the a given project has a root parent. A root parent is a parent that is empty parent or the parent is TLF or LFProjects
 func IsProjectHasRootParent(project *models.ProjectOutputDetailed) bool {
-	return StringValue(project.Parent) == "" || (project.Foundation != nil && (project.Foundation.Name == TheLinuxFoundation || project.Foundation.Name == LFProjectsLLC))
+	return project.Foundation == nil || (project.Foundation != nil && project.Foundation.ID != "" && (project.Foundation.Name == TheLinuxFoundation || project.Foundation.Name == LFProjectsLLC))
 }
 
 // IsStandaloneProject determines if a given project is a standalone project. A standalone project is a project with no parent or the parent is TLF/LFProjects and does not have any children
 func IsStandaloneProject(project *models.ProjectOutputDetailed) bool {
 	// standalone: No parent or parent is TLF/LFProjects....and no children
-	return (StringValue(project.Parent) == "" ||
+	return (project.Foundation == nil ||
 		(project.Foundation != nil && (project.Foundation.Name == TheLinuxFoundation || project.Foundation.Name == LFProjectsLLC))) &&
 		len(project.Projects) == 0
 }

--- a/cla-backend-go/v2/cla_groups/handlers.go
+++ b/cla-backend-go/v2/cla_groups/handlers.go
@@ -308,15 +308,15 @@ func Configure(api *operations.EasyclaAPI, service Service, v1ProjectService v1P
 				}
 				var parentProject *v2ProjectServiceModels.ProjectOutputDetailed
 				// Handle the ONAP edge case
-				if utils.StringValue(project.Parent) != "" {
-					parentProject, projectErr = psc.GetProject(utils.StringValue(project.Parent))
+				if utils.IsProjectHaveParent(project) {
+					parentProject, projectErr = psc.GetProject(utils.GetProjectParentSFID(project))
 					if parentProject == nil || projectErr != nil {
-						msg := fmt.Sprintf("Failed to get parent: %s", utils.StringValue(project.Parent))
+						msg := fmt.Sprintf("Failed to get parent: %s", utils.GetProjectParentSFID(project))
 						log.WithFields(f).Warnf(msg)
 						return cla_group.NewEnrollProjectsBadRequest().WithXRequestID(reqID).WithPayload(utils.ErrorResponseBadRequest(reqID, msg))
 					}
 				}
-				if (utils.StringValue(project.Parent) != "" && !utils.IsProjectCategory(project, parentProject)) || (utils.IsProjectHasRootParent(project) && project.ProjectType == utils.ProjectTypeProjectGroup) {
+				if (utils.IsProjectHaveParent(project) && !utils.IsProjectCategory(project, parentProject)) || (utils.IsProjectHasRootParent(project) && project.ProjectType == utils.ProjectTypeProjectGroup) {
 					msg := fmt.Sprintf("Unable to enroll salesforce foundation project: %s in project level cla-group.", projectSFID)
 					return cla_group.NewEnrollProjectsBadRequest().WithXRequestID(reqID).WithPayload(utils.ErrorResponseBadRequest(reqID, msg))
 				}
@@ -424,9 +424,9 @@ func Configure(api *operations.EasyclaAPI, service Service, v1ProjectService v1P
 		log.WithFields(f).Debug("found project - evaluating parent...")
 		var projectSFIDs []string
 		// Add the foundation ID, if available
-		if project.Foundation != nil && project.Foundation.ID != "" {
-			log.WithFields(f).Debugf("parent project - found %s - adding to list of project IDs...", project.Foundation.ID)
-			projectSFIDs = append(projectSFIDs, project.Foundation.ID)
+		if utils.IsProjectHaveParent(project) {
+			log.WithFields(f).Debugf("parent project - found %s - adding to list of project IDs...", utils.GetProjectParentSFID(project))
+			projectSFIDs = append(projectSFIDs, utils.GetProjectParentSFID(project))
 		}
 		log.WithFields(f).Debug("project - adding to list of project IDs...")
 		projectSFIDs = append(projectSFIDs, project.ID)

--- a/cla-backend-go/v2/cla_groups/service.go
+++ b/cla-backend-go/v2/cla_groups/service.go
@@ -386,7 +386,8 @@ func (s *service) ListClaGroupsForFoundationOrProject(ctx context.Context, proje
 	var parentDetails *v2ProjectServiceModels.ProjectOutputDetailed
 	var parentDetailErr error
 
-	if utils.StringValue(sfProjectModelDetails.Parent) != "" {
+	// If we have a parent...
+	if utils.IsProjectHaveParent(sfProjectModelDetails) {
 		var parentSFID string
 		// Use utility function that considers TLF and LF Projects, LLC
 		parentSFID, parentDetailErr = v2ProjectService.GetClient().GetParentProject(projectOrFoundationSFID)
@@ -646,9 +647,9 @@ func (s *service) appendCLAGroupsForProject(ctx context.Context, f logrus.Fields
 	// Since this is a project and not a foundation, we'll want to set he parent foundation ID and name (which is
 	// our parent in this case)
 	var foundationID, foundationName string
-	if sfProjectModelDetails.ProjectOutput.Foundation != nil {
-		foundationID = sfProjectModelDetails.ProjectOutput.Foundation.ID
-		foundationName = sfProjectModelDetails.ProjectOutput.Foundation.Name
+	if utils.IsProjectHaveParent(sfProjectModelDetails) {
+		foundationID = sfProjectModelDetails.Foundation.ID
+		foundationName = sfProjectModelDetails.Foundation.Name
 		log.WithFields(f).Debugf("using parent foundation ID: %s and name: %s", foundationID, foundationName)
 	} else {
 		// Project with no parent - must be a standalone - use our ID and Name as the foundation

--- a/cla-backend-go/v2/company/service.go
+++ b/cla-backend-go/v2/company/service.go
@@ -1144,6 +1144,9 @@ func (s *service) GetCompanyCLAGroupManagers(ctx context.Context, companyID, cla
 
 func v2ProjectToMap(projectDetails *v2ProjectServiceModels.ProjectOutputDetailed) (map[string]*v2ProjectServiceModels.ProjectOutput, error) {
 	epmap := make(map[string]*v2ProjectServiceModels.ProjectOutput) // key project_sfid
+	if projectDetails == nil {
+		return epmap, nil
+	}
 	var pr v2ProjectServiceModels.ProjectOutput
 	err := copier.Copy(&pr, projectDetails)
 	if err != nil {
@@ -1212,7 +1215,7 @@ func (s *service) getCLAGroupsUnderProjectOrFoundation(ctx context.Context, proj
 			log.WithFields(f).WithError(err).Warnf("unable to get project IDs for CLA Group: %s", projectMapping.ClaGroupID)
 			return nil, err
 		}
-		if len(allProjectMapping) > 1 {
+		if len(allProjectMapping) > 1 && projectDetails.Foundation != nil && projectDetails.Foundation.ID != "" {
 			// reload data in projectDetails for all projects of foundation
 			projectDetails, err = psc.GetProject(projectDetails.Foundation.ID)
 			if err != nil {

--- a/cla-backend-go/v2/github_organizations/service.go
+++ b/cla-backend-go/v2/github_organizations/service.go
@@ -92,18 +92,19 @@ func (s service) GetGithubOrganizations(ctx context.Context, projectSFID string)
 
 	psc := v2ProjectService.GetClient()
 	log.WithFields(f).Debug("loading project details from the project service...")
-	projectServiceRecord, err := psc.GetProject(projectSFID)
+	project, err := psc.GetProject(projectSFID)
 	if err != nil {
 		log.WithFields(f).WithError(err).Warn("problem loading project details from the project service")
 		return nil, err
 	}
 
 	var parentProjectSFID string
-	if utils.IsProjectHasRootParent(projectServiceRecord) {
+	if !utils.IsProjectHaveParent(project) || utils.IsProjectHasRootParent(project) || utils.GetProjectParentSFID(project) == "" {
 		parentProjectSFID = projectSFID
 	} else {
-		parentProjectSFID = utils.StringValue(projectServiceRecord.Parent)
+		parentProjectSFID = utils.GetProjectParentSFID(project)
 	}
+
 	f["parentProjectSFID"] = parentProjectSFID
 	log.WithFields(f).Debug("located parentProjectID...")
 
@@ -290,12 +291,12 @@ func (s service) AddGithubOrganization(ctx context.Context, projectSFID string, 
 	}
 
 	var parentProjectSFID string
-	if utils.StringValue(project.Parent) == "" || (project.Foundation != nil &&
-		(project.Foundation.Name == utils.TheLinuxFoundation || project.Foundation.Name == utils.LFProjectsLLC)) {
+	if !utils.IsProjectHaveParent(project) || utils.IsProjectHasRootParent(project) || utils.GetProjectParentSFID(project) == "" {
 		parentProjectSFID = projectSFID
 	} else {
-		parentProjectSFID = utils.StringValue(project.Parent)
+		parentProjectSFID = utils.GetProjectParentSFID(project)
 	}
+
 	f["parentProjectSFID"] = parentProjectSFID
 	log.WithFields(f).Debug("located parentProjectID...")
 

--- a/cla-backend-go/v2/project/handlers.go
+++ b/cla-backend-go/v2/project/handlers.go
@@ -317,10 +317,10 @@ func Configure(api *operations.EasyclaAPI, service v1Project.Service, v2Service 
 
 		// Lookup the parent info, if it's available
 		var parentName string
-		if utils.StringValue(sfProject.Parent) != "" {
-			sfParentProject, err := psc.GetProject(utils.StringValue(sfProject.Parent))
+		if utils.IsProjectHaveParent(sfProject) {
+			sfParentProject, err := psc.GetProject(utils.GetProjectParentSFID(sfProject))
 			if err != nil {
-				log.WithFields(f).WithError(err).Warnf("unable to load parant project by ID: %s", utils.StringValue(sfProject.Parent))
+				log.WithFields(f).WithError(err).Warnf("unable to load parant project by ID: %s", utils.GetProjectParentSFID(sfProject))
 			}
 
 			if sfParentProject != nil {
@@ -335,18 +335,17 @@ func Configure(api *operations.EasyclaAPI, service v1Project.Service, v2Service 
 
 func buildSFProjectSummary(sfProject *v2ProjectServiceModels.ProjectOutputDetailed, parentName string) *models.SfProjectSummary {
 	return &models.SfProjectSummary{
-		EntityName:  utils.StringValue(sfProject.EntityName),
-		EntityType:  sfProject.EntityType,
-		Funding:     sfProject.Funding,
-		ID:          sfProject.ID,
-		LfSupported: sfProject.LFSponsored,
-		Name:        sfProject.Name,
-		ParentID:    utils.StringValue(sfProject.Parent),
-		ParentName:  parentName,
-		Slug:        sfProject.Slug,
-		Status:      sfProject.Status,
-		Type:        sfProject.Type,
-		IsStandalone: (sfProject.Type != utils.ProjectTypeProjectGroup) && (utils.StringValue(sfProject.Parent) == "" || (sfProject.Foundation != nil &&
-			(sfProject.Foundation.Name == utils.TheLinuxFoundation || sfProject.Foundation.Name == utils.LFProjectsLLC))),
+		EntityName:   utils.StringValue(sfProject.EntityName),
+		EntityType:   sfProject.EntityType,
+		Funding:      sfProject.Funding,
+		ID:           sfProject.ID,
+		LfSupported:  sfProject.LFSponsored,
+		Name:         sfProject.Name,
+		ParentID:     utils.GetProjectParentSFID(sfProject),
+		ParentName:   parentName,
+		Slug:         sfProject.Slug,
+		Status:       sfProject.Status,
+		Type:         sfProject.Type,
+		IsStandalone: utils.IsStandaloneProject(sfProject),
 	}
 }

--- a/cla-backend-go/v2/repositories/service.go
+++ b/cla-backend-go/v2/repositories/service.go
@@ -90,11 +90,10 @@ func (s *service) AddGithubRepositories(ctx context.Context, projectSFID string,
 	}
 
 	var parentProjectSFID string
-	if utils.StringValue(project.Parent) == "" || (project.Foundation != nil &&
-		(project.Foundation.Name == utils.TheLinuxFoundation || project.Foundation.Name == utils.LFProjectsLLC)) {
+	if !utils.IsProjectHaveParent(project) || utils.IsProjectHasRootParent(project) || utils.GetProjectParentSFID(project) == "" {
 		parentProjectSFID = projectSFID
 	} else {
-		parentProjectSFID = utils.StringValue(project.Parent)
+		parentProjectSFID = utils.GetProjectParentSFID(project)
 	}
 
 	allMappings, err := s.projectsClaGroupsRepo.GetProjectsIdsForClaGroup(ctx, aws.StringValue(input.ClaGroupID))
@@ -252,8 +251,8 @@ func (s *service) ListProjectRepositories(ctx context.Context, projectSFID strin
 		return nil, err
 	}
 	f["projectName"] = projectModel.Name
-	if utils.StringValue(projectModel.Parent) != "" {
-		f["projectParentSFID"] = projectModel.Parent
+	if utils.IsProjectHaveParent(projectModel) {
+		f["projectParentSFID"] = utils.GetProjectParentSFID(projectModel)
 	}
 	log.WithFields(f).Debug("loaded project from the project service")
 	enabled := true

--- a/cla-backend-go/v2/sign/service.go
+++ b/cla-backend-go/v2/sign/service.go
@@ -173,8 +173,7 @@ func (s *service) RequestCorporateSignature(ctx context.Context, lfUsername stri
 	}
 
 	var claGroupID string
-	if utils.StringValue(project.Parent) == "" || (project.Foundation != nil &&
-		(project.Foundation.Name == utils.TheLinuxFoundation || project.Foundation.Name == utils.LFProjectsLLC)) {
+	if !utils.IsProjectHaveParent(project) || utils.IsProjectHasRootParent(project) || utils.GetProjectParentSFID(project) == "" {
 		// this is root project
 		cgmlist, perr := s.projectClaGroupsRepo.GetProjectsIdsForFoundation(ctx, utils.StringValue(input.ProjectSfid))
 		if perr != nil {


### PR DESCRIPTION
- Updated logic to use/leverage the project model foundation ID for the
parent ID rather than using the Parent attribute. Added additional
defensive logic to projects with no parents. Resolved null pointer error
when no parent is present.

Signed-off-by: David Deal <dealako@gmail.com>