### PR TITLE
Added Defensive Checks When Processing GitHub Organization Repositories

### DIFF
--- a/cla-backend-go/github/github_installation.go
+++ b/cla-backend-go/github/github_installation.go
@@ -36,7 +36,7 @@ func GetInstallationRepositories(ctx context.Context, installationID int64) ([]*
 
 	// See pagination examples: https://godoc.org/github.com/google/go-github/github
 	opts := &github.ListOptions{
-		PerPage: 50,
+		PerPage: 100, // Max 100 per the GitHub API
 	}
 
 	for {
@@ -47,7 +47,7 @@ func GetInstallationRepositories(ctx context.Context, installationID int64) ([]*
 			return nil, errors.New(msg)
 		}
 
-		log.WithFields(f).Debugf("fetched %d records...", len(listReposResponse.Repositories))
+		//log.WithFields(f).Debugf("fetched %d records...", len(listReposResponse.Repositories))
 		allRepos = append(allRepos, listReposResponse.Repositories...)
 		if resp.NextPage == 0 {
 			break

--- a/cla-backend-go/github_organizations/helpers.go
+++ b/cla-backend-go/github_organizations/helpers.go
@@ -67,7 +67,7 @@ func buildGithubOrganizationListModels(ctx context.Context, githubOrganizations 
 						return
 					}
 
-					log.WithFields(f).Debugf("found %d repositories from GitHUb using the installation id: %d...",
+					log.WithFields(f).Debugf("found %d repositories from GitHub using the installation id: %d...",
 						len(list), ghorg.OrganizationInstallationID)
 					for _, repoInfo := range list {
 						ghorg.Repositories.List = append(ghorg.Repositories.List, &models.GithubRepositoryInfo{

--- a/cla-backend-go/github_organizations/service.go
+++ b/cla-backend-go/github_organizations/service.go
@@ -62,6 +62,9 @@ func (s Service) AddGitHubOrganization(ctx context.Context, projectSFID string, 
 		log.WithFields(f).Warnf("problem fetching github organizations by projectSFID, error: %+v", projErr)
 		return nil, projErr
 	}
+	if parentProjectSFID == "" {
+		parentProjectSFID = projectSFID
+	}
 
 	// check if valid cla group id is passed
 	if input.AutoEnabledClaGroupID != "" {
@@ -102,6 +105,9 @@ func (s Service) GetGitHubOrganizations(ctx context.Context, projectSFID string)
 	if projErr != nil {
 		log.WithFields(f).Warnf("problem fetching project parent SFID, error: %+v", projErr)
 		return nil, projErr
+	}
+	if parentProjectSFID == "" {
+		parentProjectSFID = projectSFID
 	}
 
 	//Get SF Project
@@ -188,6 +194,9 @@ func (s Service) DeleteGitHubOrganization(ctx context.Context, projectSFID strin
 	if projErr != nil {
 		log.WithFields(f).Warnf("problem fetching project parent SFID, error: %+v", projErr)
 		return projErr
+	}
+	if parentProjectSFID == "" {
+		parentProjectSFID = projectSFID
 	}
 
 	err := s.ghRepository.GitHubDisableRepositoriesOfOrganization(ctx, parentProjectSFID, githubOrgName)

--- a/cla-backend-go/utils/project_helpers.go
+++ b/cla-backend-go/utils/project_helpers.go
@@ -7,7 +7,7 @@ import "github.com/communitybridge/easycla/cla-backend-go/v2/project-service/mod
 
 // GetProjectParentSFID returns the project parent SFID if available, otherwise returns empty string
 func GetProjectParentSFID(project *models.ProjectOutputDetailed) string {
-	if project == nil || project.Foundation == nil || project.Foundation.ID == "" {
+	if project == nil || project.Foundation == nil || project.Foundation.ID == "" || project.Foundation.Name == "" || project.Foundation.Slug == "" {
 		return ""
 	}
 	return project.Foundation.ID
@@ -15,7 +15,7 @@ func GetProjectParentSFID(project *models.ProjectOutputDetailed) string {
 
 // IsProjectHaveParent returns true if the specified project has a parent
 func IsProjectHaveParent(project *models.ProjectOutputDetailed) bool {
-	return project != nil && project.Foundation != nil && project.Foundation.ID != "" && project.Foundation.Name != ""
+	return project != nil && project.Foundation != nil && project.Foundation.ID != "" && project.Foundation.Name != "" && project.Foundation.Slug != ""
 }
 
 // IsProjectHasRootParent determines if a given project has a root parent. A root parent is a parent that is empty parent or the parent is TLF or LFProjects

--- a/cla-backend-go/v2/cla_groups/service.go
+++ b/cla-backend-go/v2/cla_groups/service.go
@@ -406,7 +406,7 @@ func (s *service) ListClaGroupsForFoundationOrProject(ctx context.Context, proje
 
 		// Get Parent
 		parentDetails, parentDetailErr = v2ProjectService.GetClient().GetProject(parentSFID)
-		if parentDetailErr != nil {
+		if parentDetailErr != nil || parentDetails == nil {
 			return nil, parentDetailErr
 		}
 	}

--- a/cla-backend/cla/models/github_models.py
+++ b/cla-backend/cla/models/github_models.py
@@ -368,6 +368,7 @@ class GitHub(repository_service_interface.RepositoryService):
         # Note: late 2021/early 2022 we observed that sometimes we get the event for a PR, then go back to GitHub
         # to query for the PR details and discover the PR is 404, not available for some reason.  Added retry
         # logic to retry a couple of times to address any timing issues.
+        pull_request = {}
         tries = 3
         for i in range(tries):
             try:


### PR DESCRIPTION
- Added logic to identify and skip GitHub organization repositories that
are invalid or empty/nil.  This was causing an API error for the CFF
project.
- Added some additional defensive code when querying for projects in the
project service - trap for empty/nil fields.

Signed-off-by: David Deal <ddeal@linuxfoundation.org>