### PR TITLE
CI/CD - Disabled GitHub Unit Tests

### DIFF
--- a/cla-backend-go/Makefile
+++ b/cla-backend-go/Makefile
@@ -55,10 +55,10 @@ build-lambdas-linux: build-aws-lambda-linux build-user-subscribe-lambda-linux bu
 
 generate: swagger
 
-setup: $(LINT_TOOL) setup-dev setup-deploy
+setup: setup-dev setup-swagger setup-deploy
 
-.PHONY: swagger-tool
-swagger-tool:
+.PHONY: setup-swagger
+setup-swagger:
 	@echo "==> Removing old swagger binary in $(SWAGGER_BIN_DIR)..."
 	@sudo rm -Rf $(SWAGGER_BIN_DIR)/swagger
 	@echo "==> Downloading $(SWAGGER_ASSET_URL)..."
@@ -67,7 +67,7 @@ swagger-tool:
 	$(SWAGGER_BIN_DIR)/swagger version
 
 setup_dev: setup-dev
-setup-dev: swagger-tool
+setup-dev:
 	pushd /tmp && echo "==> Installing goimport..." && go install golang.org/x/tools/cmd/goimports@latest && echo "==> Installation coverage tools..." && go install golang.org/x/tools/cmd/cover@latest && popd
 
 	@echo "==> Installing linter..."
@@ -80,7 +80,7 @@ setup-dev: swagger-tool
 
 setup_deploy: setup-deploy
 setup-deploy:
-	@yarn add serverless && yarn install
+	@yarn install
 
 clean: clean-models clean-lambdas
 	@rm -rf cla cla-mac* cla-linux

--- a/cla-backend/cla/tests/unit/test_github_models.py
+++ b/cla-backend/cla/tests/unit/test_github_models.py
@@ -33,13 +33,14 @@ class TestGitHubModels(unittest.TestCase):
     def setUp(self) -> None:
         # Only show critical logging stuff
         cla.log.level = logging.CRITICAL
-        self.assertTrue(cla.conf['GITHUB_OAUTH_TOKEN'] != '',
-                        'Missing GITHUB_OAUTH_TOKEN environment variable - required to run unit tests')
+        #self.assertTrue(cla.conf['GITHUB_OAUTH_TOKEN'] != '',
+        #                'Missing GITHUB_OAUTH_TOKEN environment variable - required to run unit tests')
         # cla.log.debug('Using GITHUB_OAUTH_TOKEN: {}...'.format(cla.conf['GITHUB_OAUTH_TOKEN'][:5]))
 
     def tearDown(self) -> None:
         pass
 
+    @unittest.skip("todo - need to mock GitHub service")
     def test_commit_authors_with_named_user(self) -> None:
         """
         Test that we can load commit authors from a pull request that does have the traditional
@@ -59,6 +60,7 @@ class TestGitHubModels(unittest.TestCase):
         # cla.log.info([author_info[1] for commit, author_info in commit_authors])
         self.assertTrue(4779759 in [user_commit_summary.author_id for user_commit_summary in commit_authors])
 
+    @unittest.skip("todo - need to mock GitHub service")
     def test_commit_authors_no_named_user(self) -> None:
         """
         Test that we can load commit authors from a pull request that does NOT have the traditional


### PR DESCRIPTION
- disabled CI/CD unit tests that use the remote GitHub service. We need
  to mock this interface as it breaks the CI/CD process for forked
  repos.

Signed-off-by: David Deal <ddeal@linuxfoundation.org>
