### PR TITLE
Update test coverage for cla-manager APIs group + fix some missing required flags in swagger

### DIFF
--- a/cla-backend-go/swagger/cla.v2.yaml
+++ b/cla-backend-go/swagger/cla.v2.yaml
@@ -2664,6 +2664,7 @@ paths:
         - $ref: "#/parameters/path-userID"
         - name: body
           in: body
+          required: true
           schema:
             type: object
             required:
@@ -2830,6 +2831,7 @@ paths:
         - $ref: "#/parameters/path-companyID"
         - $ref: "#/parameters/path-projectSFID"
         - name: body
+          required: true
           in: body
           schema:
             type: object
@@ -2999,6 +3001,7 @@ paths:
         - $ref: "#/parameters/path-companyID"
         - name: body
           in: body
+          required: true
           schema:
             type: object
             x-nullable: false
@@ -3044,6 +3047,7 @@ paths:
         - $ref: "#/parameters/path-companyID"
         - name: body
           in: body
+          required: true
           schema:
             type: object
             x-nullable: false

--- a/tests/functional/cypress/e2e/cla-group.cy.ts
+++ b/tests/functional/cypress/e2e/cla-group.cy.ts
@@ -6,7 +6,6 @@ import {
   validate_403_Status,
   validate_404_Status,
   validate_404_Status_and_Message,
-  validate_404_Status_and_Message2,
   validate_405_Status_and_Message,
   validate_422_Status,
   getTokenKey,
@@ -184,7 +183,7 @@ describe("To Validate 'GET, CREATE, UPDATE and DELETE' CLA groups API call on ch
           method: 'GET',
           url: `${claEndpoint}foundation//cla-groups`,
           expectedStatus: 404,
-          expectedCode: 1,
+          expectedCode: 404,
           expectedMsg: 'path /v4/foundation//cla-groups was not found',
           mode: 'local',
         },
@@ -266,7 +265,7 @@ describe("To Validate 'GET, CREATE, UPDATE and DELETE' CLA groups API call on ch
           method: 'PUT',
           url: `${claEndpoint}cla-group/${exampleClaGroupId}/enroll-projects`,
           expectedStatus: 404,
-          expectedCode: 2,
+          expectedCode: 404,
           expectedMsg: `EasyCLA - 404 Not Found - problem loading CLA Group by ID: ${exampleClaGroupId} - error: cla group ${exampleClaGroupId} not found`,
           mode: 'both',
         },
@@ -298,7 +297,7 @@ describe("To Validate 'GET, CREATE, UPDATE and DELETE' CLA groups API call on ch
           method: 'PUT',
           url: `${claEndpoint}cla-group/${exampleClaGroupId}/unenroll-projects`,
           expectedStatus: 404,
-          expectedCode: 2,
+          expectedCode: 404,
           expectedMsg: `EasyCLA - 404 Not Found - unable to locate CLA Group by ID: ${exampleClaGroupId} - error: cla group ${exampleClaGroupId} not found`,
           mode: 'both',
         },
@@ -319,7 +318,7 @@ describe("To Validate 'GET, CREATE, UPDATE and DELETE' CLA groups API call on ch
           method: 'GET',
           url: `${claEndpoint}project//github/organizations`,
           expectedStatus: 404,
-          expectedCode: 1,
+          expectedCode: 404,
           expectedMsg: 'path /v4/project//github/organizations was not found',
           mode: 'local',
         },
@@ -339,7 +338,7 @@ describe("To Validate 'GET, CREATE, UPDATE and DELETE' CLA groups API call on ch
           method: 'GET',
           url: `${claEndpoint}project/aaaa/github/organizations`,
           expectedStatus: 404,
-          expectedCode: 2,
+          expectedCode: 404,
           expectedMsg: 'EasyCLA - 404 Not Found - github organization with project SFID not found: aaaa',
           mode: 'both',
         },
@@ -349,7 +348,7 @@ describe("To Validate 'GET, CREATE, UPDATE and DELETE' CLA groups API call on ch
           method: 'PUT',
           url: `${claEndpoint}project//github/organizations//config`,
           expectedStatus: 404,
-          expectedCode: 1,
+          expectedCode: 404,
           expectedMsg: 'path /v4/project//github/organizations//config was not found',
           mode: 'local',
         },
@@ -369,7 +368,7 @@ describe("To Validate 'GET, CREATE, UPDATE and DELETE' CLA groups API call on ch
           method: 'PUT',
           url: `${claEndpoint}project//github/organizations/org/config`,
           expectedStatus: 404,
-          expectedCode: 1,
+          expectedCode: 404,
           expectedMsg: 'path /v4/project//github/organizations/org/config was not found',
           mode: 'local',
         },
@@ -450,7 +449,7 @@ describe("To Validate 'GET, CREATE, UPDATE and DELETE' CLA groups API call on ch
           method: 'DELETE',
           url: `${claEndpoint}cla-group/${exampleClaGroupId}`,
           expectedStatus: 404,
-          expectedCode: 2,
+          expectedCode: 404,
           expectedMsg: `EasyCLA - 404 Not Found - cla group ${exampleClaGroupId} not found`,
           mode: 'both',
         },
@@ -479,11 +478,7 @@ describe("To Validate 'GET, CREATE, UPDATE and DELETE' CLA groups API call on ch
               case 403:
                 return validate_403_Status(response);
               case 404:
-                if (expectedCode === 1) {
-                  return validate_404_Status_and_Message(response, expectedMsg);
-                } else {
-                  return validate_404_Status_and_Message2(response, expectedMsg);
-                }
+                return validate_404_Status_and_Message(response, expectedMsg);
               case 405:
                 return validate_405_Status_and_Message(response, expectedMsg);
               case 422:

--- a/tests/functional/cypress/e2e/cla-manager.cy.ts
+++ b/tests/functional/cypress/e2e/cla-manager.cy.ts
@@ -2,7 +2,14 @@ import {
   validateApiResponse,
   validate_200_Status,
   validate_204_Status,
+  validate_400_Status,
+  validate_400_Status_Contains,
+  validate_401_Status,
+  validate_403_Status,
   validate_404_Status,
+  validate_404_Status_and_Message,
+  validate_405_Status_and_Message,
+  validate_422_Status,
   getAPIBaseURL,
   getTokenKey,
   getXACLHeader,
@@ -29,6 +36,8 @@ https://api-gw.dev.platform.linuxfoundation.org/acs/v1/api-docs#tag/Role/operati
   const projectSFID = appConfig.projectSFID; //sun
   const projectSFID_Designee = appConfig.childProjectSFID; //EASYAUTOM-CHILD2
   const claEndpoint = getAPIBaseURL('v4');
+  const timeout = 180000;
+  const local = Cypress.env('LOCAL') ? true : false;
   let bearerToken: string = null;
   const claGroupID = appConfig.claGroupId;
   const sun_claGroupID = appConfig.claGroupId_projectSFID; //sun
@@ -49,13 +58,612 @@ https://api-gw.dev.platform.linuxfoundation.org/acs/v1/api-docs#tag/Role/operati
     }
   });
 
