### PR TITLE
[3356] Resolves Authority Name Invalid Username Issue

### DIFF
--- a/cla-backend-go/swagger/cla.v2.yaml
+++ b/cla-backend-go/swagger/cla.v2.yaml
@@ -5475,8 +5475,11 @@ definitions:
         example: false
         description: send signing request as email. This should be set to true when requestor is not signatory.
       authority_name:
+        type: string
+        example: "Derk Miyamoto"
         description: the name of the CLA signatory
-        $ref: './common/properties/user-name.yaml'
+        minLength: 2
+        maxLength: 255
       authority_email:
         $ref: './common/properties/email.yaml'
         description: the email of the CLA Signatory


### PR DESCRIPTION
- Removed valid characters restriction for authority_name. Resolves
issue of users with special characters in their name.

Signed-off-by: David Deal <ddeal@linuxfoundation.org>