### PR TITLE
Add utils to get (latest) ICLA/CCLA templates and fix get latest document functions in py and go + add test coverage

### DIFF
--- a/cla-backend-go/tests/project_test.go
+++ b/cla-backend-go/tests/project_test.go
@@ -25,14 +25,20 @@ func createDocument(major, minor int, date time.Time, name string) models.ClaGro
 	}
 }
 
+func mustParseTime(t *testing.T, layout, value string) time.Time {
+	dt, err := time.Parse(layout, value)
+	assert.Nil(t, err)
+	return dt
+}
+
 func TestGetCurrentDocument(t *testing.T) {
 	// Dates
-	dt_250217, _ := time.Parse(time.RFC3339, "2025-02-17T15:00:13Z")
-	dt_240217, _ := time.Parse(time.RFC3339, "2024-02-17T15:00:13Z")
-	dt_240218, _ := time.Parse(time.RFC3339, "2024-02-18T15:00:13Z")
-	dt_230217, _ := time.Parse(time.RFC3339, "2023-02-17T15:00:13Z")
-	dt_230218, _ := time.Parse(time.RFC3339, "2023-02-18T15:00:13Z")
-	dt_220218, _ := time.Parse(time.RFC3339, "2022-02-18T15:00:13Z")
+	dt_250217 := mustParseTime(t, time.RFC3339, "2025-02-17T15:00:13Z")
+	dt_240217 := mustParseTime(t, time.RFC3339, "2024-02-17T15:00:13Z")
+	dt_240218 := mustParseTime(t, time.RFC3339, "2024-02-18T15:00:13Z")
+	dt_230217 := mustParseTime(t, time.RFC3339, "2023-02-17T15:00:13Z")
+	dt_230218 := mustParseTime(t, time.RFC3339, "2023-02-18T15:00:13Z")
+	dt_220218 := mustParseTime(t, time.RFC3339, "2022-02-18T15:00:13Z")
 
 	// Create documents
 	document_15 := createDocument(1, 5, dt_250217, "document_15")

--- a/cla-backend-go/tests/project_test.go
+++ b/cla-backend-go/tests/project_test.go
@@ -25,20 +25,20 @@ func createDocument(major, minor int, date time.Time, name string) models.ClaGro
 	}
 }
 
