### PR TITLE
Prioritize link visually in email to CLA Managers

### DIFF
--- a/cla-backend-go/emails/v2_cla_manager_templates.go
+++ b/cla-backend-go/emails/v2_cla_manager_templates.go
@@ -139,7 +139,7 @@ const (
 	<li>{{.Project.ExternalProjectName}}</li>
 </ul>
 <p>Before the contribution can be accepted, your organization must sign a CLA. 
-Either you or someone whom you designate from your company can login to this portal ({{.CorporateConsole}}) and sign the CLA for this project {{.Project.GetProjectFullURL}} </p>
+Either you or someone whom you designate from your company can login and <b>sign the CLA for this project {{.Project.GetProjectFullURL}}</b> </p>
 <p>If you are not the CLA Manager, please forward this email to the appropriate person so that they can start the CLA process.</p>
 <p> Please notify the user once CLA setup is complete.</p>
 `

--- a/cla-backend-go/tests/v2_cla_manager_templates_test.go
+++ b/cla-backend-go/tests/v2_cla_manager_templates_test.go
@@ -138,8 +138,7 @@ func TestV2CLAManagerDesigneeCorporateTemplate(t *testing.T) {
 	assert.Contains(t, result, "SenderNameValue SenderEmailValue has identified you")
 	assert.Contains(t, result, "Corporate CLA for the organization JohnsCompany")
 	assert.Contains(t, result, "<li>JohnsProject</li>")
-	assert.Contains(t, result, "can login to this portal (http://CorporateConsole.com)")
-	assert.Contains(t, result, `sign the CLA for this project <a href="http://CorporateConsole.com/foundation/FoundationSFIDValue/project/ProjectSFIDValue/cla" target="_blank">JohnsProject</a>`)
+	assert.Contains(t, result, "can login and <b>sign the CLA for this project <a href=\"http://CorporateConsole.com/foundation/FoundationSFIDValue/project/ProjectSFIDValue/cla\" target=\"_blank\">JohnsProject</a>")
 }
 
 func TestV2ToCLAManagerDesigneeTemplate(t *testing.T) {


### PR DESCRIPTION
The link to the EasyCLA portal is generic and misleading. When a user clicks it, there is no obvious path to signing the CLA. I've removed that link and added a bold emphasis on the link a user receiving this email should click.

Signed-off-by: Mike Dolan <mikedolan@gmail.com>