### PR TITLE
[#3605] Feature/Get GH Orgs by Parent

### DIFF
--- a/cla-backend-go/github_organizations/service.go
+++ b/cla-backend-go/github_organizations/service.go
@@ -117,20 +117,27 @@ func (s Service) GetGitHubOrganizations(ctx context.Context, projectSFID string)
 		return nil, projDetailsErr
 	}
 
+	var parentGithubModels *models.GithubOrganizations
+	var parentErr error
+
+	// check if project is parent or has a parent to get parent github orgs
 	if parentProjectSFID != projectSFID && (projectDetails != nil && !utils.IsProjectHasRootParent(projectDetails)) {
 		log.WithFields(f).Debugf("found parent of projectSFID: %s to be %s. Searching github organization by parent SFID: %s...", projectSFID, parentProjectSFID, parentProjectSFID)
-		// parentGithubModels, parentErr := s.repo.GetGitHubOrganizationsByParent(ctx, parentProjectSFID)
-		parentGithubModels, parentErr := s.repo.GetGitHubOrganizations(ctx, parentProjectSFID)
-		if parentErr != nil {
-			log.WithFields(f).Warnf("problem fetching github organizations by paarent projectSFID: %s , error: %+v", parentProjectSFID, err)
-			return nil, parentErr
-		}
-
-		if len(parentGithubModels.List) >= 0 {
-			githubOrgs = append(githubOrgs, parentGithubModels.List...)
-		}
-		log.WithFields(f).Debugf("loaded %d GitHub organizations using projectSFID: %s", len(parentGithubModels.List), parentProjectSFID)
+		parentGithubModels, parentErr = s.repo.GetGitHubOrganizations(ctx, parentProjectSFID)
+	} else if parentProjectSFID == projectSFID {
+		log.WithFields(f).Debugf("%s is the parent. Searching github organization by parent SFID: %s...", projectSFID, parentProjectSFID)
+		parentGithubModels, parentErr = s.repo.GetGitHubOrganizationsByParent(ctx, parentProjectSFID)
 	}
+
+	if parentErr != nil {
+		log.WithFields(f).Warnf("problem fetching github organizations by parent projectSFID: %s , error: %+v", parentProjectSFID, err)
+		return nil, parentErr
+	}
+
+	if parentGithubModels != nil && len(parentGithubModels.List) >= 0 {
+		githubOrgs = append(githubOrgs, parentGithubModels.List...)
+	}
+	log.WithFields(f).Debugf("loaded %d GitHub organizations using projectSFID: %s", len(parentGithubModels.List), parentProjectSFID)
 
 	gitHubOrgModels.List = githubOrgs
 


### PR DESCRIPTION
- Refactored gh org query by parent returning all child orgs under a given parent

Signed-off-by: Harold Wanyama <hwanyama@contractor.linuxfoundation.org>