### PR TITLE
Handle too big commits, missing commits from fork PRs, golang REST fallback

### DIFF
--- a/cla-backend-go/github/github_repository.go
+++ b/cla-backend-go/github/github_repository.go
@@ -1574,7 +1574,7 @@ query($owner:String!, $name:String!, $head:GitObjectID!, $first:Int!, $after:Str
 			break
 		}
 		if !hist.Repository.Object.History.PageInfo.HasNextPage {
-			return nil, false, fmt.Errorf("merge-base commit not found in PR history")
+			return GetPullRequestCommitAuthorsREST(ctx, usersService, installationID, pullRequestID, owner, repo, withCoAuthors)
 		}
 		cur := hist.Repository.Object.History.PageInfo.EndCursor
 		after = &cur

--- a/cla-backend/cla/models/github_models.py
+++ b/cla-backend/cla/models/github_models.py
@@ -2279,7 +2279,6 @@ def iter_pr_commits_full(g, owner: str, repo_name: str, number: int, page_size: 
             # merge-base not found — extremely rare (rebases or unusual ancestry).
             # Fall back to non-GQL old approach (limited to 250 commits but still better that error)
             raise ValueError("merge-base commit not found in PR commit history")
-            # return
 
         after = hist["pageInfo"]["endCursor"]
         safety_pages += 1
@@ -2699,7 +2698,7 @@ def update_pull_request(
         repo = getattr(getattr(pull_request, "base", None), "repo", None)
         commit_obj = repo.get_commit(last_commit_sha)
     except (GithubException, AttributeError, TypeError) as exc:
-        cla.log.error(f"{fn} - PR {pull_request.number}: exception getting base.sha: {exc}")
+        cla.log.error(f"{fn} - PR {pull_request.number}: exception getting commit sha: {exc}")
         try:
             commit_obj = pull_request.get_commits().reversed[0]
             last_commit_sha = commit_obj.sha

--- a/cla-backend/cla/utils.py
+++ b/cla-backend/cla/utils.py
@@ -1054,7 +1054,7 @@ def assemble_cla_comment(
         missing_user_id=no_user_id,
     )
     body = badge + "<br />" + comment
-    if len(body) > 0xFF00:
+    if len(body.encode('utf-8')) > 0xFF00:
         body = trim_comment(body, max_items=40, head=20, tail=20, ellipsis="…")
     return body
 


### PR DESCRIPTION
- Handle commend body too big (> 64K characters - can happen if PR has a lot of commits) in both `python` and `golang` backends.
- Handle PRs from forks with > 250 commits with graceful fallack to REST (both `python` and `golang` backends).
- Correctly locate PR head SHA using quick API call and fallback to getting last PR's commit SHA (also both backends).
- Log number of distinct commit SHAs, authors (ids, logins, emails, names) in both backends so we can see how many commit summaries were there and how many actual commits (one commit can have > 1 authors) - both backends.
- Handle private repos and forks correctly in both backends with fallbacks on errors.


cc @mlehotskylf @ahmedomosanya @jarias-lfx - this is for https://github.com/linuxfoundation/easycla/issues/4835.

Signed-off-by: Lukasz Gryglicki <lgryglicki@cncf.io>

Assisted by [OpenAI](https://platform.openai.com/)

Assisted by [GitHub Copilot](https://github.com/features/copilot)