### PR TITLE
CSV Download - Added Placeholder for CSV Zip File

### DIFF
--- a/cla-backend-go/cmd/zipbuilder_scheduler_lambda/main.go
+++ b/cla-backend-go/cmd/zipbuilder_scheduler_lambda/main.go
@@ -52,6 +52,7 @@ type ClaGroup struct {
 type BuildZipEvent struct {
 	ClaGroupID    string `json:"cla_group_id"`
 	SignatureType string `json:"signature_type"`
+	FileType      string `json:"file_type"`
 }
 
 func handler(ctx context.Context, event events.CloudWatchEvent) {
@@ -71,13 +72,30 @@ func handler(ctx context.Context, event events.CloudWatchEvent) {
 		if claGroup.ProjectCclaEnabled {
 			eventPayloads = append(eventPayloads, BuildZipEvent{
 				ClaGroupID:    claGroup.ProjectID,
-				SignatureType: "ccla",
+				SignatureType: utils.ClaTypeCCLA,
+				FileType:      utils.FileTypePDF,
+			})
+			eventPayloads = append(eventPayloads, BuildZipEvent{
+				ClaGroupID:    claGroup.ProjectID,
+				SignatureType: utils.ClaTypeCCLA,
+				FileType:      utils.FileTypeCSV,
+			})
+			eventPayloads = append(eventPayloads, BuildZipEvent{
+				ClaGroupID:    claGroup.ProjectID,
+				SignatureType: utils.ClaTypeECLA,
+				FileType:      utils.FileTypeCSV,
 			})
 		}
 		if claGroup.ProjectIclaEnabled {
 			eventPayloads = append(eventPayloads, BuildZipEvent{
 				ClaGroupID:    claGroup.ProjectID,
-				SignatureType: "icla",
+				SignatureType: utils.ClaTypeICLA,
+				FileType:      utils.FileTypePDF,
+			})
+			eventPayloads = append(eventPayloads, BuildZipEvent{
+				ClaGroupID:    claGroup.ProjectID,
+				SignatureType: utils.ClaTypeICLA,
+				FileType:      utils.FileTypeCSV,
 			})
 		}
 	}

--- a/cla-backend-go/utils/constants.go
+++ b/cla-backend-go/utils/constants.go
@@ -105,6 +105,12 @@ const SignatureTypeCLA = "cla"
 // SignatureTypeCCLA is the ccla signature type in the DB
 const SignatureTypeCCLA = "ccla"
 
+// FileTypePDF is the pdf file type
+const FileTypePDF = "pdf"
+
+// FileTypeCSV is the csv file type
+const FileTypeCSV = "csv"
+
 // SignatureReferenceTypeUser is the signature reference type for user signatures - individual and employee
 const SignatureReferenceTypeUser = "user"
 

--- a/cla-backend-go/v2/signatures/service.go
+++ b/cla-backend-go/v2/signatures/service.go
@@ -259,7 +259,7 @@ func (s *Service) GetSignedDocument(ctx context.Context, signatureID string) (*m
 
 // GetSignedCclaZipPdf returns the signed CCLA Zip PDF reference
 func (s *Service) GetSignedCclaZipPdf(claGroupID string) (*models.URLObject, error) {
-	url := utils.SignedClaGroupZipFilename(claGroupID, CCLA)
+	url := utils.SignedClaGroupZipFilename(claGroupID, utils.ClaTypeCCLA)
 	ok, err := s.IsZipPresentOnS3(url)
 	if err != nil {
 		return nil, err
@@ -278,7 +278,7 @@ func (s *Service) GetSignedCclaZipPdf(claGroupID string) (*models.URLObject, err
 
 // GetSignedIclaZipPdf returns the signed ICLA Zip PDF reference
 func (s *Service) GetSignedIclaZipPdf(claGroupID string) (*models.URLObject, error) {
-	url := utils.SignedClaGroupZipFilename(claGroupID, ICLA)
+	url := utils.SignedClaGroupZipFilename(claGroupID, utils.ClaTypeICLA)
 	ok, err := s.IsZipPresentOnS3(url)
 	if err != nil {
 		return nil, err

--- a/cla-backend-go/v2/signatures/zip_builder.go
+++ b/cla-backend-go/v2/signatures/zip_builder.go
@@ -29,8 +29,6 @@ import (
 
 // constants
 const (
-	ICLA               = "icla"
-	CCLA               = "ccla"
 	ParallelDownloader = 100
 )
 
@@ -42,8 +40,11 @@ type Zipper struct {
 
 // ZipBuilder provides method to build ICLA/CCLA zip
 type ZipBuilder interface {
-	BuildICLAZip(claGroupID string) error
-	BuildCCLAZip(claGroupID string) error
+	BuildICLAPDFZip(claGroupID string) error
+	BuildCCLAPDFZip(claGroupID string) error
+	BuildICLACSVZip(claGroupID string) error
+	BuildCCLACSVZip(claGroupID string) error
+	BuildECLACSVZip(claGroupID string) error
 }
 
 // NewZipBuilder returns the ZipBuilder
@@ -62,17 +63,32 @@ func s3ZipPrefix(claType string, claGroupID string) string {
 	return fmt.Sprintf("contract-group/%s/%s/", claGroupID, claType)
 }
 
-// BuildICLAZip builds icla pdfs zip for cla-group and upload it on s3
-func (z *Zipper) BuildICLAZip(claGroupID string) error {
-	return z.buildZip(ICLA, claGroupID)
+// BuildICLAPDFZip builds ICLA pdfs zip for cla-group and upload it on s3
+func (z *Zipper) BuildICLAPDFZip(claGroupID string) error {
+	return z.buildPDFZip(utils.ClaTypeICLA, claGroupID)
 }
 
-// BuildCCLAZip builds ccla pdfs zip for cla-group and upload it on s3
-func (z *Zipper) BuildCCLAZip(claGroupID string) error {
-	return z.buildZip(CCLA, claGroupID)
+// BuildCCLAPDFZip builds CCLA pdfs zip for cla-group and upload it on s3
+func (z *Zipper) BuildCCLAPDFZip(claGroupID string) error {
+	return z.buildPDFZip(utils.ClaTypeCCLA, claGroupID)
 }
 
-func (z *Zipper) buildZip(claType string, claGroupID string) error {
+// BuildICLACSVZip builds ICLA csvs zip for cla-group and upload it to AWS s3
+func (z *Zipper) BuildICLACSVZip(claGroupID string) error {
+	return z.buildCSVZip(utils.ClaTypeICLA, claGroupID)
+}
+
+// BuildCCLACSVZip builds CCLA csvs zip for cla-group and upload it to AWS s3
+func (z *Zipper) BuildCCLACSVZip(claGroupID string) error {
+	return z.buildCSVZip(utils.ClaTypeCCLA, claGroupID)
+}
+
+// BuildECLACSVZip builds ECLA csvs zip for cla-group and upload it to AWS s3
+func (z *Zipper) BuildECLACSVZip(claGroupID string) error {
+	return z.buildCSVZip(utils.ClaTypeECLA, claGroupID)
+}
+
+func (z *Zipper) buildPDFZip(claType string, claGroupID string) error {
 	f := logrus.Fields{"cla_group_id": claGroupID, "cla_type": claType}
 	// get zip file from s3
 	buff, err := z.getZipFileFromS3(claType, claGroupID)
@@ -147,6 +163,12 @@ func (z *Zipper) buildZip(claType string, claGroupID string) error {
 		}
 		log.Debugf("Uploaded zip file %s", remoteZipFileKey)
 	}
+	return nil
+}
+func (z *Zipper) buildCSVZip(claType string, claGroupID string) error {
+	f := logrus.Fields{"cla_group_id": claGroupID, "cla_type": claType}
+	// TODO: DAD - requires query to the signatures table to get the list of signatures, then encode as CSV, then build a zip file, and upload to S3
+	log.WithFields(f).Infof("building %s csv zip for cla-group: %s is currently not supported", claType, claGroupID)
 	return nil
 }
 


### PR DESCRIPTION
- refactored/updated logic to support CSV Zip file downloads from AWS
  S3. Since some projects have 10k+ ICLAs signed, it is impractical to
  wait while the backend processes all the signature files and streams
  the results back to the client. This can sometimes take >5 minutes for
  large CLA groups.  Instead, we want to periodically (daily?)
  pre-process and generate the CSV download and store the results. Then,
  users can quickly download the CSV as a zip file when the navigate to
  the UI. This PR stages the logic to accomplish this. The lambda
  processing is in place and the methods are there. The remaining piece
  is to query the DB, package, zip and upload.

Signed-off-by: David Deal <ddeal@linuxfoundation.org>
