### PR TITLE
Require redirect_url when no github session yet in /v2/user-from-session

### DIFF
--- a/cla-backend/cla/controllers/repository_service.py
+++ b/cla-backend/cla/controllers/repository_service.py
@@ -6,7 +6,7 @@ Controller related to repository service provider activity.
 """
 
 import cla
-
+from falcon import HTTP_404
 
 def received_activity(provider, data):
     """
@@ -34,7 +34,7 @@ def sign_request(provider, installation_id, github_repository_id, change_request
     service = cla.utils.get_repository_service(provider)
     return service.sign_request(installation_id, github_repository_id, change_request_id, request)
 
-def user_from_session(redirect, request, response=None):
+def user_from_session(redirect, redirect_url, request, response=None):
     """
     Return user from OAuth2 session
     """
@@ -42,7 +42,7 @@ def user_from_session(redirect, request, response=None):
     # import os
     # from cla.models.github_models import MockGitHub
     # user = MockGitHub(os.environ["GITHUB_OAUTH_TOKEN"]).user_from_session(request)
-    user = cla.utils.get_repository_service('github').user_from_session(request, redirect)
+    user = cla.utils.get_repository_service('github').user_from_session(request, redirect, redirect_url)
     if user is None:
         response.status = HTTP_404
         return {"errors": "Cannot find user from session"}

--- a/cla-backend/cla/models/github_models.py
+++ b/cla-backend/cla/models/github_models.py
@@ -96,7 +96,7 @@ class GitHub(repository_service_interface.RepositoryService):
         else:
             cla.log.debug("github_models.received_activity - Ignoring unsupported action: {}".format(data["action"]))
 
-    def user_from_session(self, request, redirect):
+    def user_from_session(self, request, redirect, redirect_url):
         fn = "github_models.user_from_session"  # function name
         cla.log.debug(f"{fn} - Loading session from request: {request}...")
         session = self._get_request_session(request)
@@ -107,7 +107,10 @@ class GitHub(repository_service_interface.RepositoryService):
             return user
         else:
             cla.log.debug(f"{fn} - No existing GitHub OAuth2 token - building authorization url and state")
-            authorization_url, state = self.get_authorization_url_and_state(None, None, None, ["user:email"])
+            if redirect_url == '':
+                cla.log.debug(f"{fn} - no redirect_url provided to redirect back after GitHub OAuth2 authorization and no session yet")
+                return None
+            authorization_url, state = self.get_github_oauth2_redirect_url_and_state(redirect_url)
             cla.log.debug(f"{fn} - Obtained GitHub OAuth2 state from authorization - storing state in the session...")
             session["github_oauth2_state"] = state
             cla.log.debug(f"{fn} - GitHub OAuth2 request with state {state} - sending user to {authorization_url}")
@@ -175,6 +178,23 @@ class GitHub(repository_service_interface.RepositoryService):
             cla.log.debug(f"{fn} - session: {session} which is now type: {type(session)}...")
 
         return session
+
+    def get_github_oauth2_redirect_url_and_state(self, redirect_uri):
+        fn = "github_models.get_github_oauth2_redirect_url_and_state"
+        github_oauth_url = cla.conf["GITHUB_OAUTH_AUTHORIZE_URL"]
+        github_oauth_client_id = os.environ["GH_OAUTH_CLIENT_ID"]
+
+        scope = ["user"]
+        cla.log.debug(
+            f"{fn} - Directing user to the github authorization url: {github_oauth_url} via "
+            f"our github installation flow: {redirect_uri} "
+            f"using the github oauth client id: {github_oauth_client_id[0:5]} "
+            f"with scope: {scope}"
+        )
+
+        return self._get_authorization_url_and_state(
+            client_id=github_oauth_client_id, redirect_uri=redirect_uri, scope=scope, authorize_url=github_oauth_url
+        )
 
     def get_authorization_url_and_state(self, installation_id, github_repository_id, pull_request_number, scope):
         """

--- a/cla-backend/cla/routes.py
+++ b/cla-backend/cla/routes.py
@@ -1835,7 +1835,8 @@ def user_from_session(request, response):
     """
     raw_redirect = request.params.get('redirect', 'false').lower()
     redirect = raw_redirect in ('1', 'true', 'yes')
-    return cla.controllers.repository_service.user_from_session(redirect, request, response)
+    redirect_url = request.params.get('redirect_url', '')
+    return cla.controllers.repository_service.user_from_session(redirect, redirect_url, request, response)
 
 
 @hug.post("/events", versions=1)

--- a/utils/get_user_from_session_py.sh
+++ b/utils/get_user_from_session_py.sh
@@ -2,6 +2,15 @@
 # API_URL=https://[xyz].ngrok-free.app (defaults to localhost:5000)
 # API_URL=https://api.lfcla.dev.platform.linuxfoundation.org
 # REDIRECT=0|1 DEBUG='' ./utils/get_user_from_session_py.sh
+# API_URL=https://api.lfcla.dev.platform.linuxfoundation.org DEBUG=1 REDIRECT=0 ./utils/get_user_from_session_py.sh 'https://contributor.easycla.lfx.linuxfoundation.org/#/cla/project/68fa91fe-51fe-41ac-a21d-e0a0bf688a53'
+
+if [ -z "$1" ]
+then
+  echo "$0: you need to specify return URL as a 1st argument, for example: 'https://contributor.easycla.lfx.linuxfoundation.org/#/cla/project/68fa91fe-51fe-41ac-a21d-e0a0bf688a53'"
+  exit 1
+fi
+export redirect_url="$1"
+export encoded_redirect_url=$(jq -rn --arg x "$redirect_url" '$x|@uri')
 
 if [ -z "$API_URL" ]
 then
@@ -13,12 +22,12 @@ then
   export REDIRECT="0"
 fi
 
-API="${API_URL}/v2/user-from-session?redirect=${REDIRECT}"
+API="${API_URL}/v2/user-from-session?redirect=${REDIRECT}&redirect_url=${encoded_redirect_url}"
 
 if [ ! -z "$DEBUG" ]
 then
   echo "curl -s -XGET -H \"Content-Type: application/json\" \"${API}\""
-  curl -s -XGET -H "Content-Type: application/json" "${API}"
+  curl -i -s -XGET -H "Content-Type: application/json" "${API}"
 else
   curl -s -XGET -H "Content-Type: application/json" "${API}" | jq -r '.'
 fi


### PR DESCRIPTION
 @amolsontakke3576 

- `/v2/user-from-session` API now requires `redirect_url` query parameter to be set if there is no github session. That URL will be used to redirect user back to after successful GitHub authorization.

cc @mlehotskylf 