### PR TITLE
Update co-authors search algorithm 

### DIFF
--- a/CO_AUTHORS.md
+++ b/CO_AUTHORS.md
@@ -155,7 +155,7 @@ If it does, the backend will process the co-authors as follows, assume trailer v
 
 - Second we check if email is in format `username@users.noreply.github.com`. If it is we use username part as GitHub username/login and fetch the user from GitHub API. If the user is found, we use that user as co-author.
 
-- Third we lookup for email using GitHub API. If the user is found, we use that user as co-author.
+- Third we lookup for email using GitHub API. If the user is found, we use that user as co-author. If not we lookup for this user in EasyCLA database by email (first by primary/LF email and then by other emails). If found, we use that user as co-author.
 
 - Finally we use the name part for `name <email>`. If the name matches the GitHub username pattern (alphanumeric characters or hyphens, must be 3–39 characters long, cannot start or end with a hyphen, and cannot contain consecutive hyphens), then we lookup using the GitHub API assuming that this name is a GitHub username/login (this is the case for some bots). If the user is found, we use that user as co-author.
 

--- a/cla-backend-go/github/github_repository.go
+++ b/cla-backend-go/github/github_repository.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	log "github.com/linuxfoundation/easycla/cla-backend-go/logging"
+	"github.com/linuxfoundation/easycla/cla-backend-go/users"
 	"github.com/linuxfoundation/easycla/cla-backend-go/utils"
 	"github.com/sirupsen/logrus"
 
@@ -29,6 +30,31 @@ var (
 	NoreplyUserPattern          = regexp.MustCompile(`^([a-zA-Z0-9-]+)@users\.noreply\.github\.com$`)
 	GithubUsernameRegex         = regexp.MustCompile(`^[A-Za-z0-9-]{3,39}$`)
 )
