### PR TITLE
Add '/v2/user-from-token' API

### DIFF
--- a/cla-backend/cla/routes.py
+++ b/cla-backend/cla/routes.py
@@ -1843,6 +1843,37 @@ def user_from_session(request, response):
     get_redirect_url = raw_redirect in ('1', 'true', 'yes')
     return cla.controllers.repository_service.user_from_session(get_redirect_url, request, response)
 
+@hug.get("/user-from-token", versions=2)
+def user_from_token(auth_user: check_auth, request, response):
+    """
+    GET: /user-from-token
+    Example: https://api.dev.lfcla.com/v2/user-from-token
+    Returns user object from Bearer token
+    Example user returned:
+    {
+      "date_created": "2025-02-11T08:16:01.000000+0000",
+      "date_modified": "2025-02-11T08:16:01.000000+0000",
+      "lf_email": "lukaszgryglicki@o2.pl",
+      "lf_sub": null,
+      "lf_username": "lgryglicki",
+      "note": null,
+      "user_company_id": "0ca30016-6457-466c-bc41-a09560c1f9bf",
+      "user_emails": null,
+      "user_external_id": "0014100000Te0yqAAB",
+      "user_github_id": null,
+      "user_github_username": null,
+      "user_gitlab_id": null,
+      "user_gitlab_username": null,
+      "user_id": "6e1fd921-e850-11ef-b5df-92cef1e60fc3",
+      "user_ldap_id": null,
+      "user_name": "Lukasz Gryglicki",
+      "version": "v1"
+    }
+    Will return 200 and user data if token is valid
+    Can return 404 on token errors
+    """
+    return cla.controllers.user.get_or_create_user(auth_user).to_dict()
+
 
 @hug.post("/events", versions=1)
 def create_event(

--- a/utils/get_user_from_token_py.sh
+++ b/utils/get_user_from_token_py.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# API_URL=https://[xyz].ngrok-free.app (defaults to localhost:5000)
+# API_URL=https://api.lfcla.dev.platform.linuxfoundation.org
+# DEBUG='' ./utils/get_user_from_token_py.sh
+# For testing locally two options:
+# 1) cla/routes.py: 'LG:': return request and cla.auth.fake_authenticate_user(request.headers) - test with fake data
+# Or to get a real user data:
+# 2a) on local (non remote) computer: ~/get_oauth_token.sh (or ~/get_oauth_token_prod.sh) (will open browser, authenticate to LF, and return token data)
+# 2b) edit 'cla/auth.py': uncomment: 'LG: for local environment override', then run server via: clear && AUTH0_USERNAME_CLAIM_CLI='http://lfx.dev/claims/username' yarn serve:ext
+# 2c) then TOKEN='value from the get_oauth_token.sh script' DEBUG='' ./utils/get_user_from_token_py.sh
+
+if [ -z "$TOKEN" ]
+then
+  # source ./auth0_token.secret
+  TOKEN="$(cat ./auth0.token.secret)"
+fi
+
+if [ -z "$TOKEN" ]
+then
+  echo "$0: TOKEN not specified and unable to obtain one"
+  exit 1
+fi
+
+if [ -z "$XACL" ]
+then
+  XACL="$(cat ./x-acl.secret)"
+fi
+
+if [ -z "$XACL" ]
+then
+  echo "$0: XACL not specified and unable to obtain one"
+  exit 2
+fi
+
+if [ -z "$API_URL" ]
+then
+  export API_URL="http://localhost:5000"
+fi
+
+API="${API_URL}/v2/user-from-token"
+
+if [ ! -z "$DEBUG" ]
+then
+  echo "curl -s -XGET -H \"X-ACL: ${XACL}\" -H \"Authorization: Bearer ${TOKEN}\" -H \"Content-Type: application/json\" \"${API}\""
+  curl -s -XGET -H "X-ACL: ${XACL}" -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" "${API}"
+else
+  curl -s -XGET -H "X-ACL: ${XACL}" -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" "${API}" | jq -r '.'
+fi


### PR DESCRIPTION
cc @mlehotskylf @amolsontakke3576 - this is a small part of https://github.com/communitybridge/easycla/pull/4680 so we can merge only a new API and then FE to use it and after both we can proceed with the remaining APIs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new API endpoint to retrieve user information based on the authenticated token.
  - Introduced a utility script for fetching user data from the API using an OAuth token, supporting both local and environment-based token retrieval.
- **Documentation**
  - Included usage instructions and example responses for the new endpoint and utility script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->