### PR TITLE
Updated Gerrit Swagger Spec

### DIFF
--- a/cla-backend-go/swagger/common/add-gerrit-input.yaml
+++ b/cla-backend-go/swagger/common/add-gerrit-input.yaml
@@ -28,16 +28,18 @@ properties:
     pattern: ^(?:http(s)?:\/\/).+$
   groupIdCcla:
     type: string
-    description: the LDAP group ID for CCLA
+    description: the LDAP group ID for CCLA encoded as a string value
     example: '1902'
-    minLength: 3
+    minLength: 1
     maxLength: 12
+    pattern: ^[1-9]\d{0,11}$
   groupIdIcla:
     type: string
-    description: the LDAP group ID for ICLA
+    description: the LDAP group ID for ICLA encoded as a string value
     example: '1903'
-    minLength: 3
+    minLength: 1
     maxLength: 12
+    pattern: ^[1-9]\d{0,11}$
   version:
     type: string
     description: the version associated with the gerrit record

--- a/cla-backend-go/swagger/common/gerrit.yaml
+++ b/cla-backend-go/swagger/common/gerrit.yaml
@@ -35,16 +35,18 @@ properties:
     format: uri
   groupIdCcla:
     type: string
-    description: the LDAP group ID for CCLA
+    description: the LDAP group ID for CCLA encoded as a string value
     example: '1902'
-    minLength: 3
+    minLength: 1
     maxLength: 12
+    pattern: ^[1-9]\d{0,11}$
   groupIdIcla:
     type: string
-    description: the LDAP group ID for ICLA
+    description: the LDAP group ID for ICLA encoded as a string value
     example: '1903'
-    minLength: 3
+    minLength: 1
     maxLength: 12
+    pattern: ^[1-9]\d{0,11}$
   groupNameCcla:
     type: string
     description: the LDAP group name for CCLA


### PR DESCRIPTION
- Updated add/get gerrit API to allow LDAP values/ranges to support
single digit ID values, added regex to support positive integer values,
updated description

Signed-off-by: David Deal <ddeal@linuxfoundation.org>