### PR TITLE
Revise the action for CLA signatories.

### DIFF
--- a/cla-backend-go/emails/v2_cla_manager_templates.go
+++ b/cla-backend-go/emails/v2_cla_manager_templates.go
@@ -69,7 +69,7 @@ const (
 	<li>{{.Project.ExternalProjectName}}</li>
 </ul>
 <p>Before the contribution can be accepted, your organization must sign a CLA. 
-Either you or someone whom to designate from your company can login to this portal ({{.CorporateConsole}}) and sign the CLA for this project {{.Project.GetProjectFullURL}} </p>
+Either you or someone whom to designate from your company can login to the EasyCLA portal and <b>sign the CLA for this project {{.Project.GetProjectFullURL}}</b>. </p>
 <p>If you are not the CLA Manager, please forward this email to the appropriate person so that they can start the CLA process.</p>
 <p> Please notify the user once CLA setup is complete.</p>
 `


### PR DESCRIPTION
The link to the EasyCLA portal is generic and misleading. When a user clicks it, there is no obvious path to signing the CLA. I've removed that link and added a bold emphasis on the link a user receiving this email should click.