### PR TITLE
Revert "Bump serverless from 3.32.2 to 3.33.0 in /cla-backend"

### DIFF
--- a/cla-backend/package.json
+++ b/cla-backend/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "install": "^0.13.0",
     "node.extend": "^2.0.2",
-    "serverless": "^3.33.0",
+    "serverless": "^3.32.2",
     "serverless-domain-manager": "^7.0.4",
     "serverless-finch": "^4.0.3",
     "serverless-layers": "^2.6.1",

--- a/cla-backend/yarn.lock
+++ b/cla-backend/yarn.lock
@@ -1545,7 +1545,7 @@ available-typed-arrays@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz"
 
-aws-sdk@^2.1329.0, aws-sdk@^2.1404.0:
+aws-sdk@^2.1329.0, aws-sdk@^2.1389.0:
   version "2.1386.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1386.0.tgz#6005b33d6c8e9769268d899b3640695e88ce36fd"
   dependencies:
@@ -1980,9 +1980,9 @@ d@1, d@^1.0.1:
     es5-ext "^0.10.50"
     type "^1.0.1"
 
-dayjs@^1.11.8:
-  version "1.11.9"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.9.tgz#9ca491933fadd0a60a2c19f6c237c03517d71d1a"
+dayjs@^1.11.7:
+  version "1.11.7"
+  resolved "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz"
 
 debug@4, debug@^4.1.1, debug@^4.3.4:
   version "4.3.4"
@@ -2092,9 +2092,9 @@ dotenv-expand@^10.0.0:
   version "10.0.0"
   resolved "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz"
 
-dotenv@^16.3.1:
-  version "16.3.1"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
+dotenv@^16.1.3:
+  version "16.1.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.1.3.tgz#0c67e90d0ddb48d08c570888f709b41844928210"
 
 duration@^0.2.2:
   version "0.2.2"
@@ -3577,9 +3577,9 @@ semver@^6.0.0:
   version "6.3.0"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz"
 
-semver@^7.3.2, semver@^7.3.5, semver@^7.3.8, semver@^7.5.3:
-  version "7.5.3"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.3.tgz#161ce8c2c6b4b3bdca6caadc9fa3317a4c4fe88e"
+semver@^7.3.2, semver@^7.3.5, semver@^7.3.8, semver@^7.5.1:
+  version "7.5.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.1.tgz#c90c4d631cf74720e46b21c1d37ea07edfab91ec"
   dependencies:
     lru-cache "^6.0.0"
 
@@ -3663,9 +3663,9 @@ serverless-wsgi@^3.0.1:
     lodash "^4.17.21"
     process-utils "^4.0.0"
 
-serverless@^3.33.0:
-  version "3.33.0"
-  resolved "https://registry.yarnpkg.com/serverless/-/serverless-3.33.0.tgz#7d4aacfacb5f122a24e8c6a8d2972cce99746c0c"
+serverless@^3.32.2:
+  version "3.32.2"
+  resolved "https://registry.yarnpkg.com/serverless/-/serverless-3.32.2.tgz#7d55a44eb2e08cbb8349b9c8c68b747ba4e4a462"
   dependencies:
     "@serverless/dashboard-plugin" "^6.2.3"
     "@serverless/platform-client" "^4.3.2"
@@ -3673,7 +3673,7 @@ serverless@^3.33.0:
     ajv "^8.12.0"
     ajv-formats "^2.1.1"
     archiver "^5.3.1"
-    aws-sdk "^2.1404.0"
+    aws-sdk "^2.1389.0"
     bluebird "^3.7.2"
     cachedir "^2.3.0"
     chalk "^4.1.2"
@@ -3681,9 +3681,9 @@ serverless@^3.33.0:
     ci-info "^3.8.0"
     cli-progress-footer "^2.3.2"
     d "^1.0.1"
-    dayjs "^1.11.8"
+    dayjs "^1.11.7"
     decompress "^4.2.1"
-    dotenv "^16.3.1"
+    dotenv "^16.1.3"
     dotenv-expand "^10.0.0"
     essentials "^1.2.0"
     ext "^1.7.0"
@@ -3711,7 +3711,7 @@ serverless@^3.33.0:
     process-utils "^4.0.0"
     promise-queue "^2.2.5"
     require-from-string "^2.0.2"
-    semver "^7.5.3"
+    semver "^7.5.1"
     signal-exit "^3.0.7"
     stream-buffers "^3.0.2"
     strip-ansi "^6.0.1"


### PR DESCRIPTION
This reverts commit 6f93cbb0948794876e03e8d0bdbd2f30cd121230.