### PR TITLE
[3464] Resolves Missing Commit Info in GitHub Status

### DIFF
--- a/cla-backend/cla/controllers/github.py
+++ b/cla-backend/cla/controllers/github.py
@@ -372,7 +372,7 @@ def handle_pull_request_comment_event(action: str, body: dict):
             result = service.process_easycla_command_comment(body)
             return result
         except ValueError as ex:
-            cla.log.warning(f"process_easycla_command_comment failed with : {str(ex)}")
+            cla.log.debug(f'{func_name} - ignoring github pull_request comment: {str(ex)}')
             return None
     else:
         cla.log.debug(f'{func_name} - ignoring github pull_request comment activity for action: {action}')

--- a/cla-backend/cla/routes.py
+++ b/cla-backend/cla/routes.py
@@ -1646,8 +1646,7 @@ def github_app_activity(body, request, response):
             cla.log.error(f'{fn} - v4 golang api failed with : 500 : {ex}')
             response.status = HTTP_500
             return {"status": f'v4_easycla_github_activity failed {ex}'}
-    cla.log.debug(f'{fn} - not forwarding event type: \'{event_type}\' with action: \'{action}\'.'
-                  'Will handle it here...')
+    cla.log.debug(f'{fn} - not forwarding event type: \'{event_type}\' with action: \'{action}\'.')
 
     if event_type is None:
         cla.log.error(f"{fn} - unable to determine the event type from request headers: {request.headers}")


### PR DESCRIPTION
- Updated logic to use a class/data model to track missing vs signed
users. This class collects all the user info and makes it available for
display on the GitHub status page. Updated display output to show
as much information as possible about the user including the login
value, the user's name and email.

Signed-off-by: David Deal <ddeal@linuxfoundation.org>