### PR TITLE
Added Additional User Tagging Logic for CLA Gating Failures

### DIFF
--- a/cla-backend/cla/models/github_models.py
+++ b/cla-backend/cla/models/github_models.py
@@ -1036,9 +1036,10 @@ def update_pull_request(installation_id, github_repository_id, pull_request, rep
     # knows if it is pass/fail.
     # Create check run for users that haven't yet signed and/or affiliated
     if missing:
-        text = ""
+        text = ''
+        help_url = ''
         for user_commit_summary in missing:
-            # Check for valid github id
+            # Check for valid GitHub id
             # old tuple: (sha, (author_id, author_login_or_name, author_email, optionalTrue))
             if not user_commit_summary.is_valid_user():
                 help_url = "https://help.github.com/en/github/committing-changes-to-your-project/why-are-my-commits-linked-to-the-wrong-user"
@@ -1051,7 +1052,7 @@ def update_pull_request(installation_id, github_repository_id, pull_request, rep
             if user_commit_summary.commit_sha != last_commit.sha:
                 continue
 
-            text += user_commit_summary.get_display_text()
+            text += user_commit_summary.get_display_text(tag_user=True)
 
         payload = {
             "name": "CLA check",

--- a/cla-backend/cla/user.py
+++ b/cla-backend/cla/user.py
@@ -78,35 +78,27 @@ class UserCommitSummary:
     def is_valid_user(self) -> bool:
         return self.author_id is not None and (self.author_login is not None or self.author_name is not None)
 
-    def get_user_info(self, tag_user:bool = False) -> str:
+    def get_user_info(self, tag_user: bool = False) -> str:
         user_info = ''
         if self.author_login:
             user_info += f'login: {"@" if tag_user else ""}{self.author_login} / '
         if self.author_name:
             user_info += f'name: {self.author_name} / '
-        # if self.author_email:
-        #     user_info += f'email: {self.author_email}'
 
-        pattern = r'/ $'
-        return re.sub(pattern, '', user_info)
+        return re.sub(r'/ $', '', user_info)
 
-    def get_display_text(self) -> str:
+    def get_display_text(self, tag_user: bool = False) -> str:
 
         if not self.author_id:
             return f'{self.author_email} is not linked to this commit.\n'
-
-        text = self.get_user_info()
 
         if not self.is_valid_user():
             return 'Invalid author details.\n'
 
         if self.authorized and self.affiliated:
-            text += ' is authorized.\n'
-            return text
+            return self.get_user_info(tag_user) + ' is authorized.\n'
 
         if self.affiliated:
-            text += ' is associated with a company, but not on an approval list.\n'
+            return self.get_user_info(tag_user) + ' is associated with a company, but not on an approval list.\n'
         else:
-            text += ' is not associated with a company.\n'
-
-        return text
+            return self.get_user_info(tag_user) + ' is not associated with a company.\n'

--- a/cla-backend/cla/utils.py
+++ b/cla-backend/cla/utils.py
@@ -988,7 +988,7 @@ def get_comment_body(repository_type, sign_url, signed: List[UserCommitSummary],
         committers = {}
         for user_commit_summary in signed:
             if user_commit_summary.is_valid_user():
-                author_info = user_commit_summary.get_user_info()
+                author_info = user_commit_summary.get_user_info(tag_user=False)
             else:
                 author_info = 'Unknown'
 
@@ -1011,9 +1011,8 @@ def get_comment_body(repository_type, sign_url, signed: List[UserCommitSummary],
         # Build a lookup table to group all the commits by author.
         committers = {}
         for user_commit_summary in missing:
-            tag_user = True
             if user_commit_summary.is_valid_user():
-                author_info = user_commit_summary.get_user_info(tag_user)
+                author_info = user_commit_summary.get_user_info(tag_user=True)
             else:
                 author_info = 'Unknown'
 
@@ -1030,16 +1029,17 @@ def get_comment_body(repository_type, sign_url, signed: List[UserCommitSummary],
                 # build a quick list of just the commit hash values
                 commit_shas = [user_commit_summary.commit_sha for user_commit_summary in user_commit_summaries]
                 committers_comment += (
-                        f"<li> {failed} The commit ({', '.join(commit_shas)}). "
-                        f"This user is missing the User's ID, preventing the EasyCLA check. "
-                        f"<a href='{github_help_url}' target='_blank'>Consult GitHub Help</a> to resolve."
-                        f'For further assistance with EasyCLA, '
-                        f"<a href='{support_url}' target='_blank'>please submit a support request ticket</a>."
-                        '</li>')
+                    f"<li> {failed} The commit ({', '.join(commit_shas)}). "
+                    f"This user is missing the User's ID, preventing the EasyCLA check. "
+                    f"<a href='{github_help_url}' target='_blank'>Consult GitHub Help</a> to resolve."
+                    f'For further assistance with EasyCLA, '
+                    f"<a href='{support_url}' target='_blank'>please submit a support request ticket</a>."
+                    '</li>')
             else:
-                missing_affiliations = [user_commit_summary.affiliated and user_commit_summary.authorized for user_commit_summary in user_commit_summaries
-                                       if not user_commit_summary.affiliated]
-                if len(missing_affiliations) > 0 :
+                missing_affiliations = [user_commit_summary.affiliated and user_commit_summary.authorized for
+                                        user_commit_summary in user_commit_summaries
+                                        if not user_commit_summary.affiliated]
+                if len(missing_affiliations) > 0:
                     # build a quick list of just the commit hash values for users missing company affiliations
                     commit_shas = [user_commit_summary.commit_sha for user_commit_summary in user_commit_summaries
                                    if not user_commit_summary.affiliated]
@@ -1058,14 +1058,14 @@ def get_comment_body(repository_type, sign_url, signed: List[UserCommitSummary],
                     # build a quick list of just the commit hash values
                     commit_shas = [user_commit_summary.commit_sha for user_commit_summary in user_commit_summaries]
                     committers_comment += (
-                            f'<li>'
-                            f"<a href='{sign_url}' target='_blank'>{failed}</a> - "
-                            f"{author_info}. The commit ({', '.join(commit_shas)}) "
-                            "is not authorized under a signed CLA. "
-                            f"<a href='{sign_url}' target='_blank'>Please click here to be authorized</a>. "
-                            f"For further assistance with EasyCLA, "
-                            f"<a href='{support_url}' target='_blank'>please submit a support request ticket</a>."
-                            "</li>")
+                        f'<li>'
+                        f"<a href='{sign_url}' target='_blank'>{failed}</a> - "
+                        f"{author_info}. The commit ({', '.join(commit_shas)}) "
+                        "is not authorized under a signed CLA. "
+                        f"<a href='{sign_url}' target='_blank'>Please click here to be authorized</a>. "
+                        f"For further assistance with EasyCLA, "
+                        f"<a href='{support_url}' target='_blank'>please submit a support request ticket</a>."
+                        "</li>")
 
     if len(signed) > 0 or len(missing) > 0:
         committers_comment += '</ul>'


### PR DESCRIPTION
- Added additional logic to tag users in additional GitHub gating
failure use cases

Signed-off-by: David Deal <ddeal@linuxfoundation.org>