### PR TITLE
Added GitLab Repo Query Filter by GitLab Group Prefix

### DIFF
--- a/cla-backend-go/swagger/common/gitlab-organization.yaml
+++ b/cla-backend-go/swagger/common/gitlab-organization.yaml
@@ -56,6 +56,10 @@ properties:
   auto_enabled_cla_group_id:
     type: string
     description: Specifies which Cla group ID to be used when autoEnabled flag in enabled for the Github Organization. If autoEnabled is on this field needs to be set as well.
+  branch_protection_enabled:
+    type: boolean
+    description: Flag to indicate if this GitHub Organization is configured to automatically setup branch protection on CLA enabled repositories.
+    x-omitempty: false
   auth_info:
     type: string
     description: auth info

--- a/cla-backend-go/v2/gitlab-activity/handlers.go
+++ b/cla-backend-go/v2/gitlab-activity/handlers.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	gitlab_api "github.com/communitybridge/easycla/cla-backend-go/gitlab_api"
 	"github.com/communitybridge/easycla/cla-backend-go/v2/gitlab_organizations"
 
@@ -27,7 +28,7 @@ func Configure(api *operations.EasyclaAPI, service Service, gitlabOrgRepo gitlab
 		requestID, _ := uuid.NewV4()
 		reqID := requestID.String()
 
-		if params.GitlabTriggerInput == nil || params.GitlabTriggerInput.GitlabOrganizationID == nil || params.GitlabTriggerInput.GitlabExternalRepositoryID == nil || params.GitlabTriggerInput.GitlabMrID == nil{
+		if params.GitlabTriggerInput == nil || params.GitlabTriggerInput.GitlabOrganizationID == nil || params.GitlabTriggerInput.GitlabExternalRepositoryID == nil || params.GitlabTriggerInput.GitlabMrID == nil {
 			return gitlab_activity.NewGitlabActivityBadRequest().WithPayload(
 				utils.ErrorResponseBadRequest(reqID, "missing parameter"))
 		}
@@ -37,11 +38,11 @@ func Configure(api *operations.EasyclaAPI, service Service, gitlabOrgRepo gitlab
 		gitlabMrID := *params.GitlabTriggerInput.GitlabMrID
 
 		f := logrus.Fields{
-			"functionName": "gitlab_activity.handlers.GitlabActivityGitlabTriggerHandler",
-			"requestID":    reqID,
-			"gitlabOrganizationID":gitlabOrganizationID,
-			"gitlabExternalRepositoryID":gitlabExternalRepositoryID,
-			"gitlabMrID":gitlabMrID,
+			"functionName":               "gitlab_activity.handlers.GitlabActivityGitlabTriggerHandler",
+			"requestID":                  reqID,
+			"gitlabOrganizationID":       gitlabOrganizationID,
+			"gitlabExternalRepositoryID": gitlabExternalRepositoryID,
+			"gitlabMrID":                 gitlabMrID,
 		}
 
 		log.WithFields(f).Debugf("handling gitlab trigger")

--- a/cla-backend-go/v2/gitlab_organizations/service.go
+++ b/cla-backend-go/v2/gitlab_organizations/service.go
@@ -288,7 +288,8 @@ func (s *Service) GetGitLabOrganizations(ctx context.Context, projectSFID string
 			continue
 		}
 
-		repoList, repoErr := s.v2GitRepoService.GitLabGetRepositoriesByProjectSFID(ctx, projectSFID)
+		log.WithFields(f).Debugf("filtering repositories based on group path: %s", org.OrganizationFullPath)
+		repoList, repoErr := s.v2GitRepoService.GitLabGetRepositoriesByNamePrefix(ctx, fmt.Sprintf("%s/", org.OrganizationFullPath))
 		if repoErr != nil {
 			if _, ok := err.(*utils.GitLabRepositoryNotFound); ok {
 				log.WithFields(f).WithError(repoErr).Debugf("no GitLab repositories onboarded for project : %s", projectSFID)
@@ -306,7 +307,7 @@ func (s *Service) GetGitLabOrganizations(ctx context.Context, projectSFID string
 			OrganizationFullPath:    org.OrganizationFullPath,
 			OrganizationExternalID:  org.OrganizationExternalID,
 			InstallationURL:         buildInstallationURL(org.OrganizationID, orgDetailed.AuthState),
-			BranchProtectionEnabled: false,                               // TODO review this - why not modeled?
+			BranchProtectionEnabled: org.BranchProtectionEnabled,
 			ConnectionStatus:        "",                                  // updated below
 			Repositories:            []*models.GitlabProjectRepository{}, // updated below
 		}

--- a/cla-backend-go/v2/repositories/gitlab_services.go
+++ b/cla-backend-go/v2/repositories/gitlab_services.go
@@ -305,7 +305,24 @@ func (s *Service) GitLabGetRepositoriesByCLAGroup(ctx context.Context, claGroupI
 
 // GitLabGetRepositoriesByOrganizationName returns the list of repositories associated with the Organization/Group name
 func (s *Service) GitLabGetRepositoriesByOrganizationName(ctx context.Context, orgName string) (*v2Models.GitlabRepositoriesList, error) {
-	dbModels, err := s.gitV2Repository.GitHubGetRepositoriesByOrganizationName(ctx, orgName)
+	dbModels, err := s.gitV2Repository.GitLabGetRepositoriesByOrganizationName(ctx, orgName)
+	if err != nil {
+		return nil, err
+	}
+
+	responses, err := dbModelsToGitLabRepositories(dbModels)
+	if err != nil {
+		return nil, err
+	}
+
+	return &v2Models.GitlabRepositoriesList{
+		List: responses,
+	}, nil
+}
+
+// GitLabGetRepositoriesByNamePrefix returns a list of repositories that match the name prefix
+func (s *Service) GitLabGetRepositoriesByNamePrefix(ctx context.Context, repositoryNamePrefix string) (*v2Models.GitlabRepositoriesList, error) {
+	dbModels, err := s.gitV2Repository.GitLabGetRepositoriesByNamePrefix(ctx, repositoryNamePrefix)
 	if err != nil {
 		return nil, err
 	}

--- a/cla-backend-go/v2/repositories/service.go
+++ b/cla-backend-go/v2/repositories/service.go
@@ -59,6 +59,7 @@ type ServiceInterface interface {
 	GitLabGetRepositoriesByProjectSFID(ctx context.Context, projectSFID string) (*v2Models.GitlabRepositoriesList, error)
 	GitLabGetRepositoriesByCLAGroup(ctx context.Context, claGroupID string, enabled bool) (*v2Models.GitlabRepositoriesList, error)
 	GitLabGetRepositoriesByOrganizationName(ctx context.Context, orgName string) (*v2Models.GitlabRepositoriesList, error)
+	GitLabGetRepositoriesByNamePrefix(ctx context.Context, repositoryNamePrefix string) (*v2Models.GitlabRepositoriesList, error)
 	GitLabAddRepositories(ctx context.Context, projectSFID string, input *GitLabAddRepoModel) (*v2Models.GitlabRepositoriesList, error)
 	GitLabAddRepositoriesByApp(ctx context.Context, gitLabOrgModel *common.GitLabOrganization) ([]*v2Models.GitlabRepository, error)
 	GitLabEnrollRepositories(ctx context.Context, claGroupID string, repositoryIDList []int64, enrollValue bool) error


### PR DESCRIPTION
- Added filter so that GitLab repos are filter based on the GitLab group
name as a prefix. This handles the case linuxfoundation/product/asitha
vs linuxfoundation/product/asitha-cla matching together.

Signed-off-by: David Deal <dealako@gmail.com>