-func mustParseTime(t *testing.T, layout, value string) time.Time {
-	dt, err := time.Parse(layout, value)
+func mustParseTime(t *testing.T, value string) time.Time {
+	dt, err := time.Parse(time.RFC3339, value)
 	assert.Nil(t, err)
 	return dt
 }
 
 func TestGetCurrentDocument(t *testing.T) {
 	// Dates
-	dt_250217 := mustParseTime(t, time.RFC3339, "2025-02-17T15:00:13Z")
-	dt_240217 := mustParseTime(t, time.RFC3339, "2024-02-17T15:00:13Z")
-	dt_240218 := mustParseTime(t, time.RFC3339, "2024-02-18T15:00:13Z")
-	dt_230217 := mustParseTime(t, time.RFC3339, "2023-02-17T15:00:13Z")
-	dt_230218 := mustParseTime(t, time.RFC3339, "2023-02-18T15:00:13Z")
-	dt_220218 := mustParseTime(t, time.RFC3339, "2022-02-18T15:00:13Z")
+	dt_250217 := mustParseTime(t, "2025-02-17T15:00:13Z")
+	dt_240217 := mustParseTime(t, "2024-02-17T15:00:13Z")
+	dt_240218 := mustParseTime(t, "2024-02-18T15:00:13Z")
+	dt_230217 := mustParseTime(t, "2023-02-17T15:00:13Z")
+	dt_230218 := mustParseTime(t, "2023-02-18T15:00:13Z")
+	dt_220218 := mustParseTime(t, "2022-02-18T15:00:13Z")
 
 	// Create documents
 	document_15 := createDocument(1, 5, dt_250217, "document_15")

--- a/cla-backend-go/tests/project_test.go
+++ b/cla-backend-go/tests/project_test.go
@@ -5,7 +5,9 @@ package tests
 
 import (
 	"context"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/communitybridge/easycla/cla-backend-go/project/common"
 
@@ -13,6 +15,78 @@ import (
 	"github.com/communitybridge/easycla/cla-backend-go/utils"
 	"github.com/stretchr/testify/assert"
 )
+
+func createDocument(major, minor int, date time.Time, name string) models.ClaGroupDocument {
+	return models.ClaGroupDocument{
+		DocumentMajorVersion: strconv.Itoa(major),
+		DocumentMinorVersion: strconv.Itoa(minor),
+		DocumentCreationDate: utils.TimeToString(date),
+		DocumentName:         name,
+	}
+}
+
+func TestGetCurrentDocument(t *testing.T) {
+	// Dates
+	dt_250217, _ := time.Parse(time.RFC3339, "2025-02-17T15:00:13Z")
+	dt_240217, _ := time.Parse(time.RFC3339, "2024-02-17T15:00:13Z")
+	dt_240218, _ := time.Parse(time.RFC3339, "2024-02-18T15:00:13Z")
+	dt_230217, _ := time.Parse(time.RFC3339, "2023-02-17T15:00:13Z")
+	dt_230218, _ := time.Parse(time.RFC3339, "2023-02-18T15:00:13Z")
+	dt_220218, _ := time.Parse(time.RFC3339, "2022-02-18T15:00:13Z")
+
+	// Create documents
+	document_15 := createDocument(1, 5, dt_250217, "document_15")
+	document_29 := createDocument(2, 9, dt_240217, "document_29")
+	document_29_newer := createDocument(2, 9, dt_240218, "document_29_newer")
+	document_210 := createDocument(2, 10, dt_230217, "document_210")
+	document_210_newer := createDocument(2, 10, dt_230218, "document_210_newer")
+	document_30 := createDocument(3, 0, dt_220218, "document_30")
+	document_31 := createDocument(3, 1, dt_220218, "document_31")
+	document_310 := createDocument(3, 10, dt_220218, "document_310")
+
+	// Test cases
+	tests := []struct {
+		docs          []models.ClaGroupDocument
+		expectedName  string
+		expectedMajor int
+		expectedMinor int
+	}{
+		{[]models.ClaGroupDocument{document_29}, "document_29", 2, 9},
+		{[]models.ClaGroupDocument{document_29_newer, document_29}, "document_29_newer", 2, 9},
+		{[]models.ClaGroupDocument{document_29, document_29_newer}, "document_29_newer", 2, 9},
+		{[]models.ClaGroupDocument{document_29, document_210}, "document_210", 2, 10},
+		{[]models.ClaGroupDocument{document_29_newer, document_210}, "document_210", 2, 10},
+		{[]models.ClaGroupDocument{document_29, document_210_newer}, "document_210_newer", 2, 10},
+		{[]models.ClaGroupDocument{document_29_newer, document_210_newer}, "document_210_newer", 2, 10},
+		{[]models.ClaGroupDocument{document_29, document_29_newer, document_210}, "document_210", 2, 10},
+		{[]models.ClaGroupDocument{document_29, document_210, document_210_newer}, "document_210_newer", 2, 10},
+		{[]models.ClaGroupDocument{document_29, document_29_newer, document_210, document_210_newer}, "document_210_newer", 2, 10},
+		{[]models.ClaGroupDocument{document_210, document_210_newer, document_29_newer, document_29}, "document_210_newer", 2, 10},
+		{[]models.ClaGroupDocument{document_210, document_15, document_210_newer, document_29_newer, document_29}, "document_210_newer", 2, 10},
+		{[]models.ClaGroupDocument{document_210, document_210_newer, document_29_newer, document_30, document_29}, "document_30", 3, 0},
+		{[]models.ClaGroupDocument{document_210, document_15, document_210_newer, document_29_newer, document_30, document_29}, "document_30", 3, 0},
+		{[]models.ClaGroupDocument{document_15, document_30, document_29}, "document_30", 3, 0},
+		{[]models.ClaGroupDocument{document_31, document_310, document_30}, "document_310", 3, 10},
+	}
+
+	for _, tt := range tests {
+		doc, err := common.GetCurrentDocument(context.Background(), tt.docs)
+		assert.Nil(t, err)
+
+		// Check the document name
+		assert.Equal(t, tt.expectedName, doc.DocumentName)
+
+		// Check the major version
+		major, err := strconv.Atoi(doc.DocumentMajorVersion)
+		assert.Nil(t, err)
+		assert.Equal(t, tt.expectedMajor, major)
+
+		// Check the minor version
+		minor, err := strconv.Atoi(doc.DocumentMinorVersion)
+		assert.Nil(t, err)
+		assert.Equal(t, tt.expectedMinor, minor)
+	}
+}
 
 func TestGetCurrentDocumentVersion(t *testing.T) {
 	currentTime, _ := utils.CurrentTime()

--- a/cla-backend/cla/models/dynamo_models.py
+++ b/cla-backend/cla/models/dynamo_models.py
@@ -1409,13 +1409,16 @@ class Project(model_interfaces.Project):  # pylint: disable=too-many-public-meth
             if current_major > last_major:
                 last_major = current_major
                 last_minor = current_minor
+                latest_date = document.get_document_creation_date()
                 current_document = document
                 continue
             if current_major == last_major and current_minor > last_minor:
                 last_minor = current_minor
+                latest_date = document.get_document_creation_date()
                 current_document = document
+                continue
             # Retrieve document that has the latest date
-            if not latest_date or document.get_document_creation_date() > latest_date:
+            if current_major == last_major and current_minor == last_minor and (not latest_date or document.get_document_creation_date() > latest_date):
                 latest_date = document.get_document_creation_date()
                 current_document = document
         return (last_major, last_minor, current_document)

--- a/cla-backend/cla/tests/unit/test_dynamo_models.py
+++ b/cla-backend/cla/tests/unit/test_dynamo_models.py
@@ -5,14 +5,78 @@ from unittest.mock import Mock
 
 import pytest
 from cla import utils
-from cla.models.dynamo_models import Company, User
+from cla.models.dynamo_models import Company, User, Project, Document
 
 
 @pytest.fixture
 def user():
-    yield  User()
+    yield User()
 
 
+@pytest.fixture
+def project():
+    yield Project()
+
+@pytest.fixture
+def document_factory():
+    def create_document(major, minor, date):
+        mock_document = Mock(spec=Document)
+        mock_document.get_document_major_version.return_value = major
+        mock_document.get_document_minor_version.return_value = minor
+        mock_document.get_document_creation_date.return_value = date
+        return mock_document
+    return create_document
+
+@pytest.fixture
+def document_15(document_factory):
+    return document_factory(1, 5, "2025-02-17T15:00:13Z")
+
+@pytest.fixture
+def document_29(document_factory):
+    return document_factory(2, 9, "2024-02-17T15:00:13Z")
+
+@pytest.fixture
+def document_29_newer(document_factory):
+    return document_factory(2, 9, "2024-02-18T15:00:13Z")
+
+@pytest.fixture
+def document_210(document_factory):
+    return document_factory(2, 10, "2023-02-17T15:00:13Z")
+
+@pytest.fixture
+def document_210_newer(document_factory):
+    return document_factory(2, 10, "2023-02-18T15:00:13Z")
+
+@pytest.fixture
+def document_30(document_factory):
+    return document_factory(3, 0, "2022-02-18T15:00:13Z")
+
+@pytest.fixture
+def document_310(document_factory):
+    return document_factory(3, 10, "2022-02-18T15:00:13Z")
+
+@pytest.fixture
+def document_31(document_factory):
+    return document_factory(3, 1, "2022-02-18T15:00:13Z")
+
+def test_get_latest_version(project, document_15, document_29, document_29_newer, document_210, document_210_newer, document_30, document_31, document_310):
+    assert project._get_latest_version([]) == (0, -1, None)
+    assert project._get_latest_version([document_29]) == (2, 9, document_29)
+    assert project._get_latest_version([document_29_newer, document_29]) == (2, 9, document_29_newer)
+    assert project._get_latest_version([document_29, document_29_newer]) == (2, 9, document_29_newer)
+    assert project._get_latest_version([document_29, document_210]) == (2, 10, document_210)
+    assert project._get_latest_version([document_29_newer, document_210]) == (2, 10, document_210)
+    assert project._get_latest_version([document_29, document_210_newer]) == (2, 10, document_210_newer)
+    assert project._get_latest_version([document_29_newer, document_210_newer]) == (2, 10, document_210_newer)
+    assert project._get_latest_version([document_29, document_29_newer, document_210]) == (2, 10, document_210)
+    assert project._get_latest_version([document_29, document_210, document_210_newer]) == (2, 10, document_210_newer)
+    assert project._get_latest_version([document_29, document_29_newer, document_210, document_210_newer]) == (2, 10, document_210_newer)
+    assert project._get_latest_version([document_210, document_210_newer, document_29_newer, document_29]) == (2, 10, document_210_newer)
+    assert project._get_latest_version([document_210, document_15, document_210_newer, document_29_newer, document_29]) == (2, 10, document_210_newer)
+    assert project._get_latest_version([document_210, document_210_newer, document_29_newer, document_30, document_29]) == (3, 0, document_30)
+    assert project._get_latest_version([document_210, document_15, document_210_newer, document_29_newer, document_30, document_29]) == (3, 0, document_30)
+    assert project._get_latest_version([document_15, document_30, document_29]) == (3, 0, document_30)
+    assert project._get_latest_version([document_31, document_310, document_30]) == (3, 10, document_310)
 
 def test_get_user_email_with_private_email(user):
     """ Test user with a single private email instance """
@@ -28,5 +92,3 @@ def test_get_user_email(user):
     """ Test getting user email with valid email """
     user.model.user_emails = set(["wanyaland@gmail.com"])
     assert utils.get_public_email(user) == "wanyaland@gmail.com"
-
-

--- a/utils/get_all_current_documents_sf.sh
+++ b/utils/get_all_current_documents_sf.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# STAGE=prod
+if [ -z "${STAGE}" ]
+then
+  export STAGE=dev
+fi
+if [ "${STAGE}" = "prod" ]
+then
+  export TABLE="fivetran_ingest.dynamodb_product_us_east_1.cla_prod_projects"
+else
+  export TABLE="fivetran_ingest.dynamodb_product_us_east1_dev.cla_dev_projects"
+fi
+
+JQ='sort_by(.document_major_version, .document_minor_version, .document_creation_date) | .[-1].document_s3_url'
+
+declare -A template_projects
+declare -A projects
+
+data=$(snowsql $(cat ./snowflake.secret) -o friendly=false -o header=false -o timing=false -o output_format=plain -q "select distinct object_construct('project_id', project_id, 'project_name', data:project_name) from ${TABLE} order by 1" | jq -s -r '.')
+
+while read -r project_id project_name
+do
+  template=$(snowsql $(cat ./snowflake.secret) -o friendly=false -o header=false -o timing=false -o output_format=plain -q "select data:project_individual_documents from ${TABLE} where project_id = '${project_id}'" | jq -r "${JQ}")
+  if ( [ -z "${template}" ] || [ "${template}" = "null" ] )
+  then
+    continue
+  fi
+  echo "ICLA ${project_id}"
+  if [ -n "${template_projects[$template]}" ]
+  then
+    template_projects["$template"]+=";${project_id}"
+  else
+    template_projects["$template"]="${project_id}"
+  fi
+  projects["$project_id"]="${project_name}"
+done < <(echo "${data}" | jq -r -c '.[] | "\(.project_id) \(.project_name)"')
+
+while read -r project_id project_name
+do
+  template=$(snowsql $(cat ./snowflake.secret) -o friendly=false -o header=false -o timing=false -o output_format=plain -q "select data:project_corporate_documents from ${TABLE} where project_id = '${project_id}'" | jq -r "${JQ}")
+  if ( [ -z "${template}" ] || [ "${template}" = "null" ] )
+  then
+    continue
+  fi
+  echo "CCLA ${project_id}"
+  if [ -n "${template_projects[$template]}" ]
+  then
+    template_projects["$template"]+=";${project_id}"
+  else
+    template_projects["$template"]="${project_id}"
+  fi
+  projects["$project_id"]="${project_name}"
+done < <(echo "${data}" | jq -r -c '.[] | "\(.project_id) \(.project_name)"')
+
+# for template in "${!template_projects[@]}"
+for template in $(printf "%s\n" "${!template_projects[@]}" | sort)
+do
+  projs="${template_projects[$template]}"
+  names=""
+  IFS=';' read -ra idary <<< "${projs}"
+  for id in "${idary[@]}"; do
+    if [ -z "${names}" ]
+    then
+      names="${projects[$id]} (${id})"
+    else
+      names+=";${projects[$id]} (${id})"
+    fi
+  done
+  IFS=';' read -ra ary <<< "${names}"
+  sorted_projects=$(printf "%s\n" "${ary[@]}" | sort | paste -sd ',' | sed 's/),/), /g')
+  echo "Template: ${template} used by projects: ${sorted_projects}"
+done

--- a/utils/get_all_current_documents_sf.sh
+++ b/utils/get_all_current_documents_sf.sh
@@ -57,7 +57,6 @@ for template in $(printf "%s\n" "${!template_projects[@]}" | sort)
 do
   projs="${template_projects[$template]}"
   names=""
-  np=0
   IFS=';' read -ra idary <<< "${projs}"
   for id in "${idary[@]}"; do
     if [ -z "${names}" ]
@@ -66,9 +65,8 @@ do
     else
       names+=";${projects[$id]} (${id})"
     fi
-    ((np++))
   done
   IFS=';' read -ra ary <<< "${names}"
   sorted_projects=$(printf "%s\n" "${ary[@]}" | sort | uniq | paste -sd ',' | sed 's/),/), /g')
-  echo "Template: ${template} used by ${np} project(s): ${sorted_projects}"
+  echo "Template: ${template} used by project(s): ${sorted_projects}"
 done

--- a/utils/get_all_current_documents_sf.sh
+++ b/utils/get_all_current_documents_sf.sh
@@ -57,6 +57,7 @@ for template in $(printf "%s\n" "${!template_projects[@]}" | sort)
 do
   projs="${template_projects[$template]}"
   names=""
+  np=0
   IFS=';' read -ra idary <<< "${projs}"
   for id in "${idary[@]}"; do
     if [ -z "${names}" ]
@@ -65,8 +66,9 @@ do
     else
       names+=";${projects[$id]} (${id})"
     fi
+    ((np++))
   done
   IFS=';' read -ra ary <<< "${names}"
   sorted_projects=$(printf "%s\n" "${ary[@]}" | sort | paste -sd ',' | sed 's/),/), /g')
-  echo "Template: ${template} used by projects: ${sorted_projects}"
+  echo "Template: ${template} used by ${np} project(s): ${sorted_projects}"
 done

--- a/utils/get_all_current_documents_sf.sh
+++ b/utils/get_all_current_documents_sf.sh
@@ -69,6 +69,6 @@ do
     ((np++))
   done
   IFS=';' read -ra ary <<< "${names}"
-  sorted_projects=$(printf "%s\n" "${ary[@]}" | sort | paste -sd ',' | sed 's/),/), /g')
+  sorted_projects=$(printf "%s\n" "${ary[@]}" | sort | uniq | paste -sd ',' | sed 's/),/), /g')
   echo "Template: ${template} used by ${np} project(s): ${sorted_projects}"
 done

--- a/utils/get_projects_corporate_documents_sf.sh
+++ b/utils/get_projects_corporate_documents_sf.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# STAGE=prod
+# JQ='.[] | {document_major_version, document_minor_version, document_file_id, document_name, document_creation_date, document_s3_url}'
+# JQ='sort_by(.document_major_version, .document_minor_version, .document_creation_date) | .[-1]'
+# JQ='sort_by(.document_major_version, .document_minor_version, .document_creation_date) | .[-1] | {document_major_version, document_minor_version, document_file_id, document_name, document_creation_date, document_s3_url}'
+# d8cead54-92b7-48c5-a2c8-b1e295e8f7f1 - prod CNCF project ID
+if [ -z "$1" ]
+then
+  echo "$0: you need to specify project_id as a 1st argument, example: 'd8cead54-92b7-48c5-a2c8-b1e295e8f7f1'"
+  exit 1
+fi
+if [ -z "${STAGE}" ]
+then
+  export STAGE=dev
+fi
+if [ "${STAGE}" = "prod" ]
+then
+  export TABLE="fivetran_ingest.dynamodb_product_us_east_1.cla_prod_projects"
+else
+  export TABLE="fivetran_ingest.dynamodb_product_us_east1_dev.cla_dev_projects"
+fi
+if [ -z "${JQ}" ]
+then
+  snowsql $(cat ./snowflake.secret) -o friendly=false -o header=false -o timing=false -o output_format=plain -q "select data:project_corporate_documents from ${TABLE} where project_id = '${1}'" | jq -r '.'
+else
+  snowsql $(cat ./snowflake.secret) -o friendly=false -o header=false -o timing=false -o output_format=plain -q "select data:project_corporate_documents from ${TABLE} where project_id = '${1}'" | jq -r "${JQ}"
+fi

--- a/utils/get_projects_individual_documents_sf.sh
+++ b/utils/get_projects_individual_documents_sf.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # STAGE=prod
-# JQ='.[] | {document_major_version, document_minor_version, document_creation_date, document_file_id, document_name}'
-# JQ='sort_by(.document_major_version, .document_minor_version) | .[-1]'
-# JQ='sort_by(.document_major_version, .document_minor_version) | .[-1] | {document_major_version, document_minor_version, document_creation_date, document_file_id, document_name}'
+# JQ='.[] | {document_major_version, document_minor_version, document_file_id, document_name, document_creation_date, document_s3_url}'
+# JQ='sort_by(.document_major_version, .document_minor_version, .document_creation_date) | .[-1]'
+# JQ='sort_by(.document_major_version, .document_minor_version, .document_creation_date) | .[-1] | {document_major_version, document_minor_version, document_file_id, document_name, document_creation_date, document_s3_url}'
 # d8cead54-92b7-48c5-a2c8-b1e295e8f7f1 - prod CNCF project ID
 if [ -z "$1" ]
 then

--- a/utils/get_projects_individual_documents_sf.sh
+++ b/utils/get_projects_individual_documents_sf.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# STAGE=prod
+# JQ='.[] | {document_major_version, document_minor_version, document_creation_date, document_file_id, document_name}'
+# JQ='sort_by(.document_major_version, .document_minor_version) | .[-1]'
+# JQ='sort_by(.document_major_version, .document_minor_version) | .[-1] | {document_major_version, document_minor_version, document_creation_date, document_file_id, document_name}'
+# d8cead54-92b7-48c5-a2c8-b1e295e8f7f1 - prod CNCF project ID
+if [ -z "$1" ]
+then
+  echo "$0: you need to specify project_id as a 1st argument, example: 'd8cead54-92b7-48c5-a2c8-b1e295e8f7f1'"
+  exit 1
+fi
+if [ -z "${STAGE}" ]
+then
+  export STAGE=dev
+fi
+if [ "${STAGE}" = "prod" ]
+then
+  export TABLE="fivetran_ingest.dynamodb_product_us_east_1.cla_prod_projects"
+else
+  export TABLE="fivetran_ingest.dynamodb_product_us_east1_dev.cla_dev_projects"
+fi
+if [ -z "${JQ}" ]
+then
+  snowsql $(cat ./snowflake.secret) -o friendly=false -o header=false -o timing=false -o output_format=plain -q "select data:project_individual_documents from ${TABLE} where project_id = '${1}'" | jq -r '.'
+else
+  snowsql $(cat ./snowflake.secret) -o friendly=false -o header=false -o timing=false -o output_format=plain -q "select data:project_individual_documents from ${TABLE} where project_id = '${1}'" | jq -r "${JQ}"
+fi


### PR DESCRIPTION
- Add utils to get (latest/newest or all) ICLA/CCLA templates for given project.
- Fix get latest document functions in `python` and `golang` (some edge cases).
- Add test coverage for those function (including those edge cases too).

The issue was subtle, could happen when minor version is >= 10:
```
I think I’ve found some subtle bug in golang function to get the latest document (when minor is > 9) - this is not affecting our case, but I will fix to avoid issues in the past.

golang parses versions as float major.minor - parsing from string made of two integers. But when minor becomes 10 then 2.10 is NOT > than 2.9 because 2.10 as float is the same as 2.1.

actually python version also has possible subtle bug, I’ll fix it as well - detected this while adding the test coverage - it wasn't always computing the latest date which could result in wrong document being returned.
```

cc @mlehotskylf @dealako 