+
+// Note: we use | and ||| as placeholders for inline and fenced code, then swap to backticks at render time.
+const MissingCoAuthorsMessage = `
+
+One or more co-authors of this pull request were not found. You must specify co-authors in commit message trailer via:
+
+|||
+Co-authored-by: name <email>
+|||
+
+Supported |Co-authored-by:| formats include:
+
+1) |Anything <id+login@users.noreply.github.com>| - it will locate your GitHub user by |id| part.
+2) |Anything <login@users.noreply.github.com>| - it will locate your GitHub user by |login| part.
+3) |Anything <public-email>| - it will locate your GitHub user by |public-email| part. Note that this email must be made public on Github.
+4) |Anything <other-email>| - it will locate your GitHub user by |other-email| part but only if that email was used before for any other CLA as a main commit author.
+5) |login <any-valid-email>| - it will locate your GitHub user by |login| part, note that |login| part must be at least 3 characters long.
+
+Please update your commit message(s) by doing |git commit --amend| and then |git push [--force]| and then request re-running CLA check via commenting on this pull request:
+
+|||
+/easycla
+|||
+
+`
 
 const (
 	help         = "https://help.github.com/en/github/committing-changes-to-your-project/why-are-my-commits-linked-to-the-wrong-user"
@@ -327,13 +353,15 @@ func GetCoAuthorsFromCommit(
 		commitMessage := commit.GetCommit().GetMessage()
 		// log.WithFields(f).Debugf("commit message: %s", commitMessage)
 
-		re := regexp.MustCompile(`(?i)co-authored-by: (.*) <(.*)>`)
+		re := regexp.MustCompile(`(?i)co-authored-by:\s*(.+?)\s*<([^<>]+)>`)
 		matches := re.FindAllStringSubmatch(commitMessage, -1)
 		for _, match := range matches {
 			name := strings.TrimSpace(match[1])
-			email := strings.TrimSpace(match[2])
-			coAuthors = append(coAuthors, [2]string{name, email})
-			log.WithFields(f).Debugf("found co-author: name: %s, email: %s", name, email)
+			email := strings.ToLower(strings.TrimSpace(match[2]))
+			if name != "" && email != "" {
+				coAuthors = append(coAuthors, [2]string{name, email})
+				log.WithFields(f).Debugf("found co-author: name: %s, email: %s", name, email)
+			}
 		}
 	}
 	return coAuthors
@@ -343,21 +371,27 @@ func GetCoAuthorsFromCommit(
 func ExpandWithCoAuthors(
 	ctx context.Context,
 	client *github.Client,
+	usersService users.Service,
 	commit *github.RepositoryCommit,
 	pr int,
 	installationID int64,
 	commitAuthors *[]*UserCommitSummary,
-) {
+) bool {
 	f := logrus.Fields{
 		"functionName": "github.github_repository.ExpandWithCoAuthors",
 		"pr":           pr,
 	}
 	coAuthors := GetCoAuthorsFromCommit(ctx, commit)
 	log.WithFields(f).Debugf("co-authors found: %s", coAuthors)
+	missing := false
 	for _, coAuthor := range coAuthors {
-		summary := GetCoAuthorCommits(ctx, client, coAuthor, commit, pr, installationID)
+		summary, found := GetCoAuthorCommits(ctx, client, usersService, coAuthor, commit, pr, installationID)
 		*commitAuthors = append(*commitAuthors, summary)
+		if !missing && !found {
+			missing = true
+		}
 	}
+	return missing
 }
 
 // IsValidGitHubUsername checks if the provided username is a valid GitHub username.
@@ -374,14 +408,16 @@ func IsValidGitHubUsername(username string) bool {
 	return true
 }
 
+//nolint:gocyclo // complexity is acceptable for now
 func GetCoAuthorCommits(
 	ctx context.Context,
 	client *github.Client,
+	usersService users.Service,
 	coAuthor [2]string,
 	commit *github.RepositoryCommit,
 	pr int,
 	installationID int64,
-) *UserCommitSummary {
+) (*UserCommitSummary, bool) {
 	f := logrus.Fields{
 		"functionName":    "github.github_repository.GetCoAuthorCommits",
 		"pr":              pr,
@@ -398,9 +434,12 @@ func GetCoAuthorCommits(
 	)
 	name = strings.TrimSpace(coAuthor[0])
 	email = strings.TrimSpace(coAuthor[1])
+	lName := strings.ToLower(name)
 
-	if cachedUser, ok := GithubUserCache.Get([2]string{name, email}); ok {
+	cacheKey := [2]string{lName, email}
+	if cachedUser, ok := GithubUserCache.Get(cacheKey); ok {
 		log.WithFields(f).Debugf("GitHub user found in cache for name/email: %s/%s: %+v", name, email, cachedUser)
+		found := false
 		var summary *UserCommitSummary
 		if cachedUser != nil {
 			summary = &UserCommitSummary{
@@ -409,6 +448,7 @@ func GetCoAuthorCommits(
 				Affiliated:   false,
 				Authorized:   false,
 			}
+			found = cachedUser.ID != nil
 		} else {
 			summary = &UserCommitSummary{
 				SHA: utils.StringValue(commit.SHA),
@@ -423,7 +463,7 @@ func GetCoAuthorCommits(
 			}
 		}
 		log.WithFields(f).Debugf("PR: %d, %+v (from cache)", pr, summary)
-		return summary
+		return summary, found
 	}
 
 	log.WithFields(f).Debugf("Getting co-author details: %+v", coAuthor)
@@ -454,19 +494,63 @@ func GetCoAuthorCommits(
 		}
 	}
 
-	// 3. Try to find user by email
+	// 3. Try to find user by email via GitHub APIs
 	if user == nil {
 		user, err = SearchGithubUserByEmail(ctx, client, email)
 		if err != nil {
-			log.WithFields(f).Debugf("Co-author GitHub user not found via email %s: %v (error: %v)", email, coAuthor, err)
+			log.WithFields(f).Debugf("Co-author GitHub user not found via github email %s: %v (error: %v)", email, coAuthor, err)
 			user = nil
 		}
 	}
 
+	//	3b. Try to find user by email in our database
+	if user == nil {
+		var githubID string
+		dbUsers, err2 := usersService.GetUsersByLFEmail(email)
+		if err2 == nil {
+			for _, dbUser := range dbUsers {
+				if dbUser.GithubID != "" {
+					githubID = dbUser.GithubID
+					// log.WithFields(f).Debugf("FOUND githubID.1 = %s", githubID)
+					break
+				}
+			}
+		} else {
+			log.WithFields(f).Debugf("Co-author GitHub user not found via lf email %s: %v (error: %v)", email, coAuthor, err2)
+		}
+		if githubID == "" {
+			dbUsers, err2 := usersService.GetUsersByEmail(email)
+			if err2 == nil {
+				for _, dbUser := range dbUsers {
+					if dbUser.GithubID != "" {
+						githubID = dbUser.GithubID
+						// log.WithFields(f).Debugf("FOUND githubID.2 = %s", githubID)
+						break
+					}
+				}
+			} else {
+				log.WithFields(f).Debugf("Co-author GitHub user not found via emails %s: %v (error: %v)", email, coAuthor, err2)
+			}
+		}
+		if githubID != "" {
+			githubIDInt, err2 := strconv.ParseInt(githubID, 10, 64)
+			if err2 != nil {
+				log.WithFields(f).Debugf("Co-author GitHub user not found via lf email %s, wrong GitHub ID: %s: %v (error: %v)", email, githubID, coAuthor, err2)
+			} else {
+				user, err = GetGithubUserByID(ctx, client, githubIDInt)
+				if err != nil {
+					log.WithFields(f).Debugf("Error fetching user by ID %d: %v", githubIDInt, err)
+					user = nil
+				}
+				// log.WithFields(f).Debugf("FOUND user = (%s, %d, %s, %s)", *user.Login, *user.ID, *user.Name, *user.Email)
+			}
+		}
+	}
+
 	// 4. Last resort - try to find by name=login
-	if user == nil && IsValidGitHubUsername(name) {
+	if user == nil && IsValidGitHubUsername(lName) {
 		// Note that Co-authored-by: name <email> is not actually a GitHub login but rather a name - but we are trying hard to find a GitHub profile
-		user, err = GetGithubUserByLogin(ctx, client, name)
+		user, err = GetGithubUserByLogin(ctx, client, lName)
 		if err != nil {
 			log.WithFields(f).Debugf("Co-author GitHub user not found via name=login=%s: %v (error: %v)", name, coAuthor, err)
 			user = nil
@@ -476,12 +560,14 @@ func GetCoAuthorCommits(
 	log.WithFields(f).Debugf("Co-author: %v, user: %+v", coAuthor, user)
 
 	var summary *UserCommitSummary
+	found := false
 	if user != nil {
 		if user.Login != nil {
 			login = *user.Login
 		}
 		if user.ID != nil {
 			githubID = *user.ID
+			found = true
 		}
 		if user.Name == nil || (user.Name != nil && strings.TrimSpace(*user.Name) == "") {
 			user.Name = &name
@@ -512,11 +598,11 @@ func GetCoAuthorCommits(
 		log.WithFields(f).Debugf("Co-author GitHub user details not found: %v", coAuthor)
 	}
 
-	GithubUserCache.Set([2]string{name, email}, user)
-	return summary
+	GithubUserCache.Set(cacheKey, user)
+	return summary, found
 }
 
-func GetPullRequestCommitAuthors(ctx context.Context, installationID int64, pullRequestID int, owner, repo string, withCoAuthors bool) ([]*UserCommitSummary, *string, error) {
+func GetPullRequestCommitAuthors(ctx context.Context, usersService users.Service, installationID int64, pullRequestID int, owner, repo string, withCoAuthors bool) ([]*UserCommitSummary, *string, bool, error) {
 	f := logrus.Fields{
 		"functionName":  "github.github_repository.GetPullRequestCommitAuthors",
 		"pullRequestID": pullRequestID,
@@ -527,21 +613,22 @@ func GetPullRequestCommitAuthors(ctx context.Context, installationID int64, pull
 	client, err := NewGithubAppClient(installationID)
 	if err != nil {
 		log.WithFields(f).WithError(err).Warn("unable to create Github client")
-		return nil, nil, err
+		return nil, nil, false, err
 	}
 
 	commits, resp, comErr := client.PullRequests.ListCommits(ctx, owner, repo, pullRequestID, &github.ListOptions{})
 	if comErr != nil {
 		log.WithFields(f).WithError(comErr).Warnf("problem listing commits for repo: %s/%s pull request: %d", owner, repo, pullRequestID)
-		return nil, nil, comErr
+		return nil, nil, false, comErr
 	}
 	if resp.StatusCode != http.StatusOK {
 		msg := fmt.Sprintf("unexpected status code: %d - expected: %d", resp.StatusCode, http.StatusOK)
 		log.WithFields(f).Warn(msg)
-		return nil, nil, errors.New(msg)
+		return nil, nil, false, errors.New(msg)
 	}
 
 	log.WithFields(f).Debugf("found %d commits for pull request: %d", len(commits), pullRequestID)
+	anyMissing := false
 	for _, commit := range commits {
 		log.WithFields(f).Debugf("loaded commit: %+v", commit)
 		commitAuthor := ""
@@ -571,7 +658,10 @@ func GetPullRequestCommitAuthors(ctx context.Context, installationID int64, pull
 			Authorized:   false,
 		})
 		if withCoAuthors {
-			ExpandWithCoAuthors(ctx, client, commit, pullRequestID, installationID, &userCommitSummary)
+			missing := ExpandWithCoAuthors(ctx, client, usersService, commit, pullRequestID, installationID, &userCommitSummary)
+			if !anyMissing && missing {
+				anyMissing = true
+			}
 		}
 	}
 
@@ -584,10 +674,10 @@ func GetPullRequestCommitAuthors(ctx context.Context, installationID int64, pull
 	//	}
 	//	log.WithFields(f).Debugf("user commit summary: %+v", *summary)
 	//}
-	return userCommitSummary, latestCommitSHA, nil
+	return userCommitSummary, latestCommitSHA, anyMissing, nil
 }
 
-func UpdatePullRequest(ctx context.Context, installationID int64, pullRequestID int, owner, repo string, repoID *int64, latestSHA string, signed []*UserCommitSummary, missing []*UserCommitSummary, CLABaseAPIURL, CLALandingPage, CLALogoURL string) error {
+func UpdatePullRequest(ctx context.Context, installationID int64, pullRequestID int, owner, repo string, repoID *int64, latestSHA string, signed []*UserCommitSummary, missing []*UserCommitSummary, anyMissing bool, CLABaseAPIURL, CLALandingPage, CLALogoURL string) error {
 	f := logrus.Fields{
 		"functionName":   "github.github_repository.UpdatePullRequest",
 		"installationID": installationID,
@@ -618,7 +708,7 @@ func UpdatePullRequest(ctx context.Context, installationID int64, pullRequestID 
 		return failedErr
 	}
 
-	body := assembleCLAComment(ctx, int(installationID), pullRequestID, repoID, signed, missing, CLABaseAPIURL, CLALogoURL, CLALandingPage)
+	body := assembleCLAComment(ctx, int(installationID), pullRequestID, repoID, signed, missing, anyMissing, CLABaseAPIURL, CLALogoURL, CLALandingPage)
 
 	if len(missing) == 0 {
 		// All contributors are passing
@@ -649,7 +739,7 @@ func UpdatePullRequest(ctx context.Context, installationID int64, pullRequestID 
 			// If we have previously succeeded, then we also need to update the comment (pass => fail)
 			log.WithFields(f).Debugf("Found previously succeeeded checks - updating the CLA comment in the PR : %d", pullRequestID)
 			// Generate a new comment with all the failed CLA info
-			failedComment := assembleCLAComment(ctx, int(installationID), pullRequestID, repoID, signed, missing, CLABaseAPIURL, CLALogoURL, CLALandingPage)
+			failedComment := assembleCLAComment(ctx, int(installationID), pullRequestID, repoID, signed, missing, anyMissing, CLABaseAPIURL, CLALogoURL, CLALandingPage)
 			previousSucceededComment.Body = &failedComment
 			_, _, err = client.Issues.EditComment(ctx, owner, repo, *previousSucceededComment.ID, previousSucceededComment)
 			if err != nil {
@@ -766,7 +856,7 @@ func assembleCLAStatus(authorName string, signed bool) (string, string) {
 	return authorName, "Missing CLA Authorization."
 }
 
-func assembleCLAComment(ctx context.Context, installationID, pullRequestID int, repositoryID *int64, signed, missing []*UserCommitSummary, apiBaseURL, CLALogoURL, CLALandingPage string) string {
+func assembleCLAComment(ctx context.Context, installationID, pullRequestID int, repositoryID *int64, signed, missing []*UserCommitSummary, anyMissing bool, apiBaseURL, CLALogoURL, CLALandingPage string) string {
 	f := logrus.Fields{
 		"functionName":   "github.github_repository.assembleCLAComment",
 		utils.XREQUESTID: ctx.Value(utils.XREQUESTID),
@@ -786,13 +876,13 @@ func assembleCLAComment(ctx context.Context, installationID, pullRequestID int, 
 
 	log.WithFields(f).Debug("Building CLAComment body ")
 	signURL := getFullSignURL(repositoryType, strconv.Itoa(installationID), strconv.Itoa(int(*repositoryID)), strconv.Itoa(pullRequestID), apiBaseURL)
-	commentBody := getCommentBody(repositoryType, signURL, signed, missing)
+	commentBody := getCommentBody(repositoryType, signURL, signed, missing, anyMissing)
 	allSigned := len(missing) == 0
 	badge := getCommentBadge(allSigned, signURL, missingID, false, CLALandingPage, CLALogoURL)
 	return fmt.Sprintf("%s<br >%s", badge, commentBody)
 }
 
-func getCommentBody(repositoryType, signURL string, signed, missing []*UserCommitSummary) string {
+func getCommentBody(repositoryType, signURL string, signed, missing []*UserCommitSummary, anyMissing bool) string {
 	f := logrus.Fields{
 		"functionName":   "github.github_repository:getCommentBody",
 		"repositoryType": repositoryType,
@@ -864,6 +954,10 @@ func getCommentBody(repositoryType, signURL string, signed, missing []*UserCommi
 		text = "<br>The committers listed above are authorized under a signed CLA."
 	}
 
+	if anyMissing {
+		committersComment.WriteString(strings.ReplaceAll(MissingCoAuthorsMessage, "|", "`"))
+		log.WithFields(f).Debug("some co-authors are missing for this PR, added the missing co-author message")
+	}
 	return fmt.Sprintf("%s%s", committersComment.String(), text)
 }
 

--- a/cla-backend-go/signatures/service.go
+++ b/cla-backend-go/signatures/service.go
@@ -1023,7 +1023,7 @@ func (s service) updateChangeRequest(ctx context.Context, ghOrg *models.GithubOr
 	// Fetch committers
 	withCoAuthors := github.IsCoAuthorsEnabledForRepo(ghOrg.EnableCoAuthors, gitHubRepoName)
 	log.WithFields(f).Debugf("fetching commit authors for PR: %d using repository owner: %s, repo: %s", pullRequestID, gitHubOrgName, gitHubRepoName)
-	authors, latestSHA, authorsErr := github.GetPullRequestCommitAuthors(ctx, ghOrg.OrganizationInstallationID, int(pullRequestID), gitHubOrgName, gitHubRepoName, withCoAuthors)
+	authors, latestSHA, anyMissing, authorsErr := github.GetPullRequestCommitAuthors(ctx, s.usersService, ghOrg.OrganizationInstallationID, int(pullRequestID), gitHubOrgName, gitHubRepoName, withCoAuthors)
 	if authorsErr != nil {
 		log.WithFields(f).WithError(authorsErr).Warnf("unable to get commit authors for %s/%s for PR: %d", gitHubOrgName, gitHubRepoName, pullRequestID)
 		return authorsErr
@@ -1124,7 +1124,7 @@ func (s service) updateChangeRequest(ctx context.Context, ghOrg *models.GithubOr
 	log.WithFields(f).Debugf("commit authors status after allowlisting bots => signed: %+v, missing: %+v, allowlisted: %+v", signed, unsigned, allowlisted)
 
 	// update pull request
-	updateErr := github.UpdatePullRequest(ctx, ghOrg.OrganizationInstallationID, int(pullRequestID), gitHubOrgName, gitHubRepoName, githubRepository.ID, *latestSHA, signed, unsigned, s.claBaseAPIURL, s.claLandingPage, s.claLogoURL)
+	updateErr := github.UpdatePullRequest(ctx, ghOrg.OrganizationInstallationID, int(pullRequestID), gitHubOrgName, gitHubRepoName, githubRepository.ID, *latestSHA, signed, unsigned, anyMissing, s.claBaseAPIURL, s.claLandingPage, s.claLogoURL)
 	if updateErr != nil {
 		log.WithFields(f).Debugf("unable to update PR: %d", pullRequestID)
 		return updateErr

--- a/cla-backend-go/users/mocks/mock_repo.go
+++ b/cla-backend-go/users/mocks/mock_repo.go
@@ -216,6 +216,21 @@ func (mr *MockUserRepositoryMockRecorder) GetUsersByEmail(userEmail interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsersByEmail", reflect.TypeOf((*MockUserRepository)(nil).GetUsersByEmail), userEmail)
 }
 
+// GetUsersByLFEmail mocks base method.
+func (m *MockUserRepository) GetUsersByLFEmail(userEmail string) ([]*models.User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUsersByLFEmail", userEmail)
+	ret0, _ := ret[0].([]*models.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUsersByLFEmail indicates an expected call of GetUsersByLFEmail.
+func (mr *MockUserRepositoryMockRecorder) GetUsersByLFEmail(userEmail interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsersByLFEmail", reflect.TypeOf((*MockUserRepository)(nil).GetUsersByLFEmail), userEmail)
+}
+
 // Save mocks base method.
 func (m *MockUserRepository) Save(user *models.UserUpdate) (*models.User, error) {
 	m.ctrl.T.Helper()

--- a/cla-backend-go/users/repository.go
+++ b/cla-backend-go/users/repository.go
@@ -42,6 +42,7 @@ type UserRepository interface {
 	GetUserByExternalID(userExternalID string) (*models.User, error)
 	GetUserByUserName(userName string, fullMatch bool) (*models.User, error)
 	GetUserByEmail(userEmail string) (*models.User, error)
+	GetUsersByLFEmail(userEmail string) ([]*models.User, error)
 	GetUserByGitHubID(gitHubID string) (*models.User, error)
 	GetUserByGitHubUsername(gitHubUsername string) (*models.User, error)
 	GetUserByGitlabID(gitlabID int) (*models.User, error)
@@ -125,7 +126,7 @@ func (repo repository) CreateUser(user *models.User) (*models.User, error) {
 
 	if user.LfEmail != "" {
 		attributes["lf_email"] = &dynamodb.AttributeValue{
-			S: aws.String(user.LfEmail.String()),
+			S: aws.String(strings.ToLower(user.LfEmail.String())),
 		}
 	}
 
@@ -340,6 +341,7 @@ func (repo repository) Save(user *models.UserUpdate) (*models.User, error) {
 		"tableName":        repo.tableName,
 	}
 
+	user.LfEmail = strings.ToLower(user.LfEmail)
 	var oldUserModel *models.User
 	var err error
 	oldUserModel, err = repo.getUserByUpdateModel(user)
@@ -881,12 +883,76 @@ func (repo repository) GetUsersByEmail(userEmail string) ([]*models.User, error)
 	return users, nil
 }
 
+// GetUsersByLFEmail fetches the user record by email
+func (repo repository) GetUsersByLFEmail(userEmail string) ([]*models.User, error) {
+	f := logrus.Fields{
+		"functionName": "users.repository.GetUsersByLFEmail",
+		"userEmail":    userEmail,
+	}
+	userEmail = strings.ToLower(userEmail)
+	// This is the key we want to match
+	condition := expression.Key("lf_email").Equal(expression.Value(userEmail))
+
+	// These are the columns we want returned
+	projection := buildUserProjection()
+
+	// Use the nice builder to create the expression
+	expr, err := expression.NewBuilder().WithKeyCondition(condition).WithProjection(projection).Build()
+	if err != nil {
+		log.WithFields(f).WithError(err).Warnf("error building expression for lf_email : %s, error: %v", userEmail, err)
+		return []*models.User{}, err
+	}
+
+	// Assemble the query input parameters
+	queryInput := &dynamodb.QueryInput{
+		ExpressionAttributeNames:  expr.Names(),
+		ExpressionAttributeValues: expr.Values(),
+		KeyConditionExpression:    expr.KeyCondition(),
+		ProjectionExpression:      expr.Projection(),
+		TableName:                 aws.String(repo.tableName),
+		IndexName:                 aws.String("lf-email-index"),
+	}
+
+	// Make the DynamoDB Query API call
+	result, err := repo.dynamoDBClient.Query(queryInput)
+	if err != nil {
+		log.WithFields(f).WithError(err).Warnf("error retrieving user by lf_email: %s, error: %+v", userEmail, err)
+		return []*models.User{}, err
+	}
+
+	// The user model
+	var dbUserModels []DBUser
+
+	err = dynamodbattribute.UnmarshalListOfMaps(result.Items, &dbUserModels)
+	if err != nil {
+		log.WithFields(f).WithError(err).Warnf("error unmarshalling user record from database for lf_email: %s, error: %+v", userEmail, err)
+		return []*models.User{}, err
+	}
+
+	if len(dbUserModels) == 0 {
+		return []*models.User{}, &utils.UserNotFound{
+			Message:   fmt.Sprintf("user not found when searching by lf email: %s", userEmail),
+			UserLFID:  "",
+			UserName:  "",
+			UserEmail: userEmail,
+			Err:       nil,
+		}
+	}
+
+	usrs := make([]*models.User, 0, len(dbUserModels))
+	for _, dbUser := range dbUserModels {
+		usrs = append(usrs, convertDBUserModel(dbUser))
+	}
+	return usrs, nil
+}
+
 // GetUserByEmail fetches the user record by email
 func (repo repository) GetUserByEmail(userEmail string) (*models.User, error) {
 	f := logrus.Fields{
 		"functionName": "users.repository.GetUserByEmail",
 		"userEmail":    userEmail,
 	}
+	userEmail = strings.ToLower(userEmail)
 	// This is the key we want to match
 	condition := expression.Key("lf_email").Equal(expression.Value(userEmail))
 
@@ -1325,7 +1391,7 @@ func convertDBUserModel(user DBUser) *models.User {
 		UserID:         user.UserID,
 		UserExternalID: user.UserExternalID,
 		Admin:          user.Admin,
-		LfEmail:        strfmt.Email(user.LFEmail),
+		LfEmail:        strfmt.Email(strings.ToLower(user.LFEmail)),
 		LfSub:          user.LFSub,
 		LfUsername:     user.LFUsername,
 		DateCreated:    user.DateCreated,

--- a/cla-backend-go/users/service.go
+++ b/cla-backend-go/users/service.go
@@ -22,6 +22,8 @@ type Service interface {
 	GetUserByLFUserName(lfUserName string) (*models.User, error)
 	GetUserByUserName(userName string, fullMatch bool) (*models.User, error)
 	GetUserByEmail(userEmail string) (*models.User, error)
+	GetUsersByEmail(userEmail string) ([]*models.User, error)
+	GetUsersByLFEmail(userEmail string) ([]*models.User, error)
 	GetUserByGitHubID(gitHubID string) (*models.User, error)
 	GetUserByGitHubUsername(gitlabUsername string) (*models.User, error)
 	GetUserByGitlabID(gitHubID int) (*models.User, error)
@@ -154,6 +156,22 @@ func (s service) GetUserByEmail(userEmail string) (*models.User, error) {
 		return nil, errors.New("userEmail is empty")
 	}
 	return s.repo.GetUserByEmail(userEmail)
+}
+
+// GetUsersByEmail fetches the users by email
+func (s service) GetUsersByEmail(userEmail string) ([]*models.User, error) {
+	if userEmail == "" {
+		return nil, errors.New("userEmail is empty")
+	}
+	return s.repo.GetUsersByEmail(userEmail)
+}
+
+// GetUsersByLFEmail fetches the users by email
+func (s service) GetUsersByLFEmail(userEmail string) ([]*models.User, error) {
+	if userEmail == "" {
+		return nil, errors.New("userEmail is empty")
+	}
+	return s.repo.GetUsersByLFEmail(userEmail)
 }
 
 // GetUserByGitHubID fetches the user by GitHub ID

--- a/cla-backend-go/v2/sign/helpers.go
+++ b/cla-backend-go/v2/sign/helpers.go
@@ -61,7 +61,7 @@ func (s service) updateChangeRequest(ctx context.Context, installationID, reposi
 		withCoAuthors = github.IsCoAuthorsEnabledForRepo(ghOrg.EnableCoAuthors, gitHubRepoName)
 	}
 	log.WithFields(f).Debugf("fetching commit authors for PR: %d using repository owner: %s, repo: %s", pullRequestID, gitHubOrgName, gitHubRepoName)
-	authors, latestSHA, authorsErr := github.GetPullRequestCommitAuthors(ctx, installationID, int(pullRequestID), gitHubOrgName, gitHubRepoName, withCoAuthors)
+	authors, latestSHA, anyMissing, authorsErr := github.GetPullRequestCommitAuthors(ctx, s.userService, installationID, int(pullRequestID), gitHubOrgName, gitHubRepoName, withCoAuthors)
 	if authorsErr != nil {
 		log.WithFields(f).WithError(authorsErr).Warnf("unable to get commit authors for %s/%s for PR: %d", gitHubOrgName, gitHubRepoName, pullRequestID)
 		return authorsErr
@@ -164,7 +164,7 @@ func (s service) updateChangeRequest(ctx context.Context, installationID, reposi
 	}
 
 	// update pull request
-	updateErr := github.UpdatePullRequest(ctx, installationID, int(pullRequestID), gitHubOrgName, gitHubRepoName, githubRepository.ID, *latestSHA, signed, unsigned, s.ClaV1ApiURL, s.claLandingPage, s.claLogoURL)
+	updateErr := github.UpdatePullRequest(ctx, installationID, int(pullRequestID), gitHubOrgName, gitHubRepoName, githubRepository.ID, *latestSHA, signed, unsigned, anyMissing, s.ClaV1ApiURL, s.claLandingPage, s.claLogoURL)
 	if updateErr != nil {
 		log.WithFields(f).Debugf("unable to update PR: %d", pullRequestID)
 		return updateErr

--- a/cla-backend-go/v2/signatures/mock_users/mock_service.go
+++ b/cla-backend-go/v2/signatures/mock_users/mock_service.go
@@ -97,6 +97,46 @@ func (mr *MockServiceMockRecorder) GetUserByEmail(userEmail interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserByEmail", reflect.TypeOf((*MockService)(nil).GetUserByEmail), userEmail)
 }
 
+// GetUsersByEmail mocks base method.
+func (m *MockService) GetUsersByEmail(userEmail string) ([]*models.User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUsersByEmail", userEmail)
+	ret0, _ := ret[0].([]*models.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUsersByEmail indicates an expected call of GetUsersByEmail.
+func (mr *MockServiceMockRecorder) GetUsersByEmail(userEmail interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"GetUsersByEmail",
+		reflect.TypeOf((*MockService)(nil).GetUsersByEmail),
+		userEmail,
+	)
+}
+
+// GetUsersByLFEmail mocks base method.
+func (m *MockService) GetUsersByLFEmail(userEmail string) ([]*models.User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUsersByLFEmail", userEmail)
+	ret0, _ := ret[0].([]*models.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUsersByLFEmail indicates an expected call of GetUsersByLFEmail.
+func (mr *MockServiceMockRecorder) GetUsersByLFEmail(userEmail interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(
+		mr.mock,
+		"GetUsersByLFEmail",
+		reflect.TypeOf((*MockService)(nil).GetUsersByLFEmail),
+		userEmail,
+	)
+}
+
 // GetUserByGitHubID mocks base method.
 func (m *MockService) GetUserByGitHubID(gitHubID string) (*models.User, error) {
 	m.ctrl.T.Helper()
@@ -247,9 +287,8 @@ func (mr *MockServiceMockRecorder) UpdateUserCompanyID(userID, companyID, note i
 }
 
 func (m *MockService) ConvertUserModelToUserCompatModel(user *models.User) (*models.UserCompat, error) {
-    ret := m.ctrl.Call(m, "ConvertUserModelToUserCompatModel", user)
-    ret0, _ := ret[0].(*models.UserCompat)
-    ret1, _ := ret[1].(error)
-    return ret0, ret1
+	ret := m.ctrl.Call(m, "ConvertUserModelToUserCompatModel", user)
+	ret0, _ := ret[0].(*models.UserCompat)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
-

--- a/cla-backend/cla/controllers/user.py
+++ b/cla-backend/cla/controllers/user.py
@@ -45,7 +45,7 @@ def get_user(user_id=None, user_email=None, user_github_id=None):
         except DoesNotExist as err:
             return {'errors': {'user_id': str(err)}}
     elif user_email is not None:
-        users = get_user_instance().get_user_by_email(str(user_email).lower())
+        users = get_user_instance().get_user_by_email_fast(str(user_email).lower())
         if users is None:
             return {'errors': {'user_email': 'User not found'}}
         # Use the first user for now - need to revisit - what if multiple are returned?

--- a/cla-backend/cla/models/dynamo_models.py
+++ b/cla-backend/cla/models/dynamo_models.py
@@ -236,6 +236,23 @@ class LFUsernameIndex(GlobalSecondaryIndex):
     # This attribute is the hash key for the index.
     lf_username = UnicodeAttribute(hash_key=True)
 
+class LFEmailIndex(GlobalSecondaryIndex):
+    """
+    This class represents a global secondary index for querying users by LF Emails.
+    """
+
+    class Meta:
+        """Meta class for LF Email index."""
+
+        index_name = "lf-email-index"
+        write_capacity_units = int(cla.conf["DYNAMO_WRITE_UNITS"])
+        read_capacity_units = int(cla.conf["DYNAMO_READ_UNITS"])
+        # All attributes are projected - not sure if this is necessary.
+        projection = AllProjection()
+
+    # This attribute is the hash key for the index.
+    lf_email = UnicodeAttribute(hash_key=True)
+
 
 class ProjectRepositoryIndex(GlobalSecondaryIndex):
     """
@@ -1625,6 +1642,7 @@ class UserModel(BaseModel):
     lf_email = UnicodeAttribute(null=True)
     lf_username = UnicodeAttribute(null=True)
     lf_username_index = LFUsernameIndex()
+    lf_email_index = LFEmailIndex()
     lf_sub = UnicodeAttribute(null=True)
 
 
@@ -1826,7 +1844,7 @@ class User(model_interfaces.User):  # pylint: disable=too-many-public-methods
         self.model.user_external_id = user_external_id
 
     def set_lf_email(self, lf_email):
-        self.model.lf_email = lf_email
+        self.model.lf_email = (lf_email or "").strip().lower()
 
     def set_lf_sub(self, sub):
         self.model.sub = sub
@@ -1872,6 +1890,16 @@ class User(model_interfaces.User):  # pylint: disable=too-many-public-methods
     def set_note(self, note):
         self.model.note = note
 
+    def get_user_by_email_fast(self, user_email) -> Optional[List[User]]:
+        if user_email is None:
+            cla.log.warning("Unable to lookup user by lf_email/user_email - email is empty")
+            return None
+
+        users = self.get_user_by_lf_email(user_email)
+        if users:
+            return users
+        return self.get_user_by_email(user_email)
+
     def get_user_by_email(self, user_email) -> Optional[List[User]]:
         if user_email is None:
             cla.log.warning("Unable to lookup user by user_email - email is empty")
@@ -1879,6 +1907,22 @@ class User(model_interfaces.User):  # pylint: disable=too-many-public-methods
 
         users = []
         for user_model in UserModel.scan(UserModel.user_emails.contains(user_email)):
+            user = User()
+            user.model = user_model
+            users.append(user)
+        if len(users) > 0:
+            return users
+        else:
+            return None
+
+    def get_user_by_lf_email(self, lf_email) -> Optional[List[User]]:
+        if lf_email is None:
+            cla.log.warning("Unable to lookup user by lf_email - lf_email is empty")
+            return None
+
+        lf_email_norm = lf_email.strip().lower()
+        users = []
+        for user_model in self.model.lf_email_index.query(lf_email_norm):
             user = User()
             user.model = user_model
             users.append(user)

--- a/cla-backend/cla/models/github_models.py
+++ b/cla-backend/cla/models/github_models.py
@@ -588,7 +588,7 @@ class GitHub(repository_service_interface.RepositoryService):
         return pull_request
 
     def update_merge_group_status(
-        self, installation_id, repository_id, pull_request, merge_commit_sha, signed, missing, project_version
+        self, installation_id, repository_id, pull_request, merge_commit_sha, signed, missing, any_missing, project_version
     ):
         """
         Helper function to update a merge queue entrys status based on the list of signers.
@@ -609,7 +609,7 @@ class GitHub(repository_service_interface.RepositoryService):
                 "github", str(installation_id), repository_id, pull_request.number, project_version
             )
             cla.log.debug(
-                f"{fn} - Creating new CLA '{state}' status - {len(signed)} passed, {missing} failed, "
+                f"{fn} - Creating new CLA '{state}' status - {len(signed)} passed, {missing} failed, any_co_author_missing: {any_missing}, "
                 f"signing url: {sign_url}"
             )
         elif signed is not None and len(signed) > 0:
@@ -794,10 +794,11 @@ class GitHub(repository_service_interface.RepositoryService):
             )
             return
 
+        any_missing = False
         try:
             # Get Commit authors
             with_co_authors = self.is_co_authors_enabled_for_repo(github_org.get_enable_co_authors(), repository.get_repository_name())
-            commit_authors = get_pull_request_commit_authors(pull_request, installation_id, with_co_authors)
+            commit_authors, any_missing = get_pull_request_commit_authors(pull_request, installation_id, with_co_authors)
             cla.log.debug(f"{fn} - commit authors: {commit_authors}")
         except Exception as e:
             cla.log.warning(
@@ -826,7 +827,7 @@ class GitHub(repository_service_interface.RepositoryService):
 
         # update Merge group status
         self.update_merge_group_status(
-            installation_id, github_repository_id, pull_request, merge_group_sha, signed, missing, project.get_version()
+            installation_id, github_repository_id, pull_request, merge_group_sha, signed, missing, any_missing, project.get_version()
         )
 
     def update_change_request(self, installation_id, github_repository_id, change_request_id):
@@ -941,7 +942,7 @@ class GitHub(repository_service_interface.RepositoryService):
 
         # Get all unique users/authors involved in this PR - returns a List[UserCommitSummary] objects
         with_co_authors = self.is_co_authors_enabled_for_repo(github_org.get_enable_co_authors(), repository.get_repository_name())
-        commit_authors = get_pull_request_commit_authors(pull_request, installation_id, with_co_authors)
+        commit_authors, any_missing = get_pull_request_commit_authors(pull_request, installation_id, with_co_authors)
 
         cla.log.debug(
             f"{fn} - PR: {pull_request.number}, found {len(commit_authors)} unique commit authors "
@@ -1006,6 +1007,7 @@ class GitHub(repository_service_interface.RepositoryService):
             repository_name=repository_name,
             signed=signed,
             missing=missing,
+            any_missing=any_missing,
             project_version=project.get_version(),
         )
 
@@ -1376,10 +1378,11 @@ class GitHub(repository_service_interface.RepositoryService):
         # User not found by GitHub ID, trying by email.
         cla.log.debug(f"{fn} - Could not find GitHub user by GitHub ID: %s", github_user["id"])
         # TODO: This is very slow and needs to be improved - may need a DB schema change.
+        # LG: at least it now tries search by index lf_email first and only falls back to slow scan if nothing is found
         users = None
         user = cla.utils.get_user_instance()
         for email in emails:
-            users = user.get_user_by_email(email)
+            users = user.get_user_by_email_fast(email)
             if users is not None:
                 break
 
@@ -1778,16 +1781,21 @@ def get_merge_group_commit_authors(merge_group_sha, installation_id=None) -> Lis
 
     return commit_authors
 
-def expand_with_co_authors(commit, pr, installation_id, commit_authors):
+def expand_with_co_authors(commit, pr, installation_id, commit_authors) -> bool:
     """
     Helper to append UserCommitSummary objects for all co-authors to commit_authors list.
     """
     co_authors = cla.utils.get_co_authors_from_commit(commit)
+    missing = False
     for co_author in co_authors:
-        commit_authors.append(get_co_author_commits(co_author, commit, pr, installation_id))
+        summary, found = get_co_author_commits(co_author, commit, pr, installation_id)
+        commit_authors.append(summary)
+        if not missing and not found:
+            missing = True
+    return missing
 
 
-def get_author_summary(commit, pr, installation_id, with_co_authors) -> List[UserCommitSummary]:
+def get_author_summary(commit, pr, installation_id, with_co_authors) -> Tuple[List[UserCommitSummary], bool]:
     """
     Helper function to extract author information from a GitHub commit.
     :param commit: A GitHub commit object.
@@ -1842,12 +1850,13 @@ def get_author_summary(commit, pr, installation_id, with_co_authors) -> List[Use
     )
     cla.log.debug(f"{fn} - PR: {pr}, {commit_author_summary}")
     commit_authors.append(commit_author_summary)
+    missing = False
     if with_co_authors is True:
-        expand_with_co_authors(commit, pr, installation_id, commit_authors)
-    return commit_authors
+        missing = expand_with_co_authors(commit, pr, installation_id, commit_authors)
+    return (commit_authors, missing)
 
 
-def get_pull_request_commit_authors(pull_request, installation_id, with_co_authors) -> List[UserCommitSummary]:
+def get_pull_request_commit_authors(pull_request, installation_id, with_co_authors) -> Tuple[List[UserCommitSummary], bool]:
     """
     Helper function to extract all committer information for a GitHub PR.
 
@@ -1869,6 +1878,7 @@ def get_pull_request_commit_authors(pull_request, installation_id, with_co_autho
     cla.log.debug(f"{fn} - PR: {pull_request.number}, number of commits: {no_commits}")
 
     commit_authors = []
+    any_missing = False
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=30) as executor:
         future_to_commit = {
@@ -1878,29 +1888,35 @@ def get_pull_request_commit_authors(pull_request, installation_id, with_co_autho
         for future in concurrent.futures.as_completed(future_to_commit):
             future_to_commit[future]
             try:
-                commit_authors.extend(future.result())
+                authors, missing = future.result()
+                if not any_missing and missing:
+                    any_missing = True
+                commit_authors.extend(authors)
             except Exception as exc:
                 cla.log.warning(f"{fn} - PR: {pull_request.number}, get_author_summary generated an exception: {exc}")
                 raise exc
 
-    return commit_authors
+    return (commit_authors, any_missing)
 
 def is_valid_github_username(username: str) -> bool:
     return bool(GITHUB_USERNAME_REGEX.match(username))
 
-def get_co_author_commits(co_author, commit, pr, installation_id):
+def get_co_author_commits(co_author, commit, pr, installation_id) -> Tuple[UserCommitSummary, bool]:
     fn = "cla.models.github_models.get_co_author_commits"
     # check if co-author is a github user
     co_author_summary = None
     login, github_id = None, None
-    email = co_author[1].strip()
-    name = co_author[0].strip()
+    # We don't need to strip() or lower() here, as get_co_authors_from_commit already does that
+    email = co_author[1]
+    name = co_author[0]
+    lname = name.lower()
 
     # caching starts
-    cache_key = (name, email)
+    cache_key = (lname, email)
     cached_user, hit = github_user_cache.get(cache_key)
 
     if hit:
+        found = False
         if cached_user is not None:
             cla.log.debug(f"{fn} - GitHub user found in cache for name/email: {name}/{email}: {cached_user}")
             # Build UserCommitSummary using cached_user
@@ -1913,6 +1929,7 @@ def get_co_author_commits(co_author, commit, pr, installation_id):
                 False,
                 False,
             )
+            found = getattr(cached_user, 'id', None) is not None
         else:
             cla.log.debug(f"{fn} - GitHub user found in cache for name/email: {name}/{email}: (information that this user is missing)")
             summary = UserCommitSummary(
@@ -1926,7 +1943,7 @@ def get_co_author_commits(co_author, commit, pr, installation_id):
             )
 
         cla.log.debug(f"{fn} - PR: {pr}, {summary} (from cache)")
-        return summary
+        return (summary, found)
     # caching ends
 
     # get repository service
@@ -1959,14 +1976,45 @@ def get_co_author_commits(co_author, commit, pr, installation_id):
                 cla.log.warning(f"{fn} - Error fetching user by login {login_str}: {ex}")
                 user = None
 
-    # 3. Try to find user by email
+    # 3. Try to find user by email via GitHub APIs
     if user is None:
         try:
             cla.log.debug(f"{fn} - Lookup via GitHub email: {email}")
             user = github.get_github_user_by_email(email, installation_id)
         except (GithubException, IncompletableObject, RateLimitExceededException) as ex:
             # user not found
-            cla.log.debug(f"{fn} - co-author github user not found via email {email}: {co_author} with exception: {ex}")
+            cla.log.debug(f"{fn} - co-author github user not found via github email {email}: {co_author} with exception: {ex}")
+            user = None
+
+    # 3b. Try to find user by email in our database
+    if user is None:
+        try:
+            cla.log.debug(f"{fn} - Lookup via lf email: {email}")
+            user_model = cla.utils.get_user_instance()
+            db_users = user_model.get_user_by_lf_email(email)
+            github_id = None
+            if db_users is not None:
+                for db_user in db_users:
+                    github_id = db_user.get_user_github_id()
+                    if github_id is not None:
+                        break
+            if not github_id:
+                db_users = user_model.get_user_by_email(email)
+                if db_users is not None:
+                    for db_user in db_users:
+                        github_id = db_user.get_user_github_id()
+                        if github_id is not None:
+                            break
+            if github_id:
+                cla.log.debug(f"{fn} - Found GitHub ID {github_id} for lf email: {email} in EasyCLA DB")
+                try:
+                    user = github.get_github_user_by_id(github_id, installation_id)
+                except Exception as ex:
+                    cla.log.warning(f"{fn} - Error fetching user by ID {github_id}: {ex}")
+                    user = None
+        except Exception as ex:
+            # user not found
+            cla.log.debug(f"{fn} - co-author github user not found via lf email {email}: {co_author} with exception: {ex}")
             user = None
 
     # 4. Last resort: try to find by name (login)
@@ -1974,7 +2022,7 @@ def get_co_author_commits(co_author, commit, pr, installation_id):
         try:
             # Note that Co-authored-by: name <email> is not actually a GitHub login but rather a name - but we are trying hard to find a GitHub profile
             cla.log.debug(f"{fn} - Lookup via login=name: {name}")
-            user = github.get_github_user_by_login(name, installation_id)
+            user = github.get_github_user_by_login(lname, installation_id)
         except (GithubException, IncompletableObject, RateLimitExceededException) as ex:
             # user not found
             cla.log.debug(f"{fn} - co-author github user not found via login=name: {name}: {co_author} with exception: {ex}")
@@ -1982,6 +2030,7 @@ def get_co_author_commits(co_author, commit, pr, installation_id):
 
     cla.log.debug(f"{fn} - co-author: {co_author}, user: {user}")
 
+    found = False
     if user:
         login = user.login
         github_id = user.id
@@ -2010,14 +2059,15 @@ def get_co_author_commits(co_author, commit, pr, installation_id):
             False,  # default not authorized - will be evaluated and updated later
         )
         cla.log.debug(f"{fn} - PR: {pr}, {co_author_summary}")
+        found = github_id is not None
     else:
         co_author_summary = UserCommitSummary(
             commit.sha, None, None, name, email, False, False  # default not authorized - will be evaluated and updated later
         )
         cla.log.debug(f"{fn} - co-author github user details not found: {co_author}")
 
-    github_user_cache.set((name, email), user)
-    return co_author_summary
+    github_user_cache.set(cache_key, user)
+    return (co_author_summary, found)
 
 
 def has_check_previously_passed_or_failed(pull_request: PullRequest):
@@ -2054,6 +2104,7 @@ def update_pull_request(
     repository_name,
     signed: List[UserCommitSummary],
     missing: List[UserCommitSummary],
+    any_missing: bool,
     project_version,
 ):  # pylint: disable=too-many-locals
     """
@@ -2071,6 +2122,8 @@ def update_pull_request(
     :type: signed: List[UserCommitSummary]
     :param: missing: The list of User Commit Summary objects for this PR.
     :type: missing: List[UserCommitSummary]
+    :param: any_missing: Boolean flag indicating if any co-authors are missing.
+    :type: any_missing: bool
     :param: project_version: Project version associated with PR
     :type: missing: string
     """
@@ -2120,11 +2173,11 @@ def update_pull_request(
     # Update the comment
     if both or notification == "comment":
         body = cla.utils.assemble_cla_comment(
-            "github", str(installation_id), github_repository_id, pull_request.number, signed, missing, project_version
+            "github", str(installation_id), github_repository_id, pull_request.number, signed, missing, any_missing, project_version
         )
         previously_pass_or_failed, comment = has_check_previously_passed_or_failed(pull_request)
         if not missing:
-            # After Issue #167 wsa in place, they decided via Issue #289 that we
+            # After Issue #167 was in place, they decided via Issue #289 that we
             # DO want to update the comment, but only after we've previously failed
             if previously_pass_or_failed:
                 cla.log.debug(f"{fn} - Found previously passed or failed checks - updating CLA comment in PR.")

--- a/cla-backend/cla/models/model_interfaces.py
+++ b/cla-backend/cla/models/model_interfaces.py
@@ -511,6 +511,28 @@ class User(object):
     def set_lf_sub(self, sub):
         raise NotImplementedError()
 
+    def get_user_by_email_fast(self, user_email):
+        """
+        Fetches the user object that matches the email specified.
+
+        :param user_email: The user's email.
+        :type user_email: string
+        :return: The user object with the matching email address - None if not found.
+        :rtype: cla.models.model_interfaces.User | None
+        """
+        raise NotImplementedError()
+
+    def get_user_by_lf_email(self, user_email):
+        """
+        Fetches the user object that matches the lf_email specified.
+
+        :param user_email: The user's email.
+        :type user_email: string
+        :return: The user object with the matching email address - None if not found.
+        :rtype: cla.models.model_interfaces.User | None
+        """
+        raise NotImplementedError()
+
     def get_user_by_email(self, user_email):
         """
         Fetches the user object that matches the email specified.

--- a/cla-backend/cla/tests/unit/test_github_models.py
+++ b/cla-backend/cla/tests/unit/test_github_models.py
@@ -64,7 +64,7 @@ class TestGetPullRequestCommitAuthors(TestCase):
         installation_id = 123
 
         # Call the function
-        result = get_co_author_commits(co_author,commit, pr, installation_id)
+        result, _ = get_co_author_commits(co_author,commit, pr, installation_id)
 
         # Assertions
         self.assertEqual(result.commit_sha, "fake_sha")
@@ -87,7 +87,7 @@ class TestGetPullRequestCommitAuthors(TestCase):
         installation_id = 123
 
         # Call the function
-        result = get_co_author_commits(co_author,commit, pr, installation_id)
+        result, _ = get_co_author_commits(co_author,commit, pr, installation_id)
 
         # Assertions
         self.assertEqual(result.commit_sha, "fake_sha")

--- a/cla-backend/cla/tests/unit/test_user_commit_summary.py
+++ b/cla-backend/cla/tests/unit/test_user_commit_summary.py
@@ -36,7 +36,7 @@ class TestUserCommitSummary(unittest.TestCase):
         m = UserCommitSummary("some_other_sha", 123456, 'login_value2', 'author name2', 'foo2@bar.com', False, False)
         missing = [m]
 
-        body = get_comment_body('github', 'https://foo.com', signed, missing)
+        body = get_comment_body('github', 'https://foo.com', signed, missing, False)
         self.assertTrue(':white_check_mark:' in body)
         self.assertTrue(':x:' in body)
 
@@ -47,7 +47,7 @@ class TestUserCommitSummary(unittest.TestCase):
 
         missing = []
 
-        body = get_comment_body('github', 'https://foo.com', signed, missing)
+        body = get_comment_body('github', 'https://foo.com', signed, missing, False)
         self.assertTrue(':white_check_mark:' in body)
         self.assertTrue('login_value' in body)
         self.assertFalse('@login_value' in body)  # users should not be tagged in signed use case
@@ -58,6 +58,19 @@ class TestUserCommitSummary(unittest.TestCase):
         m = UserCommitSummary("some_other_sha", 123456, 'login_value2', 'author name2', 'foo2@bar.com', False, False)
         missing = [m]
 
-        body = get_comment_body('github', 'https://foo.com', signed, missing)
+        body = get_comment_body('github', 'https://foo.com', signed, missing, False)
         self.assertTrue(':x:' in body)
         self.assertTrue('@login_value2' in body)  # users should be tagged in missing use case
+
+    def test_user_commit_summary_get_comment_body_missing_co_authors(self) -> None:
+        s1 = UserCommitSummary("abc1234xyz-123", 1234, 'login_value', 'author name', 'foo@bar.com', True, True)
+        s2 = UserCommitSummary("abc1234xyz-456", 1234, 'login_value', 'author name', 'foo@bar.com', True, True)
+        signed = [s1, s2]
+
+        m = UserCommitSummary("some_other_sha", 123456, 'login_value2', 'author name2', 'foo2@bar.com', False, False)
+        missing = [m]
+
+        body = get_comment_body('github', 'https://foo.com', signed, missing, True)
+        self.assertTrue(':white_check_mark:' in body)
+        self.assertTrue(':x:' in body)
+        self.assertTrue('One or more co-authors of this pull request were not found' in body)

--- a/cla-backend/cla/utils.py
+++ b/cla-backend/cla/utils.py
@@ -37,6 +37,29 @@ CLA_LOGO_URL = os.environ.get("CLA_BUCKET_LOGO_URL", "")
 CORPORATE_BASE = os.environ.get("CLA_CORPORATE_BASE", "")
 CORPORATE_V2_BASE = os.environ.get("CLA_CORPORATE_V2_BASE", "")
 SVG_VERSION = "?v=2"
+MISSING_CO_AUTHOR_MESSAGE='''
+
+One or more co-authors of this pull request were not found. You must specify co-authors in commit message trailer via:
+
+```
+Co-authored-by: name <email>
+```
+
+Supported `Co-authored-by:` formats include:
+
+1) `Anything <id+login@users.noreply.github.com>` - it will locate your GitHub user by `id` part.
+2) `Anything <login@users.noreply.github.com>` - it will locate your GitHub user by `login` part.
+3) `Anything <public-email>` - it will locate your GitHub user by `public-email` part. Note that this email must be made public on Github.
+4) `Anything <other-email>` - it will locate your GitHub user by `other-email` part but only if that email was used before for any other CLA as a main commit author.
+5) `login <any-valid-email>` - it will locate your GitHub user by `login` part, note that `login` part must be at least 3 characters long.
+
+Please update your commit message(s) by doing `git commit --amend` and then `git push [--force]` and then request re-running CLA check via commenting on this pull request:
+
+```
+/easycla
+```
+
+'''
 
 def get_cla_path():
     """Returns the CLA code root directory on the current system."""
@@ -981,6 +1004,7 @@ def assemble_cla_comment(
     change_request_id,
     signed: List[UserCommitSummary],
     missing: List[UserCommitSummary],
+    any_missing: bool,
     project_version,
 ):
     """
@@ -1004,6 +1028,8 @@ def assemble_cla_comment(
     :param missing: The list of user commit summary objects indicating which authors have not signed for this
         change request.
     :type missing: List[UserCommitSummary]
+    :param any_missing: Whether or not there are any missing co-authors
+    :type any_missing: boolean
     :param project_version: Project version associated with PR comment
     :type project_version: string
     """
@@ -1018,7 +1044,7 @@ def assemble_cla_comment(
     # approved_ids = list(filter(lambda x: len(x[1]) == 4 and x[1][3] is True, missing))
     # approved_by_manager = len(approved_ids) > 0
     sign_url = get_full_sign_url(repository_type, installation_id, github_repository_id, change_request_id, project_version)
-    comment = get_comment_body(repository_type, sign_url, signed, missing)
+    comment = get_comment_body(repository_type, sign_url, signed, missing, any_missing)
     all_signed = len(missing) == 0
     badge = get_comment_badge(
         repository_type=repository_type,
@@ -1030,7 +1056,7 @@ def assemble_cla_comment(
     return badge + "<br />" + comment
 
 
-def get_comment_body(repository_type, sign_url, signed: List[UserCommitSummary], missing: List[UserCommitSummary]):
+def get_comment_body(repository_type, sign_url, signed: List[UserCommitSummary], missing: List[UserCommitSummary], any_missing: bool):
     """
     Returns the CLA comment that will appear on the repository provider's change request item.
 
@@ -1042,6 +1068,8 @@ def get_comment_body(repository_type, sign_url, signed: List[UserCommitSummary],
     :type: signed: List[UserCommitSummary]
     :param: missing: List of user commit summary objects containing the commit and author name of not-signed users.
     :type: missing: List[UserCommitSummary]
+    :param any_missing: Whether or not there are any missing co-authors
+    :type any_missing: boolean
     """
     fn = "utils.get_comment_body"
     cla.log.info(f"{fn} - Getting comment body for repository type: %s", repository_type)
@@ -1157,8 +1185,13 @@ def get_comment_body(repository_type, sign_url, signed: List[UserCommitSummary],
     committers_comment += '<!-- Date Modified: ' + str(datetime.now()) + ' -->'
 
     if len(signed) > 0 and len(missing) == 0:
-        text = "The committers listed above are authorized under a signed CLA."
+        text += "The committers listed above are authorized under a signed CLA."
 
+    if any_missing:
+        committers_comment += MISSING_CO_AUTHOR_MESSAGE
+        cla.log.info(f"{fn} - some co-authors are missing for this PR, added the missing co-author message")
+    # else:
+    #     cla.log.info(f"{fn} - all co-authors are present for this PR, no missing co-author message added")
     return text + committers_comment
 
 
@@ -1949,10 +1982,13 @@ def get_co_authors_from_commit(commit):
         commit_message = commit.commit.message
         # cla.log.debug(f"{fn} - commit message: {commit_message}")
         if commit_message:
-            matches = re.findall(r"co-authored-by: (.*) <(.*)>", commit_message, re.I)
-            co_authors = [(name.strip(), email.strip()) for name, email in matches]
+            matches = re.findall(r"co-authored-by:\s*(.+?)\s*<([^<>]+)>", commit_message, re.I)
+            co_authors = [
+                (name.strip(), email.strip().lower())
+                for name, email in matches
+                if name.strip() and email.strip()
+            ]
     return co_authors
-
 
 def extract_pull_request_number(pull_request_message):
     """

--- a/utils/count_apis.sh
+++ b/utils/count_apis.sh
@@ -18,4 +18,6 @@ jq -r '
 | sed -E 's/[0-9a-fA-F-]{36}/<uuid>/g' \
 | sed -E ':a;s#/([0-9]{1,})(/|$)#/<id>\2#g;ta' \
 | sed -E 's#/(00|a0)[A-Za-z0-9]{13,16}(/|$)#/<sfid>\2#g' \
+| sed -E 's#/lf[A-Za-z0-9]{16,22}(/|$)#/<lfxid>\1#g' \
+| sed -E 's#/null(/|$)#/<null>\1#g' \
 | sort | uniq -c | sort -nr


### PR DESCRIPTION
- Updated co-authors search algorithm so it can search for co-author in DynamoDB using `email` provided in `Co-authored-by: name <email>` commit message trailer if email is not found via GitHub APIs (is not public on GitHub for example).

- If any of co-authors isn't found then EasyCLA comment explains how to address this by amending commit message with a correct co-author trailer and doing `/easycla` comment to re-run CLA checks.

This is for https://github.com/linuxfoundation/easycla/issues/4760.

cc @mlehotskylf @jarias-lfx 