### PR TITLE
add exclude pattern

### DIFF
--- a/cla-backend/serverless.yml
+++ b/cla-backend/serverless.yml
@@ -398,6 +398,7 @@ functions:
     package:
       individually: true
       patterns:
+        - '!**'
         - 'auth/bin/**'
 
   api-v3-lambda:


### PR DESCRIPTION
This pull request includes a change to the `cla-backend/serverless.yml` file to update the packaging patterns for the `functions` configuration. The change ensures that all files are excluded from the package except for those in the `auth/bin` directory.

* [`cla-backend/serverless.yml`](diffhunk://#diff-1a1492fd477eba54969fb1027532519df559b8a3f15afb7ecd59be478a75ce82R401): Added a pattern to exclude all files from the package except for those in the `auth/bin` directory.