-  it('Assigns CLA Manager designee to a given user.', function () {
+  describe('Expected failures', () => {
+    const companySFID = appConfig.companyExternalID;
+    const companyID = appConfig.companyID;
+    const userLFID = appConfig.lfid2;
+
+    // UUID helpers
+    const badUUID = '00000000-0000-0000-0000-000000000000'; // fails UUIDv4 validation
+    const badSFID = projectSFID + 'abcd';
+    const exampleV4 = 'd9428888-122b-4b20-8c4a-0c9a1a6f9b8e'; // valid UUIDv4 shape
+
+    it('Returns 401 for all CLA-Manager APIs when called without token', function () {
+      // Minimal-but-valid bodies where the spec requires a body (so auth is checked first)
+      const managerBody = {
+        firstName: 'Alice',
+        lastName: 'Tester',
+        userEmail: 'alice@example.org',
+      };
+      const managerReqBody = { fullName: 'Alice Tester' };
+      const notifyListBody = { list: [{ email: 'alice@example.org', name: 'Alice' }], claGroupID: exampleV4 };
+
+      const requests = [
+        // Add CLA Manager (POST /company/{companyID}/project/{projectSFID}/cla-manager)
+        {
+          method: 'POST',
+          url: `${claEndpoint}company/${companyID}/project/${projectSFID}/cla-manager`,
+          body: managerBody,
+        },
+
+        // Add CLA Manager Request (POST /company/{companyID}/project/{projectSFID}/cla-manager/requests)
+        {
+          method: 'POST',
+          url: `${claEndpoint}company/${companyID}/project/${projectSFID}/cla-manager/requests`,
+          body: managerReqBody,
+        },
+
+        // Delete CLA Manager (DELETE /company/{companyID}/project/{projectSFID}/cla-manager/{userLFID})
+        { method: 'DELETE', url: `${claEndpoint}company/${companyID}/project/${projectSFID}/cla-manager/${userLFID}` },
+
+        // GET CLA Manager Designee Status (GET /company/{companySFID}/user/{userLFID}/claGroupID/{claGroupID}/is-cla-manager-designee)
+        // LG: this endpoint does not require token
+        //{
+        //  method: 'GET',
+        //  url: `${claEndpoint}company/${companySFID}/user/${userLFID}/claGroupID/${claGroupID}/is-cla-manager-designee`,
+        //},
+
+        // Assign CLA Manager Designee (POST /company/{companySFID}/claGroup/{claGroupID}/cla-manager-designee)
+        {
+          method: 'POST',
+          url: `${claEndpoint}company/${companySFID}/claGroup/${exampleV4}/cla-manager-designee`,
+        },
+
+        // Assign CLA Manager Designee (POST /company/{companyID}/project/{projectSFID}/cla-manager-designee)
+        {
+          method: 'POST',
+          url: `${claEndpoint}company/${companyID}/project/${projectSFID}/cla-manager-designee`,
+        },
+
+        // List CLA Managers (GET /company/{companyID}/project/{projectSFID}/cla-managers)
+        { method: 'GET', url: `${claEndpoint}company/${companyID}/project/${projectSFID}/cla-managers` },
+
+        // List CLA Managers by CLA Group (GET /company/{companyID}/cla-group/{claGroupID}/cla-managers)
+        // LG: In swagger those APIs have `security: []` so they don't need token.
+        // { method: 'GET', url: `${claEndpoint}company/${companyID}/cla-group/${exampleV4}/cla-managers` },
+        // { method: 'POST', url: `${claEndpoint}notify-cla-managers` },
+        // { method: 'POST', url: `${claEndpoint}user/${userId2}/invite-company-admin` },
+      ];
+
+      cy.wrap(requests).each((req: any) => {
+        cy.task('log', `--> ${req.method} ${req.url}`);
+        cy.request({
+          method: req.method,
+          url: req.url,
+          failOnStatusCode: false,
+          timeout,
+          ...(req.body ? { body: req.body } : {}),
+        }).then((response) => {
+          return cy.logJson('401 response', response).then(() => {
+            // In local env the message body differs
+            validate_401_Status(response, local);
+          });
+        });
+      });
+    });
+
+    it('Returns errors due to missing parameters', function () {
+      // Build a suite mirroring cla-group "missing params" checks, mapped to cla-manager endpoints
+      const effectiveMode = local ? 'local' : 'remote';
+      const both = 'both';
+      const claManagerDesigneeBody = { userEmail: 'luke@o2.pl' };
+      const inviteCompanyAdminBody = {
+        claGroupID: sun_claGroupID,
+        companyID: companyID,
+        contactAdmin: true,
+        name: 'veerendra thakur',
+        userEmail: userEmail,
+      };
+
+      const requests = [
+        // Notify CLA Managers
+        {
+          method: 'POST',
+          url: `${claEndpoint}notify-cla-managers`,
+          expectedStatus: 422,
+          expectedCode: 602,
+          expectedMsg: 'body in body is required',
+          mode: both,
+        },
+
+        // Invite Company Admin
+        {
+          method: 'POST',
+          url: `${claEndpoint}user/${userId2}/invite-company-admin`,
+          expectedStatus: 422,
+          expectedCode: 602,
+          expectedMsg: 'body in body is required',
+          mode: both,
+        },
+        {
+          method: 'POST',
+          url: `${claEndpoint}user//invite-company-admin`,
+          expectedStatus: 404,
+          expectedCode: 404,
+          expectedMsg: 'path /v4/user//invite-company-admin was not found',
+          mode: 'local',
+        },
+        {
+          method: 'POST',
+          url: `${claEndpoint}user//invite-company-admin`,
+          expectedStatus: 403,
+          expectedCode: 403,
+          expectedMsg: '',
+          mode: 'remote',
+        },
+        {
+          method: 'POST',
+          url: `${claEndpoint}user/aa/invite-company-admin`,
+          expectedStatus: 422,
+          expectedCode: 604,
+          expectedMsg: 'userID in path should be at least 5 chars long',
+          body: inviteCompanyAdminBody,
+          mode: both,
+        },
+
+        // 1) Add CLA Manager: missing body
+        {
+          method: 'POST',
+          url: `${claEndpoint}company/${companyID}/project/${projectSFID}/cla-manager`,
+          expectedStatus: 422,
+          expectedCode: 602,
+          expectedMsg: 'body in body is required',
+          mode: both,
+        },
+        {
+          method: 'POST',
+          url: `${claEndpoint}company//project//cla-manager`,
+          expectedStatus: 404,
+          expectedCode: 404,
+          expectedMsg: 'path /v4/company//project//cla-manager was not found',
+          mode: 'local',
+        },
+        {
+          method: 'POST',
+          url: `${claEndpoint}company//project//cla-manager`,
+          expectedStatus: 403,
+          expectedCode: 403,
+          expectedMsg: '',
+          mode: 'remote',
+        },
+        {
+          method: 'POST',
+          url: `${claEndpoint}company/${companyID}/project//cla-manager`,
+          expectedStatus: 404,
+          expectedCode: 404,
+          expectedMsg: `path /v4/company/${companyID}/project//cla-manager was not found`,
+          mode: 'local',
+        },
+        {
+          method: 'POST',
+          url: `${claEndpoint}company/${companyID}/project//cla-manager`,
+          expectedStatus: 403,
+          expectedCode: 403,
+          expectedMsg: '',
+          mode: 'remote',
+        },
+        {
+          method: 'POST',
+          url: `${claEndpoint}company//project/${projectSFID}/cla-manager`,
+          expectedStatus: 404,
+          expectedCode: 404,
+          expectedMsg: `path /v4/company//project/${projectSFID}/cla-manager was not found`,
+          mode: 'local',
+        },
+        {
+          method: 'POST',
+          url: `${claEndpoint}company//project/${projectSFID}/cla-manager`,
+          expectedStatus: 403,
+          expectedCode: 403,
+          expectedMsg: '',
+          mode: 'remote',
+        },
+
+        // 2) Add CLA Manager: missing projectSFID (route with //)
+        {
+          method: 'POST',
+          url: `${claEndpoint}company/${companyID}/project//cla-manager`,
+          expectedStatus: 404,
+          expectedCode: 404,
+          expectedMsg: 'path /v4/company/' + companyID + '/project//cla-manager was not found',
+          mode: 'local',
+        },
+
+        // Remote gateway often 403 on malformed paths
+        {
+          method: 'POST',
+          url: `${claEndpoint}company/${companyID}/project//cla-manager`,
+          expectedStatus: 403,
+          expectedCode: 403,
+          expectedMsg: '',
+          mode: 'remote',
+        },
+
+        // 3) Add CLA Manager Request: missing body (required fullName)
+        {
+          method: 'POST',
+          url: `${claEndpoint}company/${companyID}/project/${projectSFID}/cla-manager/requests`,
+          expectedStatus: 422,
+          expectedCode: 602,
+          expectedMsg: 'body in body is required',
+          // LG: comment out until new api is deployed to dev for remote testing
+          // mode: 'local',
+          mode: both,
+        },
+
+        // 4) Delete CLA Manager: missing userLFID
+        {
+          method: 'DELETE',
+          url: `${claEndpoint}company/${companyID}/project/${projectSFID}/cla-manager/`,
+          expectedStatus: 405,
+          expectedCode: 405,
+          expectedMsg: 'method DELETE is not allowed, but [POST] are',
+          mode: 'local',
+        },
+        {
+          method: 'DELETE',
+          url: `${claEndpoint}company/${companyID}/project/${projectSFID}/cla-manager/`,
+          expectedStatus: 403,
+          expectedCode: 403,
+          expectedMsg: '',
+          mode: 'remote',
+        },
+        {
+          method: 'DELETE',
+          url: `${claEndpoint}company//project//cla-manager/`,
+          expectedStatus: 404,
+          expectedCode: 404,
+          expectedMsg: 'path /v4/company//project//cla-manager/ was not found',
+          mode: 'local',
+        },
+        {
+          method: 'DELETE',
+          url: `${claEndpoint}company//project//cla-manager/`,
+          expectedStatus: 403,
+          expectedCode: 403,
+          expectedMsg: '',
+          mode: 'remote',
+        },
+        {
+          method: 'DELETE',
+          url: `${claEndpoint}company/${companyID}/project//cla-manager/`,
+          expectedStatus: 404,
+          expectedCode: 404,
+          expectedMsg: `path /v4/company/${companyID}/project//cla-manager/ was not found`,
+          mode: 'local',
+        },
+        {
+          method: 'DELETE',
+          url: `${claEndpoint}company/${companyID}/project//cla-manager/`,
+          expectedStatus: 403,
+          expectedCode: 403,
+          expectedMsg: '',
+          mode: 'remote',
+        },
+        {
+          method: 'DELETE',
+          url: `${claEndpoint}company//project/${projectSFID}/cla-manager/`,
+          expectedStatus: 404,
+          expectedCode: 404,
+          expectedMsg: `path /v4/company//project/${projectSFID}/cla-manager/ was not found`,
+          mode: 'local',
+        },
+        {
+          method: 'DELETE',
+          url: `${claEndpoint}company//project/${projectSFID}/cla-manager/`,
+          expectedStatus: 403,
+          expectedCode: 403,
+          expectedMsg: '',
+          mode: 'remote',
+        },
+        {
+          method: 'DELETE',
+          url: `${claEndpoint}company//project//cla-manager/${userLFID}`,
+          expectedStatus: 404,
+          expectedCode: 404,
+          expectedMsg: `path /v4/company//project//cla-manager/${userLFID} was not found`,
+          mode: 'local',
+        },
+        {
+          method: 'DELETE',
+          url: `${claEndpoint}company//project//cla-manager/${userLFID}`,
+          expectedStatus: 403,
+          expectedCode: 403,
+          expectedMsg: '',
+          mode: 'remote',
+        },
+
+        // Is CLA manager designee with any of parameters missing
+        {
+          method: 'GET',
+          url: `${claEndpoint}company//user//claGroupID//is-cla-manager-designee`,
+          expectedStatus: 404,
+          expectedCode: 404,
+          expectedMsg: 'path /v4/company//user//claGroupID//is-cla-manager-designee was not found',
+          mode: both,
+        },
+        {
+          method: 'GET',
+          url: `${claEndpoint}company//user/${userLFID}/claGroupID/${claGroupID}/is-cla-manager-designee`,
+          expectedStatus: 404,
+          expectedCode: 404,
+          expectedMsg: `path /v4/company//user/${userLFID}/claGroupID/${claGroupID}/is-cla-manager-designee was not found`,
+          mode: both,
+        },
+        {
+          method: 'GET',
+          url: `${claEndpoint}company/${companySFID}/user//claGroupID/${claGroupID}/is-cla-manager-designee`,
+          expectedStatus: 404,
+          expectedCode: 404,
+          expectedMsg: `path /v4/company/${companySFID}/user//claGroupID/${claGroupID}/is-cla-manager-designee was not found`,
+          mode: both,
+        },
+        {
+          method: 'GET',
+          url: `${claEndpoint}company/${companySFID}/user/${userLFID}/claGroupID//is-cla-manager-designee`,
+          expectedStatus: 404,
+          expectedCode: 404,
+          expectedMsg: `path /v4/company/${companySFID}/user/${userLFID}/claGroupID//is-cla-manager-designee was not found`,
+          mode: both,
+        },
+
+        // 5a) Assign CLA Manager Designee by claGroup/companySFID: missing/wrong parameters, missy body parameter
+        {
+          method: 'POST',
+          url: `${claEndpoint}company//claGroup//cla-manager-designee`,
+          expectedStatus: 404,
+          expectedCode: 404,
+          expectedMsg: 'path /v4/company//claGroup//cla-manager-designee was not found',
+          mode: 'local',
+        },
+        {
+          method: 'POST',
+          url: `${claEndpoint}company//claGroup//cla-manager-designee`,
+          expectedStatus: 403,
+          expectedCode: 403,
+          expectedMsg: '',
+          mode: 'remote',
+        },
+        {
+          method: 'POST',
+          url: `${claEndpoint}company/${companyID}/claGroup//cla-manager-designee`,
+          expectedStatus: 404,
+          expectedCode: 404,
+          expectedMsg: `path /v4/company/${companyID}/claGroup//cla-manager-designee was not found`,
+          mode: 'local',
+        },
+        {
+          method: 'POST',
+          url: `${claEndpoint}company/${companyID}/claGroup//cla-manager-designee`,
+          expectedStatus: 403,
+          expectedCode: 403,
+          expectedMsg: '',
+          mode: 'remote',
+        },
+        {
+          method: 'POST',
+          url: `${claEndpoint}company//claGroup/${claGroupID}/cla-manager-designee`,
+          expectedStatus: 404,
+          expectedCode: 404,
+          expectedMsg: `path /v4/company//claGroup/${claGroupID}/cla-manager-designee was not found`,
+          mode: 'local',
+        },
+        {
+          method: 'POST',
+          url: `${claEndpoint}company//claGroup/${claGroupID}/cla-manager-designee`,
+          expectedStatus: 403,
+          expectedCode: 403,
+          expectedMsg: '',
+          mode: 'remote',
+        },
+        {
+          method: 'POST',
+          url: `${claEndpoint}company/${badUUID}/claGroup/${claGroupID}/cla-manager-designee`,
+          expectedStatus: 422,
+          expectedCode: 605,
+          expectedMsg:
+            "companyID in path should match '^[a-fA-F0-9]{8}-?[a-fA-F0-9]{4}-?4[a-fA-F0-9]{3}-?[89ab][a-fA-F0-9]{3}-?[a-fA-F0-9]{12}$'",
+          mode: both,
+          body: claManagerDesigneeBody,
+        },
+        {
+          method: 'POST',
+          url: `${claEndpoint}company/${companyID}/claGroup/${badUUID}/cla-manager-designee`,
+          expectedStatus: 422,
+          expectedCode: 605,
+          expectedMsg:
+            "claGroupID in path should match '^[a-fA-F0-9]{8}-?[a-fA-F0-9]{4}-?4[a-fA-F0-9]{3}-?[89ab][a-fA-F0-9]{3}-?[a-fA-F0-9]{12}$'",
+          mode: both,
+          body: claManagerDesigneeBody,
+        },
+        {
+          // missing body parameter
+          method: 'POST',
+          url: `${claEndpoint}company/${companyID}/claGroup/${claGroupID}/cla-manager-designee`,
+          expectedStatus: 422,
+          expectedCode: 602,
+          expectedMsg: 'body in body is required',
+          mode: both,
+          extra: 'includes',
+        },
+
+        // 5b) Assign CLA Manager Designee by claGroup/companySFID: wrong claGroupID (bad UUIDv4)
+        {
+          method: 'POST',
+          url: `${claEndpoint}company//project//cla-manager-designee`,
+          expectedStatus: 404,
+          expectedCode: 404,
+          expectedMsg: 'path /v4/company//project//cla-manager-designee was not found',
+          mode: 'local',
+        },
+        {
+          method: 'POST',
+          url: `${claEndpoint}company//project//cla-manager-designee`,
+          expectedStatus: 403,
+          expectedCode: 403,
+          expectedMsg: '',
+          mode: 'remote',
+        },
+        {
+          method: 'POST',
+          url: `${claEndpoint}company/${companyID}/project//cla-manager-designee`,
+          expectedStatus: 404,
+          expectedCode: 404,
+          expectedMsg: `path /v4/company/${companyID}/project//cla-manager-designee was not found`,
+          mode: 'local',
+        },
+        {
+          method: 'POST',
+          url: `${claEndpoint}company/${companyID}/project//cla-manager-designee`,
+          expectedStatus: 403,
+          expectedCode: 403,
+          expectedMsg: '',
+          mode: 'remote',
+        },
+        {
+          method: 'POST',
+          url: `${claEndpoint}company//project/${projectSFID}/cla-manager-designee`,
+          expectedStatus: 404,
+          expectedCode: 404,
+          expectedMsg: `path /v4/company//project/${projectSFID}/cla-manager-designee was not found`,
+          mode: 'local',
+        },
+        {
+          method: 'POST',
+          url: `${claEndpoint}company//project/${projectSFID}/cla-manager-designee`,
+          expectedStatus: 403,
+          expectedCode: 403,
+          expectedMsg: '',
+          mode: 'remote',
+        },
+        {
+          method: 'POST',
+          url: `${claEndpoint}company/${badUUID}/project/${projectSFID}/cla-manager-designee`,
+          expectedStatus: 422,
+          expectedCode: 605,
+          expectedMsg:
+            "companyID in path should match '^[a-fA-F0-9]{8}-?[a-fA-F0-9]{4}-?4[a-fA-F0-9]{3}-?[89ab][a-fA-F0-9]{3}-?[a-fA-F0-9]{12}$'",
+          mode: both,
+          body: claManagerDesigneeBody,
+        },
+        {
+          method: 'POST',
+          url: `${claEndpoint}company/${companyID}/project/${badSFID}/cla-manager-designee`,
+          expectedStatus: 422,
+          expectedCode: 603,
+          expectedMsg: 'projectSFID in path should be at most 18 chars long',
+          mode: both,
+          body: claManagerDesigneeBody,
+        },
+        {
+          // missing body parameter
+          method: 'POST',
+          url: `${claEndpoint}company/${companyID}/project/${projectSFID}/cla-manager-designee`,
+          expectedStatus: 422,
+          expectedCode: 602,
+          expectedMsg: 'body in body is required',
+          extra: 'includes',
+        },
+
+        // 6) List CLA managers: missing projectSFID
+        {
+          method: 'GET',
+          url: `${claEndpoint}company/${companyID}/project//cla-managers`,
+          expectedStatus: 404,
+          expectedCode: 404,
+          expectedMsg: 'path /v4/company/' + companyID + '/project//cla-managers was not found',
+          mode: 'local',
+        },
+        {
+          method: 'GET',
+          url: `${claEndpoint}company/${companyID}/project//cla-managers`,
+          expectedStatus: 403,
+          expectedCode: 403,
+          expectedMsg: '',
+          mode: 'remote',
+        },
+
+        // 7) List CLA managers by CLA Group: invalid/missing claGroupID (double slash)
+        {
+          method: 'GET',
+          url: `${claEndpoint}company/${companyID}/cla-group//cla-managers`,
+          expectedStatus: 404,
+          expectedCode: 1,
+          expectedMsg: 'path /v4/company/' + companyID + '/cla-group//cla-managers was not found',
+          // mode: 'local',
+          mode: both, // LG: It returns 404 in both local and remote
+        },
+        /*
+        // LG: this should be commented out
+        {
+          method: 'GET',
+          url: `${claEndpoint}company/${companyID}/cla-group//cla-managers`,
+          expectedStatus: 403,
+          expectedCode: 403,
+          expectedMsg: '',
+          mode: 'remote',
+        },
+        */
+
+        // 8) List CLA managers by CLA Group: wrong claGroupID format (not UUID v4)
+        {
+          method: 'GET',
+          url: `${claEndpoint}company/${companyID}/cla-group/${badUUID}/cla-managers`,
+          expectedStatus: 422,
+          expectedCode: 605,
+          expectedMsg:
+            "claGroupID in path should match '^[a-fA-F0-9]{8}-?[a-fA-F0-9]{4}-?4[a-fA-F0-9]{3}-?[89ab][a-fA-F0-9]{3}-?[a-fA-F0-9]{12}$'",
+          mode: both,
+        },
+      ];
+
+      const filtered = requests.filter((r) => r.mode === both || r.mode === effectiveMode);
+      cy.wrap(filtered).each((req: any) => {
+        const { method, url, expectedStatus, expectedCode, expectedMsg } = req;
+        const extra = req.extra || '';
+        const body = req.body || null;
+        cy.task('log', `--> ${method} ${url}`);
+        cy.request({
+          method,
+          url,
+          failOnStatusCode: false,
+          headers: getXACLHeader(),
+          auth: { bearer: bearerToken },
+          timeout,
+          ...(body ? { body: body } : {}),
+        }).then((response) => {
+          return cy.logJson('response', response).then(() => {
+            switch (expectedStatus) {
+              case 400:
+                if (extra === 'includes') {
+                  return validate_400_Status_Contains(response, expectedMsg);
+                } else {
+                  return validate_400_Status(response, expectedMsg);
+                }
+              case 403:
+                return validate_403_Status(response);
+              case 404:
+                return validate_404_Status_and_Message(response, expectedMsg);
+              case 405:
+                return validate_405_Status_and_Message(response, expectedMsg);
+              case 422:
+                return validate_422_Status(response, expectedCode, expectedMsg);
+              default:
+                throw new Error(`Unexpected expectedStatus: ${expectedStatus}`);
+            }
+          });
+        });
+      });
+    });
+  });
+
+  it('Assigns CLA Manager designee to a given user 1', function () {
     let url = `${claEndpoint}company/${companyID}/claGroup/${claGroupID}/cla-manager-designee`;
     cy.task('log', `--> POST ${url}`);
     cy.request({
       method: 'POST',
       url: url,
-      timeout: 180000,
+      timeout: timeout,
       failOnStatusCode: allowFail,
       headers: getXACLHeader(),
       auth: { bearer: bearerToken },
@@ -77,13 +685,33 @@ https://api-gw.dev.platform.linuxfoundation.org/acs/v1/api-docs#tag/Role/operati
     });
   });
 
+  it('Attempts to assign CLA Manager designee to a given user in project', function () {
+    let url = `${claEndpoint}company/${companyID}/project/${projectSFID}/cla-manager-designee`;
+    cy.task('log', `--> POST ${url}`);
+    cy.request({
+      method: 'POST',
+      url: url,
+      timeout: timeout,
+      failOnStatusCode: allowFail,
+      headers: getXACLHeader(),
+      auth: { bearer: bearerToken },
+      body: { userEmail: userEmail },
+    }).then((response) => {
+      // expect(response.duration).to.be.lessThan(20000);
+      return cy.logJson('response', response).then(() => {
+        validate_400_Status_Contains(response, 'EasyCLA - 400 Bad Request');
+        validate_400_Status_Contains(response, 'error: project already signed');
+      });
+    });
+  });
+
   it('Allows an existing CLA Manager to add another CLA Manager to the specified Company and Project.', function () {
     let url = `${claEndpoint}company/${companyID}/project/${projectSFID}/cla-manager`;
     cy.task('log', `--> POST ${url}`);
     cy.request({
       method: 'POST',
       url: url,
-      timeout: 180000,
+      timeout: timeout,
       failOnStatusCode: allowFail,
       headers: getXACLHeader(),
       auth: {
@@ -115,7 +743,7 @@ https://api-gw.dev.platform.linuxfoundation.org/acs/v1/api-docs#tag/Role/operati
     cy.request({
       method: 'DELETE',
       url: `${claEndpoint}company/${companyID}/project/${projectSFID}/cla-manager/${userLFID}`,
-      timeout: 180000,
+      timeout: timeout,
       failOnStatusCode: allowFail,
       headers: getXACLHeader(),
       auth: {
@@ -127,11 +755,11 @@ https://api-gw.dev.platform.linuxfoundation.org/acs/v1/api-docs#tag/Role/operati
     });
   });
 
-  it('Assigns CLA Manager designee to a given user', function () {
+  it('Assigns CLA Manager designee to a given user 2', function () {
     cy.request({
       method: 'POST',
       url: `${claEndpoint}company/${companyID}/project/${projectSFID_Designee}/cla-manager-designee`,
-      timeout: 180000,
+      timeout: timeout,
       failOnStatusCode: allowFail,
       headers: getXACLHeader(),
       auth: {
@@ -156,7 +784,7 @@ https://api-gw.dev.platform.linuxfoundation.org/acs/v1/api-docs#tag/Role/operati
     cy.request({
       method: 'POST',
       url: `${claEndpoint}company/${companyID}/project/${projectSFID_Designee}/cla-manager/requests`,
-      timeout: 180000,
+      timeout: timeout,
       failOnStatusCode: allowFail,
       headers: getXACLHeader(),
       auth: {
@@ -197,7 +825,7 @@ https://api-gw.dev.platform.linuxfoundation.org/acs/v1/api-docs#tag/Role/operati
     cy.request({
       method: 'POST',
       url: `${claEndpoint}notify-cla-managers`,
-      timeout: 180000,
+      timeout: timeout,
       failOnStatusCode: allowFail,
       headers: getXACLHeader(),
       auth: {
@@ -229,7 +857,7 @@ https://api-gw.dev.platform.linuxfoundation.org/acs/v1/api-docs#tag/Role/operati
     cy.request({
       method: 'POST',
       url: `${claEndpoint}notify-cla-managers`,
-      timeout: 180000,
+      timeout: timeout,
       failOnStatusCode: false,
       headers: getXACLHeader(),
       auth: {
@@ -247,7 +875,7 @@ https://api-gw.dev.platform.linuxfoundation.org/acs/v1/api-docs#tag/Role/operati
     cy.request({
       method: 'POST',
       url: `${claEndpoint}user/${userId2}/invite-company-admin`,
-      timeout: 180000,
+      timeout: timeout,
       failOnStatusCode: allowFail,
       headers: getXACLHeader(),
       auth: {
@@ -268,21 +896,67 @@ https://api-gw.dev.platform.linuxfoundation.org/acs/v1/api-docs#tag/Role/operati
     });
   });
 
+  it('Lists CLA managers by Project/Company - returns 200', function () {
+    cy.request({
+      method: 'GET',
+      url: `${claEndpoint}company/${companyID}/project/${projectSFID}/cla-managers`,
+      timeout,
+      failOnStatusCode: true,
+      headers: getXACLHeader(),
+      auth: { bearer: bearerToken },
+    }).then((response) => {
+      return cy.logJson('response', response).then(() => {
+        validate_200_Status(response);
+        // Minimal shape assertions - adapt if you have a schema file
+        const body = response.body ?? response.Body ?? {};
+        // expect array-ish payload under a common key if present
+        if (Array.isArray(body)) {
+          expect(body).to.be.an('array');
+        } else if (body.list) {
+          expect(body.list).to.be.an('array');
+        }
+      });
+    });
+  });
+
+  it('Lists CLA managers by CLA Group/Company - returns 200', function () {
+    cy.request({
+      method: 'GET',
+      url: `${claEndpoint}company/${companyID}/cla-group/${claGroupID}/cla-managers`,
+      timeout,
+      failOnStatusCode: true,
+      headers: getXACLHeader(),
+      auth: { bearer: bearerToken },
+    }).then((response) => {
+      return cy.logJson('response', response).then(() => {
+        validate_200_Status(response);
+        const body = response.body ?? response.Body ?? {};
+        if (Array.isArray(body)) {
+          expect(body).to.be.an('array');
+        } else if (body.list) {
+          expect(body.list).to.be.an('array');
+        }
+      });
+    });
+  });
+
   function getClaManager() {
     cy.request({
       method: 'GET',
       url: `${claEndpoint}company/${companySFID}/user/${userLFID}/claGroupID/${claGroupID}/is-cla-manager-designee`,
-      timeout: 180000,
+      timeout: timeout,
       failOnStatusCode: allowFail,
       headers: getXACLHeader(),
       auth: {
         bearer: bearerToken,
       },
     }).then((response) => {
-      validate_200_Status(response);
-      expect(response.body.hasRole).to.eq(true);
-      expect(response.body.lfUsername).to.eq(userLFID);
-      // validateApiResponse("cla-manager/isCLAManagerDesignee.json",response)
+      return cy.logJson('response', response).then(() => {
+        validate_200_Status(response);
+        expect(response.body.hasRole).to.eq(true);
+        expect(response.body.lfUsername).to.eq(userLFID);
+        // validateApiResponse("cla-manager/isCLAManagerDesignee.json",response)
+      });
     });
   }
 });

--- a/tests/functional/cypress/support/commands.js
+++ b/tests/functional/cypress/support/commands.js
@@ -24,88 +24,132 @@ export function validateApiResponse(schemaPath, response) {
   });
 }
 
-//To validate & assert 200 response of api
-export function validate_200_Status(response) {
-  expect(response.status).to.eq(200);
-  expect(response.body).to.not.be.null;
-  const jsonResponse = JSON.stringify(response.body, null, 2);
-  cy.log(jsonResponse);
-}
-
-export function validate_204_Status(response) {
-  expect(response.status).to.eq(204);
-  expect(response.body).to.not.be.null;
-  const jsonResponse = JSON.stringify(response.body, null, 2);
-  cy.log(jsonResponse);
-}
-
-export function validate_400_Status(response, message) {
-  expect(response.status).to.eq(400);
-  expect(response.statusText).to.eq('Bad Request');
-  expect(response.body.Code).to.eq('400');
-  expect(response.body.Message).to.eq(message);
-}
-
-export function validate_401_Status(response, local) {
-  expect(response.status).to.eq(401);
-  expect(response.statusText).to.eq('Unauthorized');
-  if (local === true) {
-    expect(response.body.message).to.eq('unauthenticated for invalid credentials');
-  } else {
-    expect(response.body).to.eq('no token provided\n');
-  }
-}
-
 function parseJsonBody(resp) {
-  if (resp && typeof resp.body === 'string') {
-    const s = resp.body.trim();
+  if (!resp) {
+    return {};
+  }
+  const body = resp.body ?? resp.Body;
+  if (typeof body === 'string') {
+    const s = body.trim();
     try {
       return JSON.parse(s);
     } catch (e) {}
   }
-  return resp.body;
+  return body;
+}
+
+export function validate_status(response, expectedStatus) {
+  const status = response.status ?? response.Status;
+  expect(String(status)).to.eq(String(expectedStatus));
+}
+
+//To validate & assert 200 response of api
+export function validate_200_Status(response) {
+  const status = response.status ?? response.Status;
+  expect(String(status)).to.eq('200');
+  const body = response.body ?? response.Body;
+  expect(body).to.not.be.null;
+}
+
+export function validate_204_Status(response) {
+  const status = response.status ?? response.Status;
+  expect(String(status)).to.eq('204');
+  const body = response.body ?? response.Body;
+  expect(body).to.not.be.null;
+}
+
+export function validate_400_Status(response, message) {
+  const status = response.status ?? response.Status;
+  expect(String(status)).to.eq('400');
+  const statusText = response.statusText ?? response.StatusText;
+  expect(statusText).to.eq('Bad Request');
+  const body = response.body ?? response.Body ?? {};
+  const bodyCode = body.code ?? body.Code;
+  const bodyMessage = body.message ?? body.Message;
+  expect(String(bodyCode)).to.eq('400');
+  expect(bodyMessage).to.eq(message);
+}
+
+export function validate_400_Status_Contains(response, message) {
+  const status = response.status ?? response.Status;
+  expect(String(status)).to.eq('400');
+  const statusText = response.statusText ?? response.StatusText;
+  expect(statusText).to.eq('Bad Request');
+  const body = response.body ?? response.Body ?? {};
+  const bodyCode = body.code ?? body.Code;
+  const bodyMessage = body.message ?? body.Message;
+  expect(String(bodyCode)).to.eq('400');
+  expect(bodyMessage).to.contain(message);
+}
+
+export function validate_401_Status(response, local) {
+  const status = response.status ?? response.Status;
+  expect(String(status)).to.eq('401');
+  const statusText = response.statusText ?? response.StatusText;
+  expect(statusText).to.eq('Unauthorized');
+  const body = response.body ?? response.Body ?? {};
+  if (local === true) {
+    const bodyMessage = body.message ?? body.Message;
+    expect(bodyMessage).to.eq('unauthenticated for invalid credentials');
+  } else {
+    expect(body).to.eq('no token provided\n');
+  }
 }
 
 export function validate_403_Status(response) {
+  const status = response.status ?? response.Status;
+  expect(String(status)).to.eq('403');
+  const statusText = response.statusText ?? response.StatusText;
+  expect(statusText).to.eq('Forbidden');
   const body = parseJsonBody(response);
-  expect(response.status).to.eq(403);
-  expect(response.statusText).to.eq('Forbidden');
   const code = body && (body.Code ?? body.code);
-  expect(code).to.eq(403);
+  expect(String(code)).to.eq('403');
 }
 
 export function validate_404_Status(response) {
-  expect(response.status).to.eq(404);
-  expect(response.statusText).to.eq('Not Found');
-  expect(response.body.Code).to.eq('404');
+  const status = response.status ?? response.Status;
+  expect(String(status)).to.eq('404');
+  const statusText = response.statusText ?? response.StatusText;
+  expect(statusText).to.eq('Not Found');
+  const body = response.body ?? response.Body ?? {};
+  const bodyCode = body.code ?? body.Code;
+  expect(String(bodyCode)).to.eq('404');
 }
 
-export function validate_404_Status_and_Message(response, message) {
-  expect(response.status).to.eq(404);
-  expect(response.statusText).to.eq('Not Found');
-  expect(response.body.code).to.eq(404);
-  expect(response.body.message).to.eq(message);
+export function validate_404_Status_and_Message(response, expectedMessage) {
+  const status = response.status ?? response.Status;
+  expect(String(status)).to.eq('404');
+  const statusText = response.statusText ?? response.StatusText;
+  expect(statusText).to.eq('Not Found');
+  const body = response.body ?? response.Body ?? {};
+  const bodyCode = body.code ?? body.Code;
+  const bodyMessage = body.message ?? body.Message;
+  expect(String(bodyCode)).to.eq('404');
+  expect(bodyMessage).to.eq(expectedMessage);
 }
 
-export function validate_404_Status_and_Message2(response, message) {
-  expect(response.status).to.eq(404);
-  expect(response.statusText).to.eq('Not Found');
-  expect(response.body.Code).to.eq('404');
-  expect(response.body.Message).to.eq(message);
+export function validate_405_Status_and_Message(response, expectedMessage) {
+  const status = response.status ?? response.Status;
+  expect(String(status)).to.eq('405');
+  const statusText = response.statusText ?? response.StatusText;
+  expect(statusText).to.eq('Method Not Allowed');
+  const body = response.body ?? response.Body ?? {};
+  const bodyCode = body.code ?? body.Code;
+  const bodyMessage = body.message ?? body.Message;
+  expect(String(bodyCode)).to.eq('405');
+  expect(bodyMessage).to.eq(expectedMessage);
 }
 
-export function validate_405_Status_and_Message(response, message) {
-  expect(response.status).to.eq(405);
-  expect(response.statusText).to.eq('Method Not Allowed');
-  expect(response.body.code).to.eq(405);
-  expect(response.body.message).to.eq(message);
-}
-
-export function validate_422_Status(response, bodyCode, bodyMessage) {
-  expect(response.status).to.eq(422);
-  expect(response.statusText).to.eq('Unprocessable Entity');
-  expect(response.body.code).to.eq(bodyCode);
-  expect(response.body.message).to.eq(bodyMessage);
+export function validate_422_Status(response, expectedBodyCode, expectedBodyMessage) {
+  const status = response.status ?? response.Status;
+  expect(String(status)).to.eq('422');
+  const statusText = response.statusText ?? response.StatusText;
+  expect(statusText).to.eq('Unprocessable Entity');
+  const body = response.body ?? response.Body ?? {};
+  const bodyCode = body.code ?? body.Code;
+  const bodyMessage = body.message ?? body.Message;
+  expect(String(bodyCode)).to.eq(String(expectedBodyCode));
+  expect(bodyMessage).to.eq(expectedBodyMessage);
 }
 
 export function shortenMiddle(str) {

--- a/tests/functional/utils/run-single-test-local.sh
+++ b/tests/functional/utils/run-single-test-local.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-LOCAL=1 XACL="$(cat ./x-acl.secret)" TOKEN="$(cat ./token.secret)" ALLOW_FAIL=1 ./utils/run-single-test.sh "$@"
+ALLOW_FAIL=1 LOCAL=1 DEBUG=1 TOKEN="$(cat ./token.secret)" XACL="$(cat ./x-acl.secret)" ./utils/run-single-test.sh "$@"

--- a/tests/functional/utils/run-single-test-remote.sh
+++ b/tests/functional/utils/run-single-test-remote.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+ALLOW_FAIL=1 DEBUG=1 ./utils/run-single-test.sh "$@"

--- a/tests/functional/utils/run-single-test.sh
+++ b/tests/functional/utils/run-single-test.sh
@@ -58,6 +58,7 @@ if [ ! -z "${ENV_ARGS}" ]; then
   CMD="${CMD} --env ${ENV_ARGS}"
 fi
 
+npx prettier --write cypress/e2e/* cypress/support/* cypress/appConfig/* cypress.config.ts
 if [ ! -z "${DEBUG}" ]
 then
   echo "Running: ${CMD}"


### PR DESCRIPTION

This is for https://github.com/linuxfoundation/easycla/issues/4762.

cc @mlehotskylf @ahmedomosanya 

1) Added tests for `cla-manager` API group:
- Added expected failures when doing an API request without valid token.
- Added expected failure tests for API calls without required params or param values having incorrect formats.
20 Added `required: true` flag for a few APIs that didn't have it in swagger, but obviously required it because in API code they were referring to those parameter's properties assuming that they are always present (hence causing panics when those parameters were omitted and swagger was not guarding against this).

Note that there might be a followup PR after this one is merged & deployed because some APIs behave differently when called via API-gateway and ACS vs. locally and test coverage must support calling them both way depending on `LOCAL` cypress environment variable.


Signed-off-by: Lukasz Gryglicki <lgryglicki@cncf.io>

Assisted by [OpenAI](https://platform.openai.com/)

Assisted by [GitHub Copilot](https://github.com/features/copilot)