### PR TITLE
Updated Store Table TTL to 1 Week

### DIFF
--- a/cla-backend/cla/models/dynamo_models.py
+++ b/cla-backend/cla/models/dynamo_models.py
@@ -3740,8 +3740,8 @@ class Store(key_value_store_interface.KeyValueStore):
             return False
 
     def get_expire_timestamp(self):
-        # helper function to set store item ttl: 1 day
-        exp_datetime = datetime.datetime.now() + datetime.timedelta(days=1)
+        # helper function to set store item ttl: 7 days
+        exp_datetime = datetime.datetime.now() + datetime.timedelta(days=7)
         return exp_datetime.timestamp()
 
 


### PR DESCRIPTION
- updated store table TTL from 1 day to 1 week - this will allow us to update PR's that have been opened in the past week after the CLA manager adds the user to one of the approval lists

Signed-off-by: David Deal <ddeal@linuxfoundation.org>