### PR TITLE
Add logging of V1/V2 API calls

### DIFF
--- a/cla-backend/cla/routes.py
+++ b/cla-backend/cla/routes.py
@@ -49,6 +49,7 @@ def process_data(request, response):
     later on in the other handlers, currently only active on /github/activity
     endpoint because it's an expensive operation.
     """
+    cla.log.info('LG:api-request-path:' + request.path)
     if "/github/activity" in request.path:
         body = request.bounded_stream.read()
         request.bounded_stream.read = lambda: body


### PR DESCRIPTION
cc @mlehotskylf @thakurveerendras @dealako @jarias-lfx - this is for identifying which V1/V2 python APIs are still in use...
