### PR TITLE
Create Python venv in '.venv' for Builds

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -70,8 +70,8 @@ jobs:
       - name: Python Setup
         working-directory: cla-backend
         run: |
-          python -m venv venv
-          source venv/bin/activate
+          python -m venv .venv
+          source .venv/bin/activate
           pip install --upgrade pip
           pip install -r requirements.txt
 
@@ -83,8 +83,8 @@ jobs:
       - name: Python Test
         working-directory: cla-backend
         run: |
-          python -m venv venv
-          source venv/bin/activate
+          python -m venv .venv
+          source .venv/bin/activate
           pip install pytest
           pytest "cla/tests" -p no:warnings
         env:


### PR DESCRIPTION
Updates the Deploy DEV workflow to create the python virtual environment
in '.venv', and not 'venv', as '.venv' is explicitly excluded from
serverless while the other is not.

Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>
