### PR TITLE
Fixing build status in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Introduction to EasyCLA
 
-[![CircleCI](https://circleci.com/gh/communitybridge/easycla.svg?style=svg)](https://circleci.com/gh/communitybridge/easycla)
+[![Build Status](https://github.com/linuxfoundation/easycla/actions/workflows/deploy-prod.yml/badge.svg)](https://github.com/linuxfoundation/easycla/actions/workflows/deploy-prod.yml)
 
 The Contributor License Agreement \(CLA\) service of the Linux Foundation lets project contributors read, sign, and submit contributor license agreements easily.
 


### PR DESCRIPTION
Fixing build status in README.md
<img width="1291" height="1137" alt="Screenshot 2025-08-02 at 8 45 11 AM" src="https://github.com/user-attachments/assets/500e22b4-60ed-4042-9a27-e39305a8b82b" />
