### PR TITLE
[#3769] GitLab Auth Info

### DIFF
--- a/cla-backend-go/v2/gitlab-activity/service.go
+++ b/cla-backend-go/v2/gitlab-activity/service.go
@@ -311,7 +311,7 @@ func GetFullSignURL(gitlabOrganizationID string, gitlabRepositoryID string, mrID
 }
 
 func getAuthorInfo(gitlabUser *gitlab.User) string {
-	return fmt.Sprintf("%s:%s", gitlabUser.Username, gitlabUser.Name)
+	return fmt.Sprintf("login:@%s/name:%s", gitlabUser.Username, gitlabUser.Name)
 }
 
 func (s service) getGitlabOrganizationFromProjectPath(ctx context.Context, projectPath, projectNameSpace string) (*v2Models.GitlabOrganization, error) {


### PR DESCRIPTION
- Updated user details with login and name labels

Signed-off-by: Harold Wanyama <hwanyama@contractor.linuxfoundation.org>