### PR TITLE
Adding APIs: /v2/user-from-session, /v4/user-from-token

### DIFF
--- a/cla-backend-go/cmd/server.go
+++ b/cla-backend-go/cmd/server.go
@@ -659,7 +659,7 @@ func createUserFromRequest(authorizer auth.Authorizer, usersService users.Servic
 		if !needToStoreUser {
 			return r
 		}
-		ctx := context.WithValue(r.Context(), "user", userModel)
+		ctx := context.WithValue(r.Context(), "user", userModel) // nolint
 		return r.WithContext(ctx)
 	}
 
@@ -678,7 +678,7 @@ func createUserFromRequest(authorizer auth.Authorizer, usersService users.Servic
 		if !needToStoreUser {
 			return r
 		}
-		ctx := context.WithValue(r.Context(), "user", userModel)
+		ctx := context.WithValue(r.Context(), "user", userModel) // nolint
 		return r.WithContext(ctx)
 	}
 
@@ -705,6 +705,6 @@ func createUserFromRequest(authorizer auth.Authorizer, usersService users.Servic
 	if !needToStoreUser {
 		return r
 	}
-	ctx := context.WithValue(r.Context(), "user", userModel)
+	ctx := context.WithValue(r.Context(), "user", userModel) // nolint
 	return r.WithContext(ctx)
 }

--- a/cla-backend-go/swagger/cla.v2.yaml
+++ b/cla-backend-go/swagger/cla.v2.yaml
@@ -2652,6 +2652,32 @@ paths:
       tags:
         - cla-manager
 
+  /user-from-token:
+    get:
+      summary: Get user object from current bearer token
+      description: Get user object from current bearer token
+      operationId: getUserFromToken
+      parameters:
+        - $ref: "#/parameters/x-request-id"
+        - $ref: "#/parameters/x-acl"
+        - $ref: "#/parameters/x-username"
+        - $ref: "#/parameters/x-email"
+      responses:
+        '200':
+          description: 'Success'
+          headers:
+            x-request-id:
+              type: string
+              description: The unique request ID value - assigned/set by the API Gateway based on the session
+          schema:
+            $ref: '#/definitions/user'
+        '400':
+          $ref: '#/responses/invalid-request'
+        '404':
+          $ref: '#/responses/not-found'
+      tags:
+        - current_user
+
   /user/{userID}/request-company-admin:
     post:
       summary: Request Manager

