### PR TITLE
Fix #4640 issue

### DIFF
--- a/cla-backend/cla/utils.py
+++ b/cla-backend/cla/utils.py
@@ -1933,15 +1933,21 @@ def get_co_authors_from_commit(commit):
 def extract_pull_request_number(pull_request_message):
     """
     Helper function to return pull request number from pull request message
+    Extracts the pull request number from the first line of a message.
+    It picks the last #number in the first line (GitHub appends it automatically).
     :param pull_request_message: message in merge_group payload
     :return:
     """
     fn = "extract_pull_request_number"
     pull_request_number = None
     try:
-        pull_request_number = int(re.search(r"#(\d+)", pull_request_message).group(1))
-    except AttributeError as e:
-        cla.log.warning(f"{fn} - unable to extract pull request number from message: {pull_request_message}, error: {e}")
+        first_line = pull_request_message.splitlines()[0]
+        matches = re.findall(r"#(\d+)", first_line)
+        if matches:
+            pull_request_number = int(matches[-1])  # last match
+        else:
+            cla.log.warning(f"{fn} - error - unable to extract pull request number from message: {pull_request_message}")
     except Exception as e:
-        cla.log.warning(f"{fn} - unable to extract pull request number from message: {pull_request_message}, error: {e}")
+        cla.log.warning(f"{fn} - error - unable to extract pull request number from message: {pull_request_message}, error: {e}")
+    cla.log.debug(f"{fn} - extracted PR number {pull_request_number} from merge_queue data")
     return pull_request_number


### PR DESCRIPTION
The issue was that `python` function was parsing Pull request message provided by user to get PR number where it should fire EasyCLA action. The problem was that user cound provide a PR name that contained some other issue/PR name reference in it, like [OpenTelemetry #12832](https://github.com/open-telemetry/opentelemetry-collector/pull/12832) case where title is:
```
Add documentation example for xconfmap (#5675) #12832
```

That title refers to issue number (5675) and then PR number (12832). The previous python helper function was just getting RE match for first number preceded by `#`. That was identifying issue  5675 as PR number and then causing problems, see [investigation](https://github.com/communitybridge/easycla/issues/4640#issuecomment-2837542423), the corrected version takes the 1st line of PR message and looks for last number preceded by `#`. That value `#N` (where N is the PR number) is added by GitHub automatically, so this should work OK.

cc @mlehotskylf @thakurveerendras 

Fixes https://github.com/communitybridge/easycla/issues/4640