### PR TITLE
Chore: Use just PAT for build-pr

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -41,10 +41,9 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Configure Git to clone private Github repos
-        run: git config --global url."https://${TOKEN_USER}:${TOKEN}@github.com".insteadOf "https://github.com"
+        run: git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
         env:
           TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          TOKEN_USER: ${{ secrets.PERSONAL_ACCESS_TOKEN_USER }}
 
       - name: Add OS Tools
         run: sudo apt update && sudo apt-get install file -y


### PR DESCRIPTION
GitHub no longer requires the use of a username in the clone URL when authenticating with a PAT