### PR TITLE
Fix #4666 - use DynamoDB name & email prior to calling user-svc API as a fallback

### DIFF
--- a/cla-backend-go/v2/company/service.go
+++ b/cla-backend-go/v2/company/service.go
@@ -186,10 +186,23 @@ func (s *service) GetCompanyProjectCLAManagers(ctx context.Context, v1CompanyMod
 			continue
 		}
 		for _, user := range sig.SignatureACL {
+			name := user.Username
+			if name == "" {
+				name = user.GithubUsername
+			}
+			if name == "" {
+				name = user.GitlabUsername
+			}
+			email := ""
+			if len(user.Emails) > 0 {
+				email = user.Emails[0]
+			}
 			claManagers = append(claManagers, &models.CompanyClaManager{
 				// DB doesn't have approved_on value
 				ApprovedOn:        sig.SignatureCreated,
 				LfUsername:        user.LfUsername,
+				Name:              name,
+				Email:             strfmt.Email(email),
 				ProjectID:         sig.ProjectID,
 				OrganizationSfid:  v1CompanyModel.CompanyExternalID,
 				OrganizationID:    v1CompanyModel.CompanyID,

--- a/utils/get_company_project_cla_managers.sh
+++ b/utils/get_company_project_cla_managers.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# API_URL=https://[xyz].ngrok-free.app (defaults to localhost:5000)
+# API_URL=https://api.lfcla.dev.platform.linuxfoundation.org
+# DEBUG='' ./utils/get_company_project_cla_managers.sh f7c7ac9c-4dbf-4104-ab3f-6b38a26d82dc a09P000000DsCE5IAN
+# Note: To run manually see cla-backend-go/auth/authorizer.go:SecurityAuth() and update accordingly 'LG:'
+
+if [ -z "$TOKEN" ]
+then
+  # source ./auth0_token.secret
+  TOKEN="$(cat ./auth0.token.secret)"
+fi
+
+if [ -z "$TOKEN" ]
+then
+  echo "$0: TOKEN not specified and unable to obtain one"
+  exit 1
+fi
+
+if [ -z "$XACL" ]
+then
+  XACL="$(cat ./x-acl.secret)"
+fi
+
+if [ -z "$XACL" ]
+then
+  echo "$0: XACL not specified and unable to obtain one"
+  exit 2
+fi
+
+if [ -z "${1}" ]
+then
+  echo "$0: you need to provide company UUID as a 1st argument, for example: 'f7c7ac9c-4dbf-4104-ab3f-6b38a26d82dc'"
+  exit 3
+fi
+export company_uuid="${1}"
+
+if [ -z "${2}" ]
+then
+  echo "$0: you need to provide project SFID as a 2nd argument, for example: 'a09P000000DsCE5IAN'"
+  exit 4
+fi
+export project_sfid="${2}"
+
+if [ -z "$API_URL" ]
+then
+  export API_URL="http://localhost:5000"
+fi
+
+API="${API_URL}/v4/company/${company_uuid}/project/${project_sfid}/cla-managers"
+
+if [ ! -z "$DEBUG" ]
+then
+  echo "curl -s -XGET -H \"X-ACL: ${XACL}\" -H \"Authorization: Bearer ${TOKEN}\" -H \"Content-Type: application/json\" \"${API}\""
+  curl -s -XGET -H "X-ACL: ${XACL}" -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" "${API}"
+else
+  curl -s -XGET -H "X-ACL: ${XACL}" -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" "${API}" | jq -r '.'
+fi


### PR DESCRIPTION
Use data that was already loaded in `SignatureACL` as `name` & `email` prior to calling `user-svc` API, so if any of signature's ACL user is not found in user-service (by using LF username) then return data that was already found in DynamoDB.

cc @thakurveerendras @mlehotskylf 