### PR TITLE
Added Additional Date/Time String Format for Python

### DIFF
--- a/cla-backend/cla/utils.py
+++ b/cla-backend/cla/utils.py
@@ -1766,7 +1766,7 @@ def get_time_from_string(date_string: str) -> Optional[datetime]:
     :return:
     """
     # Try these formats
-    formats = ['%Y-%m-%d %H:%M:%S.%f%z', '%Y-%m-%dT%H:%M:%S%z', '%Y-%m-%dT%H:%M:%S.%f%z']
+    formats = ['%Y-%m-%d %H:%M:%S.%f%z', '%Y-%m-%dT%H:%M:%S%z', '%Y-%m-%dT%H:%M:%S.%f%z', '%Y-%m-%dT%H:%M:%S.%f']
     for fmt in formats:
         try:
             return datetime.strptime(date_string, fmt)


### PR DESCRIPTION
- Added date/time string format to handle legacy records: '%Y-%m-%dT%H:%M:%S.%f'

Signed-off-by: David Deal <ddeal@linuxfoundation.org>