--- a/cla-backend-go/v2/current_user/handlers.go
+++ b/cla-backend-go/v2/current_user/handlers.go
@@ -5,7 +5,6 @@ package current_user
 
 import (
 	"context"
-	"fmt"
 
 	log "github.com/communitybridge/easycla/cla-backend-go/logging"
 
@@ -23,7 +22,7 @@ func Configure(api *operations.EasyclaAPI, service Service) { // nolint
 	api.CurrentUserGetUserFromTokenHandler = current_user.GetUserFromTokenHandlerFunc(
 		func(params current_user.GetUserFromTokenParams, authUser *auth.User) middleware.Responder {
 			reqID := utils.GetRequestID(params.XREQUESTID)
-			ctx := context.WithValue(params.HTTPRequest.Context(), utils.XREQUESTID, reqID)
+			ctx := context.WithValue(params.HTTPRequest.Context(), utils.XREQUESTID, reqID) // nolint
 			utils.SetAuthUserProperties(authUser, params.XUSERNAME, params.XEMAIL)
 			f := logrus.Fields{
 				"functionName":   "v2.current_user.handlers.GetUserFromToken",
@@ -34,7 +33,7 @@ func Configure(api *operations.EasyclaAPI, service Service) { // nolint
 			log.WithFields(f).Debugf("looking for user from bearer token")
 			userModel, err := service.UserFromContext(ctx)
 			if err != nil {
-				msg := fmt.Sprintf("unable to lookup user from token")
+				msg := "unable to lookup user from token"
 				log.WithFields(f).WithError(err).Warn(msg)
 				return current_user.NewGetUserFromTokenNotFound().WithXRequestID(reqID).WithPayload(utils.ErrorResponseNotFound(reqID, msg))
 			}

--- a/cla-backend-go/v2/current_user/handlers.go
+++ b/cla-backend-go/v2/current_user/handlers.go
@@ -1,0 +1,43 @@
+// Copyright The Linux Foundation and each contributor to CommunityBridge.
+// SPDX-License-Identifier: MIT
+
+package current_user
+
+import (
+	"context"
+	"fmt"
+
+	log "github.com/communitybridge/easycla/cla-backend-go/logging"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/LF-Engineering/lfx-kit/auth"
+	"github.com/communitybridge/easycla/cla-backend-go/gen/v2/restapi/operations"
+	"github.com/communitybridge/easycla/cla-backend-go/gen/v2/restapi/operations/current_user"
+	"github.com/communitybridge/easycla/cla-backend-go/utils"
+	"github.com/go-openapi/runtime/middleware"
+)
+
+// Configure sets up the middleware handlers
+func Configure(api *operations.EasyclaAPI, service Service) { // nolint
+	api.CurrentUserGetUserFromTokenHandler = current_user.GetUserFromTokenHandlerFunc(
+		func(params current_user.GetUserFromTokenParams, authUser *auth.User) middleware.Responder {
+			reqID := utils.GetRequestID(params.XREQUESTID)
+			ctx := context.WithValue(params.HTTPRequest.Context(), utils.XREQUESTID, reqID)
+			utils.SetAuthUserProperties(authUser, params.XUSERNAME, params.XEMAIL)
+			f := logrus.Fields{
+				"functionName":   "v2.current_user.handlers.GetUserFromToken",
+				utils.XREQUESTID: ctx.Value(utils.XREQUESTID),
+				"authUserName":   utils.StringValue(params.XUSERNAME),
+				"authUserEmail":  utils.StringValue(params.XEMAIL),
+			}
+			log.WithFields(f).Debugf("looking for user from bearer token")
+			userModel, err := service.UserFromContext(ctx)
+			if err != nil {
+				msg := fmt.Sprintf("unable to lookup user from token")
+				log.WithFields(f).WithError(err).Warn(msg)
+				return current_user.NewGetUserFromTokenNotFound().WithXRequestID(reqID).WithPayload(utils.ErrorResponseNotFound(reqID, msg))
+			}
+			return current_user.NewGetUserFromTokenOK().WithXRequestID(reqID).WithPayload(userModel)
+		})
+}

--- a/cla-backend-go/v2/current_user/service.go
+++ b/cla-backend-go/v2/current_user/service.go
@@ -1,0 +1,51 @@
+// Copyright The Linux Foundation and each contributor to CommunityBridge.
+// SPDX-License-Identifier: MIT
+
+package current_user
+
+import (
+	"context"
+	"fmt"
+
+	v1Models "github.com/communitybridge/easycla/cla-backend-go/gen/v1/models"
+	v2Models "github.com/communitybridge/easycla/cla-backend-go/gen/v2/models"
+	log "github.com/communitybridge/easycla/cla-backend-go/logging"
+	"github.com/communitybridge/easycla/cla-backend-go/utils"
+	"github.com/jinzhu/copier"
+	"github.com/sirupsen/logrus"
+)
+
+type service struct{}
+
+// Service functions for current_user
+type Service interface {
+	UserFromContext(ctx context.Context) (*v2Models.User, error)
+}
+
+// NewService returns instance of current_user service
+func NewService() Service {
+	return &service{}
+}
+
+func (s *service) UserFromContext(ctx context.Context) (*v2Models.User, error) {
+	f := logrus.Fields{
+		"functionName":   "v2.current_user.service.UserFromContext",
+		utils.XREQUESTID: ctx.Value(utils.XREQUESTID),
+	}
+
+	ctxUserModel, ok := ctx.Value("user").(*v1Models.User)
+	if !ok || ctxUserModel == nil {
+		msg := "unable to lookup user from context"
+		log.WithFields(f).Warn(msg)
+		return nil, fmt.Errorf("cannot find user data in context")
+	}
+
+	var v2UserModel v2Models.User
+	copyErr := copier.Copy(&v2UserModel, &ctxUserModel)
+	if copyErr != nil {
+		log.WithFields(f).Warnf("problem converting DB user model to a v2 user model, error: %+v", copyErr)
+		return nil, copyErr
+	}
+
+	return &v2UserModel, nil
+}

--- a/cla-backend/cla/controllers/repository_service.py
+++ b/cla-backend/cla/controllers/repository_service.py
@@ -33,3 +33,17 @@ def sign_request(provider, installation_id, github_repository_id, change_request
     """
     service = cla.utils.get_repository_service(provider)
     return service.sign_request(installation_id, github_repository_id, change_request_id, request)
+
+def user_from_session(request, response=None):
+    """
+    Return user from OAuth2 session
+    """
+    # LG: to test using MockGitHub class
+    # import os
+    # from cla.models.github_models import MockGitHub
+    # user = MockGitHub(os.environ["GITHUB_OAUTH_TOKEN"]).user_from_session(request)
+    user = cla.utils.get_repository_service('github').user_from_session(request)
+    if user is None:
+        response.status = HTTP_404
+        return {"errors": "Cannot find user from session"}
+    return user.to_dict()

--- a/cla-backend/cla/routes.py
+++ b/cla-backend/cla/routes.py
@@ -1804,6 +1804,37 @@ def get_event(event_id: hug.types.text, response):
     """
     return cla.controllers.event.get_event(event_id=event_id, response=response)
 
+@hug.get("/user-from-session", versions=2)
+def user_from_session(request, response):
+    """
+    GET: /user-from-session
+    Example: https://api.dev.lfcla.com/v2/user-from-session
+    Returns user object from OAuth2 session
+    Example user returned:
+    {
+      "date_created": "2025-05-21T08:05:19.221609+0000",
+      "date_modified": "2025-05-21T08:09:19.943455+0000",
+      "lf_email": null,
+      "lf_sub": null,
+      "lf_username": null,
+      "note": null,
+      "user_company_id": null,
+      "user_emails": [
+        "test@user.com"
+      ],
+      "user_external_id": null,
+      "user_github_id": "123",
+      "user_github_username": "testuser",
+      "user_gitlab_id": null,
+      "user_gitlab_username": null,
+      "user_id": "78bb15eb-8cbf-44e6-8b64-c713db6ee51b",
+      "user_ldap_id": null,
+      "user_name": "Test User",
+      "version": "v1"
+    }
+    """
+    return cla.controllers.repository_service.user_from_session(request, response)
+
 
 @hug.post("/events", versions=1)
 def create_event(

--- a/utils/active_signature_py.sh
+++ b/utils/active_signature_py.sh
@@ -20,5 +20,7 @@ fi
 if [ ! -z "$DEBUG" ]
 then
   echo "curl -s -XGET -H 'Content-Type: application/json' \"${API_URL}/v2/user/${user_id}/active-signature\""
+  curl -s -XGET -H "Content-Type: application/json" "${API_URL}/v2/user/${user_id}/active-signature"
+else
+  curl -s -XGET -H "Content-Type: application/json" "${API_URL}/v2/user/${user_id}/active-signature" | jq -r '.'
 fi
-curl -s -XGET -H "Content-Type: application/json" "${API_URL}/v2/user/${user_id}/active-signature" | jq -r '.'

--- a/utils/active_signature_py.sh
+++ b/utils/active_signature_py.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# user_id='9dcf5bbc-2492-11ed-97c7-3e2a23ea20b5'
+# select key, data:expire from fivetran_ingest.dynamodb_product_us_east1_dev.cla_dev_store where key like 'active_signature:%' order by data:expire desc limit 1;
+# select key, data:expire from fivetran_ingest.dynamodb_product_us_east_1.cla_prod_store where key like 'active_signature:%' order by data:expire desc limit 1;
+# API_URL=https://api.lfcla.dev.platform.linuxfoundation.org DEBUG=1 ./utils/active_signature_py.sh '4b344ac4-f8d9-11ed-ac9b-b29c4ace74e9'
+# API_URL=https://api.lfcla.dev.platform.linuxfoundation.org DEBUG=1 ./utils/active_signature_py.sh '4b344ac4-f8d9-11ed-ac9b-b29c4ace74e9'
+
+if [ -z "$1" ]
+then
+  echo "$0: you need to specify user_id as a 1st parameter"
+  exit 1
+fi
+export user_id="$1"
+
+if [ -z "$API_URL" ]
+then
+  export API_URL="http://localhost:5000"
+fi
+
+if [ ! -z "$DEBUG" ]
+then
+  echo "curl -s -XGET -H 'Content-Type: application/json' \"${API_URL}/v2/user/${user_id}/active-signature\""
+fi
+curl -s -XGET -H "Content-Type: application/json" "${API_URL}/v2/user/${user_id}/active-signature" | jq -r '.'

--- a/utils/active_signature_py.sh
+++ b/utils/active_signature_py.sh
@@ -4,6 +4,7 @@
 # select key, data:expire from fivetran_ingest.dynamodb_product_us_east_1.cla_prod_store where key like 'active_signature:%' order by data:expire desc limit 1;
 # API_URL=https://api.lfcla.dev.platform.linuxfoundation.org DEBUG=1 ./utils/active_signature_py.sh '4b344ac4-f8d9-11ed-ac9b-b29c4ace74e9'
 # API_URL=https://api.lfcla.dev.platform.linuxfoundation.org DEBUG=1 ./utils/active_signature_py.sh '4b344ac4-f8d9-11ed-ac9b-b29c4ace74e9'
+# API_URL=https://api.easycla.lfx.linuxfoundation.org DEBUG='' ./utils/active_signature_py.sh '564e571e-12d7-4857-abd4-898939accdd7'
 
 if [ -z "$1" ]
 then

--- a/utils/check_prepare_employee_signature_py.sh
+++ b/utils/check_prepare_employee_signature_py.sh
@@ -3,7 +3,7 @@
 # user_id='9dcf5bbc-2492-11ed-97c7-3e2a23ea20b5'
 # company_id='862ff296-6508-4f10-9147-2bc2dd7bfe80'
 # project_id='88ee12de-122b-4c46-9046-19422054ed8d'
-# DEBUG=1 ./utils/check_prepare_employee_signature_py 9dcf5bbc-2492-11ed-97c7-3e2a23ea20b5 862ff296-6508-4f10-9147-2bc2dd7bfe80 88ee12de-122b-4c46-9046-19422054ed8d github 'http://localhost'
+# DEBUG=1 ./utils/check_prepare_employee_signature_py 9dcf5bbc-2492-11ed-97c7-3e2a23ea20b5 862ff296-6508-4f10-9147-2bc2dd7bfe80 88ee12de-122b-4c46-9046-19422054ed8d
 # DEBUG=1 ./utils/check_prepare_employee_signature_py.sh 65d22813-1ac0-4292-bb68-fdcb278473a5 4930fe6e-e023-4f56-9767-6f1996a7b730 43c546ff-bc79-4a32-9454-77dabd6afaee
 
 if [ -z "$1" ]

--- a/utils/get_user_from_session_py.sh
+++ b/utils/get_user_from_session_py.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# API_URL=https://[xyz].ngrok-free.app (defaults to localhost:5000)
+# API_URL=https://api.lfcla.dev.platform.linuxfoundation.org
+# DEBUG='' ./utils/get_user_from_session_py.sh
+
+if [ -z "$API_URL" ]
+then
+  export API_URL="http://localhost:5000"
+fi
+
+API="${API_URL}/v2/user-from-session"
+
+if [ ! -z "$DEBUG" ]
+then
+  echo "curl -s -XGET -H \"Content-Type: application/json\" \"${API}\""
+  curl -s -XGET -H "Content-Type: application/json" "${API}"
+else
+  curl -s -XGET -H "Content-Type: application/json" "${API}" | jq -r '.'
+fi

--- a/utils/get_user_from_token_go.sh
+++ b/utils/get_user_from_token_go.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# API_URL=https://[xyz].ngrok-free.app (defaults to localhost:5000)
+# API_URL=https://api.lfcla.dev.platform.linuxfoundation.org
+# DEBUG='' ./utils/get_user_from_token_go.sh
+# Note: To run manually see cla-backend-go/auth/authorizer.go:SecurityAuth() and update accordingly 'LG:'
+
+if [ -z "$TOKEN" ]
+then
+  # source ./auth0_token.secret
+  TOKEN="$(cat ./auth0.token.secret)"
+fi
+
+if [ -z "$TOKEN" ]
+then
+  echo "$0: TOKEN not specified and unable to obtain one"
+  exit 1
+fi
+
+if [ -z "$XACL" ]
+then
+  XACL="$(cat ./x-acl.secret)"
+fi
+
+if [ -z "$XACL" ]
+then
+  echo "$0: XACL not specified and unable to obtain one"
+  exit 2
+fi
+
+if [ -z "$API_URL" ]
+then
+  export API_URL="http://localhost:5000"
+fi
+
+API="${API_URL}/v4/user-from-token"
+
+if [ ! -z "$DEBUG" ]
+then
+  echo "curl -s -XGET -H \"X-ACL: ${XACL}\" -H \"Authorization: Bearer ${TOKEN}\" -H \"Content-Type: application/json\" \"${API}\""
+  curl -s -XGET -H "X-ACL: ${XACL}" -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" "${API}"
+else
+  curl -s -XGET -H "X-ACL: ${XACL}" -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" "${API}" | jq -r '.'
+fi

--- a/utils/lookup_store_ddb.sh
+++ b/utils/lookup_store_ddb.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# STAGE=prod ./utils/lookup_store_ddb.sh 'active_signature:564e571e-12d7-4857-abd4-898939accdd7'
+if [ -z "$1" ]
+then
+  echo "$0: you need to specify key as a 1st argument"
+  echo "example: 'active_signature:564e571e-12d7-4857-abd4-898939accdd7'"
+  exit 1
+fi
+if [ -z "${STAGE}" ]
+then
+  export STAGE=dev
+fi
+
+aws --profile "lfproduct-${STAGE}" dynamodb get-item --table-name "cla-${STAGE}-store" --key "{\"key\": {\"S\": \"${1}\"}}" | jq -r '.'

--- a/utils/lookup_store_sf.sh
+++ b/utils/lookup_store_sf.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# STAGE=prod ./utils/lookup_store_sf.sh 'active_signature:f6a0ed33-917b-4336-b4c3-145f0f357274'
+if [ -z "$1" ]
+then
+  echo "$0: you need to specify key as a 1st argument"
+  echo "example: 'active_signature:564e571e-12d7-4857-abd4-898939accdd7'"
+  exit 1
+fi
+if [ -z "${STAGE}" ]
+then
+  export STAGE=dev
+fi
+if [ "${STAGE}" = "prod" ]
+then
+  snowsql $(cat ./snowflake.secret) -o friendly=false -o header=false -o timing=false -o output_format=plain -q "select data from fivetran_ingest.dynamodb_product_us_east_1.cla_prod_store where key = '${1}'" | jq -r '.'
+else
+  snowsql $(cat ./snowflake.secret) -o friendly=false -o header=false -o timing=false -o output_format=plain -q "select data from fivetran_ingest.dynamodb_product_us_east1_dev.cla_dev_store where key = '${1}'" | jq -r '.'
+fi


### PR DESCRIPTION
1) Added V2 (`python`) API to get user from `GitHub session`:
- `/v2/user-from-session`.

Tested with Mock classes so it should work when deployed. Call it via: `/v2/user-from-session` and if there is an active `OAuth2` session then you will get user details like:
```
{
  "date_created": "2025-05-21T08:05:19.221609+0000",
  "date_modified": "2025-05-21T08:09:19.943455+0000",
  "lf_email": null,
  "lf_sub": null,
  "lf_username": null,
  "note": null,
  "user_company_id": null,
  "user_emails": [
    "test@user.com"
  ],
  "user_external_id": null,
  "user_github_id": "123",
  "user_github_username": "testuser",
  "user_gitlab_id": null,
  "user_gitlab_username": null,
  "user_id": "78bb15eb-8cbf-44e6-8b64-c713db6ee51b",
  "user_ldap_id": null,
  "user_name": "Test User",
  "version": "v1"
}
```
If there is no active session it will redirect via: `"GET /v2/user-from-session HTTP/1.1" 302` to something like:
```
https://github.com/login/oauth/authorize?response_type=code&client_id=[redacted]&redirect_uri=https%3A%2F%2Fapi.lfcla.dev.platform.linuxfoundation.org%2Fv2%2Fgithub%2Finstallation&scope=user%3Aemail&state=[redacted]
```
and once finished GitHub authentication it will redirect back to the same API but with GitHub session present meaning: `"github_oauth2_token"` present in session.



2) Added V4 (`golang`) API to get user from `Bearer Token`:
- `/v4/user-from-token`.
Tested with M2M token and manual updates to get claims (also used mock data), on success API will return:
```
{
  "dateCreated": "2025-05-06T05:33:08Z",
  "dateModified": "2025-05-06T05:33:08Z",
  "emails": null,
  "lfEmail": "example@gmail.com",
  "lfUsername": "user",
  "userID": "978c2fef-2a3b-11f0-b6c4-e4434be65a60",
  "username": "Name Surname",
  "version": "v1"
}
```
On failure it will return `404` - for example if claims from the token doesn’t allow to find the user (but they should always allow that because middleware is finding or creating user based on claims after routing but before actual api call):
```
{
  "Code": "404",
  "Message": "EasyCLA - 404 Not Found - unable to lookup user from token",
  "x-request-id": "6e7781be-d235-4ced-bbf8-d28c48ea6e4b"
}
```

cc @mlehotskylf @amolsontakke3576 @thakurveerendras @jarias-lfx 

Now this needs to be "experimentally" deployed to `dev` - and then FE can start playing with calling those 2 APIs and see if that can be used to implement links to sign CLAs without need of creating PRs.

Basically we should:
1) Replace documentation links like: `https://easycla.dev.communitybridge.org/#/cla/project/01af041c-fa69-4052-a23c-fb8c1d3bef24/user/4b344ac4-f8d9-11ed-ac9b-b29c4ace74e9?redirect=https:%2F%2Fgithub.com%2Fmlehotskylf-org2%2Feasycla-dev%2Fpull%2F17` (project & user specific) with `https://easycla.dev.communitybridge.org/#/cla/project/01af041c-fa69-4052-a23c-fb8c1d3bef24` (no longer with user UUID and without return URL as this can be clicked from anywhere)
2) Add a new route in FE (CLA contributor console):
- instead of `/cla/project/{project_uuid}/user/{user_uuid}` it should be `/cla/project/{project_uuid}` - so user UUID is unknown.
- And now we can test those 2 APIs - call any of them to get user DATA (which includes UUID) and on success use the returned UUID and redirect to old route (the one that needs user UUID).
- We have two options: 
  - (a) call v2 API if we have GitHub session (FE can check it?) that API will redirect to GitHub logion page if session is not present - handle redirect - it will go back to the same API but with GitHub session data filled in.
  - (b) call the V4 API which requires bearer token (so needs to be after LF SSO?) - this one will also return user data (including UUID) but can fail if there is no token and it will not redirect you them - but just fail with 404.


cc @mlehotskylf @amolsontakke3576 