### PR TITLE
Handle redirect only if redirect=true|1|yes passed

### DIFF
--- a/cla-backend/cla/controllers/repository_service.py
+++ b/cla-backend/cla/controllers/repository_service.py
@@ -34,7 +34,7 @@ def sign_request(provider, installation_id, github_repository_id, change_request
     service = cla.utils.get_repository_service(provider)
     return service.sign_request(installation_id, github_repository_id, change_request_id, request)
 
-def user_from_session(request, response=None):
+def user_from_session(redirect, request, response=None):
     """
     Return user from OAuth2 session
     """
@@ -42,8 +42,10 @@ def user_from_session(request, response=None):
     # import os
     # from cla.models.github_models import MockGitHub
     # user = MockGitHub(os.environ["GITHUB_OAUTH_TOKEN"]).user_from_session(request)
-    user = cla.utils.get_repository_service('github').user_from_session(request)
+    user = cla.utils.get_repository_service('github').user_from_session(request, redirect)
     if user is None:
         response.status = HTTP_404
         return {"errors": "Cannot find user from session"}
+    if isinstance(user, dict):
+        return user
     return user.to_dict()

--- a/cla-backend/cla/models/github_models.py
+++ b/cla-backend/cla/models/github_models.py
@@ -96,7 +96,7 @@ class GitHub(repository_service_interface.RepositoryService):
         else:
             cla.log.debug("github_models.received_activity - Ignoring unsupported action: {}".format(data["action"]))
 
-    def user_from_session(self, request):
+    def user_from_session(self, request, redirect):
         fn = "github_models.user_from_session"  # function name
         cla.log.debug(f"{fn} - Loading session from request: {request}...")
         session = self._get_request_session(request)
@@ -111,7 +111,11 @@ class GitHub(repository_service_interface.RepositoryService):
             cla.log.debug(f"{fn} - Obtained GitHub OAuth2 state from authorization - storing state in the session...")
             session["github_oauth2_state"] = state
             cla.log.debug(f"{fn} - GitHub OAuth2 request with state {state} - sending user to {authorization_url}")
-            raise falcon.HTTPFound(authorization_url)
+            print(f"redirect {redirect}")
+            if redirect:
+                raise falcon.HTTPFound(authorization_url)
+            else:
+                return { "redirect_url": authorization_url }
 
     def sign_request(self, installation_id, github_repository_id, change_request_id, request):
         """

--- a/cla-backend/cla/routes.py
+++ b/cla-backend/cla/routes.py
@@ -1833,7 +1833,9 @@ def user_from_session(request, response):
       "version": "v1"
     }
     """
-    return cla.controllers.repository_service.user_from_session(request, response)
+    raw_redirect = request.params.get('redirect', 'false').lower()
+    redirect = raw_redirect in ('1', 'true', 'yes')
+    return cla.controllers.repository_service.user_from_session(redirect, request, response)
 
 
 @hug.post("/events", versions=1)

--- a/utils/get_user_from_session_py.sh
+++ b/utils/get_user_from_session_py.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
 # API_URL=https://[xyz].ngrok-free.app (defaults to localhost:5000)
 # API_URL=https://api.lfcla.dev.platform.linuxfoundation.org
-# DEBUG='' ./utils/get_user_from_session_py.sh
+# REDIRECT=0|1 DEBUG='' ./utils/get_user_from_session_py.sh
 
 if [ -z "$API_URL" ]
 then
   export API_URL="http://localhost:5000"
 fi
 
-API="${API_URL}/v2/user-from-session"
+if [ -z "${REDIRECT}" ]
+then
+  export REDIRECT="0"
+fi
+
+API="${API_URL}/v2/user-from-session?redirect=${REDIRECT}"
 
 if [ ! -z "$DEBUG" ]
 then


### PR DESCRIPTION
Now API `/v2/user-from-session` does not return HTTP 302 redirect to OAuth2 by default.
It now only does when `redirect` query parameter is set to `1` or `yes` or `true`, like:
```
curl -s -XGET -H "Content-Type: application/json" "http://localhost:5000/v2/user-from-session?redirect=true"
```

If redirect is not specified or has different value, it now returns "redirect" URL in HTTP OK 200 response, like this: `curl -s -XGET -H "Content-Type: application/json" "http://localhost:5000/v2/user-from-session?redirect=0"`
```
{
  "redirect_url": "https://github.com/login/oauth/authorize?response_type=code&client_id=[xxx]&redirect_uri=https%3A%2F%2Fapi.lfcla.dev.platform.linuxfoundation.org%2Fv2%2Fgithub%2Finstallation&scope=user%3Aemail&state=[xxx]"
}
```

cc @amolsontakke3576 @mlehotskylf 