### PR TITLE
[#3689] Feature/ Request CLA Manager Email

### DIFF
--- a/cla-backend-go/emails/params.go
+++ b/cla-backend-go/emails/params.go
@@ -61,7 +61,7 @@ func (p CLAProjectParams) GetProjectFullURL() template.HTML {
 		projectConsolePathURL = u.String()
 	}
 
-	return template.HTML(fmt.Sprintf(fullURLHtml, projectConsolePathURL, url.QueryEscape(p.ExternalProjectName))) // nolint gosec auto-escape HTML
+	return template.HTML(fmt.Sprintf(fullURLHtml, projectConsolePathURL, p.ExternalProjectName)) // nolint gosec auto-escape HTML
 }
 
 // CLAGroupTemplateParams includes the params for the CLAGroupTemplateParams

--- a/cla-backend-go/tests/v2_cla_manager_templates_test.go
+++ b/cla-backend-go/tests/v2_cla_manager_templates_test.go
@@ -22,6 +22,7 @@ func TestV2ContributorApprovalRequestTemplate(t *testing.T) {
 			Projects: []emails.CLAProjectParams{
 				{ExternalProjectName: "Project1", ProjectSFID: "ProjectSFID1", FoundationSFID: "FoundationSFID1", CorporateConsole: "http://CorporateConsole.com"},
 				{ExternalProjectName: "Project2", ProjectSFID: "ProjectSFID2", FoundationSFID: "FoundationSFID2", CorporateConsole: "http://CorporateConsole.com"},
+				{ExternalProjectName: "Project Spaced 1", ProjectSFID: "ProjectSFID2", FoundationSFID: "FoundationSFID2", CorporateConsole: "http://CorporateConsole.com"},
 			},
 			CorporateConsole: "http://CorporateConsoleV2URL.com",
 		},
@@ -36,6 +37,7 @@ func TestV2ContributorApprovalRequestTemplate(t *testing.T) {
 	assert.Contains(t, result, "The following contributor would like to submit a contribution to the projects(s): Project1, Project2")
 	assert.Contains(t, result, "UserDetailsValue")
 	assert.Contains(t, result, "Approval can be done at http://CorporateConsoleV2URL.com")
+	assert.Contains(t, result, "target=\"_blank\">Project Spaced 1</a>")
 
 	params.SigningEntityName = "SigningEntityNameValue"
 


### PR DESCRIPTION
- Removed queryescape on project name for the hyperlink to the project console.

Signed-off-by: Harold Wanyama <hwanyama@contractor.linuxfoundation.org>