### PR TITLE
GitLab - expanded search scope when processing MR events

### DIFF
--- a/cla-backend-go/users/repository.go
+++ b/cla-backend-go/users/repository.go
@@ -71,6 +71,7 @@ func (repo repository) CreateUser(user *models.User) (*models.User, error) {
 	f := logrus.Fields{
 		"functionName": "users.repository.CreateUser",
 	}
+
 	theUUID, err := uuid.NewUUID()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- don't always create a new user when processing MR requests
- only search for active and non-blocked GitLab users
- adjusted user table search critiera

Signed-off-by: David Deal <ddeal@linuxfoundation.org>