### PR TITLE
Unicron 4835 handle edge cases prod

### DIFF
--- a/cla-backend-go/github/github_repository.go
+++ b/cla-backend-go/github/github_repository.go
@@ -68,6 +68,7 @@ const (
 	svgVersion       = "?v=2"
 	NegativeCacheTTL = 3 * time.Minute // Used for negative caching of missing/not-signed users
 	ProjectCacheTTL  = 3 * time.Hour   // Used for per-project caching of signed users
+	MaxCommentLength = 0xff00          // 65520 characters - leave some buffer under 64KB limit
 )
 
 // GraphQL related types
@@ -87,6 +88,23 @@ type gqlError struct {
 type gqlResponse struct {
 	Data   json.RawMessage `json:"data"`
 	Errors []gqlError      `json:"errors,omitempty"`
+}
+
+type gqlUser struct {
+	DatabaseID int    `json:"databaseId"`
+	Login      string `json:"login"`
+	Name       string `json:"name"`
+	Email      string `json:"email"`
+}
+
+type histNode struct {
+	OID     string `json:"oid"`
+	Message string `json:"message"`
+	Author  struct {
+		Name  string  `json:"name"`
+		Email string  `json:"email"`
+		User  gqlUser `json:"user"`
+	} `json:"author"`
 }
 
 type GraphQLError struct {
@@ -109,59 +127,29 @@ func (e *GraphQLError) Error() string {
 
 // doGraphQL posts to /graphql using v3 client and unmarshals the "data" field into v.
 // No retries; if GraphQL returns "errors", returns an error.
-func doGraphQL(ctx context.Context, c *github.Client, query string, variables map[string]interface{}, v any) (*github.Response, error) {
+func doGraphQL(ctx context.Context, c *github.Client, query string, variables map[string]interface{}, v any) error {
 	reqBody := gqlRequest{Query: query, Variables: variables}
 	req, err := c.NewRequest("POST", "graphql", reqBody) // -> https://api.github.com/graphql
 	if err != nil {
-		return nil, err
+		return err
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 	var gr gqlResponse
-	resp, err := c.Do(ctx, req, &gr)
+	_, err = c.Do(ctx, req, &gr)
 	if err != nil {
-		return resp, err
+		return err
 	}
 	if len(gr.Errors) > 0 {
-		return resp, &GraphQLError{Errs: gr.Errors}
+		return &GraphQLError{Errs: gr.Errors}
 	}
 	if v != nil && len(gr.Data) > 0 {
 		if err := json.Unmarshal(gr.Data, v); err != nil {
-			return resp, fmt.Errorf("unmarshal graphql data: %w", err)
+			return fmt.Errorf("unmarshal graphql data: %w", err)
 		}
 	}
-	return resp, nil
-}
-
-type prCommitsPage struct {
-	Repository struct {
-		PullRequest struct {
-			Commits struct {
-				TotalCount int `json:"totalCount"`
-				PageInfo   struct {
-					HasNextPage bool   `json:"hasNextPage"`
-					EndCursor   string `json:"endCursor"`
-				} `json:"pageInfo"`
-				Nodes []struct {
-					Commit struct {
-						OID     string `json:"oid"`
-						Message string `json:"message"`
-						Author  struct {
-							Name  string `json:"name"`  // commit metadata author
-							Email string `json:"email"` // commit metadata author
-							User  struct {
-								DatabaseID int    `json:"databaseId"`
-								Login      string `json:"login"`
-								Name       string `json:"name"`  // profile
-								Email      string `json:"email"` // profile (often empty)
-							} `json:"user"`
-						} `json:"author"`
-					} `json:"commit"`
-				} `json:"nodes"`
-			} `json:"commits"`
-		} `json:"pullRequest"`
-	} `json:"repository"`
+	return nil
 }
 
 type cacheEntry struct {
@@ -1222,8 +1210,9 @@ func GetCommitAuthorsSignedStatuses(
 
 //nolint:gocyclo // complexity is acceptable for now
 func GetPullRequestCommitAuthorsREST(ctx context.Context, usersService users.Service, installationID int64, pullRequestID int, owner, repo string, withCoAuthors bool) ([]*UserCommitSummary, bool, error) {
+	fn := "github.github_repository.GetPullRequestCommitAuthorsREST"
 	f := logrus.Fields{
-		"functionName":  "github.github_repository.GetPullRequestCommitAuthorsREST",
+		"functionName":  fn,
 		"pullRequestID": pullRequestID,
 		"withCoAuthors": withCoAuthors,
 	}
@@ -1301,9 +1290,46 @@ func GetPullRequestCommitAuthorsREST(ctx context.Context, usersService users.Ser
 		opts.Page = resp.NextPage
 	}
 
+	// Build distinct sets
+	distinctSHAs := make(map[string]struct{})
+	distinctIDs := make(map[int64]struct{})
+	distinctLogins := make(map[string]struct{})
+	distinctEmails := make(map[string]struct{})
+	distinctNames := make(map[string]struct{})
+
+	for _, s := range userCommitSummary {
+		if s == nil {
+			continue
+		}
+		if s.SHA != "" {
+			distinctSHAs[s.SHA] = struct{}{}
+		}
+		if s.CommitAuthor != nil {
+			if s.CommitAuthor.ID != nil {
+				distinctIDs[*s.CommitAuthor.ID] = struct{}{}
+			}
+			if s.CommitAuthor.Login != nil && *s.CommitAuthor.Login != "" {
+				distinctLogins[*s.CommitAuthor.Login] = struct{}{}
+			}
+			if s.CommitAuthor.Email != nil && *s.CommitAuthor.Email != "" {
+				distinctEmails[*s.CommitAuthor.Email] = struct{}{}
+			}
+			if s.CommitAuthor.Name != nil && *s.CommitAuthor.Name != "" {
+				distinctNames[*s.CommitAuthor.Name] = struct{}{}
+			}
+		}
+	}
+
+	log.WithFields(f).Debugf(
+		"%s - PR: %d, total commit authors summaries found: %d, any missing: %v, distinct SHAs: %d, distinct author IDs: %d, logins: %d, emails: %d, names: %d",
+		fn, pullRequestID, len(userCommitSummary), anyMissing,
+		len(distinctSHAs), len(distinctIDs), len(distinctLogins), len(distinctEmails), len(distinctNames),
+	)
+
 	return userCommitSummary, anyMissing, nil
 }
 
+//nolint:gocyclo // complexity is acceptable for now
 func GetPullRequestCommitAuthors(
 	ctx context.Context,
 	usersService users.Service,
@@ -1312,8 +1338,9 @@ func GetPullRequestCommitAuthors(
 	owner, repo string,
 	withCoAuthors bool,
 ) ([]*UserCommitSummary, bool, error) {
+	const fn = "github.github_repository.GetPullRequestCommitAuthors"
 	f := logrus.Fields{
-		"functionName":  "github.github_repository.GetPullRequestCommitAuthors",
+		"functionName":  fn,
 		"pullRequestID": pullRequestID,
 		"withCoAuthors": withCoAuthors,
 	}
@@ -1324,28 +1351,178 @@ func GetPullRequestCommitAuthors(
 		return nil, false, err
 	}
 
-	const pageSize = 100 // GraphQL max
-	const query = `
-query($owner:String!, $name:String!, $number:Int!, $pageSize:Int!, $cursor:String) {
+	// 1) Get base/head OIDs via GraphQL
+	const qInfo = `
+query($owner:String!, $name:String!, $number:Int!) {
   repository(owner:$owner, name:$name) {
-    pullRequest(number:$number) {
-      commits(first:$pageSize, after:$cursor) {
-        totalCount
-        pageInfo { hasNextPage endCursor }
-        nodes {
-          commit {
+    pullRequest(number:$number) { baseRefOid headRefOid }
+  }
+}`
+	var info struct {
+		Repository struct {
+			PullRequest struct {
+				BaseRefOid string `json:"baseRefOid"`
+				HeadRefOid string `json:"headRefOid"`
+			} `json:"pullRequest"`
+		} `json:"repository"`
+	}
+	err = doGraphQL(ctx, client, qInfo, map[string]interface{}{
+		"owner": owner, "name": repo, "number": pullRequestID,
+	}, &info)
+	if err != nil || info.Repository.PullRequest.HeadRefOid == "" {
+		log.WithFields(f).WithError(err).Error("failed to fetch base/head OIDs via GraphQL")
+		return GetPullRequestCommitAuthorsREST(ctx, usersService, installationID, pullRequestID, owner, repo, withCoAuthors)
+	}
+	baseOID := info.Repository.PullRequest.BaseRefOid
+	headOID := info.Repository.PullRequest.HeadRefOid
+
+	// 2) Get merge-base via REST Compare
+	//    NOTE: Compare takes base, head (same order as Python version)
+	cRepo := client // go-github client
+	gr := cRepo.Repositories
+	// pr := cRepo.PullRequests
+
+	// We need a REST *repo* client; NewGithubAppClient already returns go-github client
+	// Compare is under Repositories
+	comp, _, err := gr.CompareCommits(ctx, owner, repo, baseOID, headOID)
+	if err != nil || comp == nil || comp.MergeBaseCommit == nil || comp.MergeBaseCommit.SHA == nil {
+		log.WithFields(f).WithError(err).Error("failed to compute merge-base via REST compare")
+		return GetPullRequestCommitAuthorsREST(ctx, usersService, installationID, pullRequestID, owner, repo, withCoAuthors)
+	}
+	mergeBaseSHA := comp.MergeBaseCommit.GetSHA()
+
+	// 3a) Fetch HEAD commit via GraphQL (history won't include starting commit)
+	const qHead = `
+query($owner:String!, $name:String!, $oid:GitObjectID!) {
+  repository(owner:$owner, name:$name) {
+    object(oid:$oid) {
+      ... on Commit {
+        oid
+        message
+        author { name email user { databaseId login name email } }
+      }
+    }
+  }
+}`
+	var head struct {
+		Repository struct {
+			Object *struct {
+				OID     string `json:"oid"`
+				Message string `json:"message"`
+				Author  struct {
+					Name  string  `json:"name"`
+					Email string  `json:"email"`
+					User  gqlUser `json:"user"`
+				} `json:"author"`
+			} `json:"object"`
+		} `json:"repository"`
+	}
+	err = doGraphQL(ctx, client, qHead, map[string]interface{}{
+		"owner": owner, "name": repo, "oid": headOID,
+	}, &head)
+	if err != nil || head.Repository.Object == nil {
+		log.WithFields(f).WithError(err).Error("failed to fetch head commit via GraphQL")
+		return GetPullRequestCommitAuthorsREST(ctx, usersService, installationID, pullRequestID, owner, repo, withCoAuthors)
+	}
+
+	var (
+		userCommitSummary []*UserCommitSummary
+		anyMissing        atomic.Bool
+		mu                sync.Mutex
+		wg                sync.WaitGroup
+	)
+
+	// worker setup
+	maxConc := runtime.NumCPU()
+	if maxConc < 1 {
+		maxConc = 1
+	}
+	sem := make(chan struct{}, maxConc)
+
+	enqueue := func(sha, msg, authName, authEmail string, u gqlUser) {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			var id64 *int64
+			if u.DatabaseID != 0 {
+				tmp := int64(u.DatabaseID)
+				id64 = &tmp
+			}
+			var login, name, email *string
+			if u.Login != "" {
+				tmp := u.Login
+				login = &tmp
+			}
+			if u.Name != "" {
+				tmp := u.Name
+				name = &tmp
+			} else if authName != "" {
+				tmp := authName
+				name = &tmp
+			}
+			if u.Email != "" {
+				tmp := u.Email
+				email = &tmp
+			} else if authEmail != "" {
+				tmp := authEmail
+				email = &tmp
+			}
+
+			ghUser := &github.User{
+				ID:    id64,
+				Login: login,
+				Name:  name,
+				Email: email,
+			}
+			rc := &github.RepositoryCommit{
+				SHA: github.String(sha),
+				Commit: &github.Commit{
+					Message: github.String(msg),
+					Author: &github.CommitAuthor{
+						Name:  github.String(authName),
+						Email: github.String(authEmail),
+					},
+				},
+				Author: ghUser,
+			}
+
+			mu.Lock()
+			userCommitSummary = append(userCommitSummary, &UserCommitSummary{
+				SHA:          sha,
+				CommitAuthor: ghUser,
+				Affiliated:   false,
+				Authorized:   false,
+			})
+			mu.Unlock()
+
+			if withCoAuthors {
+				if ExpandWithCoAuthors(ctx, client, usersService, rc, pullRequestID, installationID, &userCommitSummary, &mu) {
+					anyMissing.Store(true)
+				}
+			}
+		}()
+	}
+
+	// Enqueue HEAD first (if not merge-base)
+	if head.Repository.Object.OID != mergeBaseSHA {
+		h := head.Repository.Object
+		enqueue(h.OID, h.Message, h.Author.Name, h.Author.Email, h.Author.User)
+	}
+
+	const qHist = `
+query($owner:String!, $name:String!, $head:GitObjectID!, $first:Int!, $after:String) {
+  repository(owner:$owner, name:$name) {
+    object(oid:$head) {
+      ... on Commit {
+        history(first:$first, after:$after) {
+          pageInfo { hasNextPage endCursor }
+          nodes {
             oid
             message
-            author {
-              name
-              email
-              user {
-                databaseId
-                login
-                name
-                email
-              }
-            }
+            author { name email user { databaseId login name email } }
           }
         }
       }
@@ -1353,141 +1530,101 @@ query($owner:String!, $name:String!, $number:Int!, $pageSize:Int!, $cursor:Strin
   }
 }`
 
-	var (
-		userCommitSummary []*UserCommitSummary
-		anyMissing        atomic.Bool
+	var after *string
+	pageSize := 100
+	safetyPages := 0
+	foundMergeBase := false
 
-		mu      sync.Mutex
-		wg      sync.WaitGroup
-		maxConc = runtime.NumCPU()
-	)
-	if maxConc < 1 {
-		maxConc = 1
-	}
-	sem := make(chan struct{}, maxConc)
-
-	var (
-		cursor      *string
-		totalLogged bool
-	)
-
-	for {
+	for !foundMergeBase {
+		var hist struct {
+			Repository struct {
+				Object *struct {
+					History struct {
+						PageInfo struct {
+							HasNextPage bool   `json:"hasNextPage"`
+							EndCursor   string `json:"endCursor"`
+						} `json:"pageInfo"`
+						Nodes []histNode `json:"nodes"`
+					} `json:"history"`
+				} `json:"object"`
+			} `json:"repository"`
+		}
 		vars := map[string]interface{}{
-			"owner":    owner,
-			"name":     repo,
-			"number":   pullRequestID,
-			"pageSize": pageSize,
-			"cursor":   nil,
+			"owner": owner, "name": repo, "head": headOID,
+			"first": pageSize, "after": nil,
 		}
-		if cursor != nil {
-			vars["cursor"] = *cursor
+		if after != nil {
+			vars["after"] = *after
 		}
 
-		var page prCommitsPage
-		if _, err := doGraphQL(ctx, client, query, vars, &page); err != nil {
-			log.WithFields(f).WithError(err).Warnf("problem listing commits via GraphQL for %s/%s PR #%d", owner, repo, pullRequestID)
+		if err := doGraphQL(ctx, client, qHist, vars, &hist); err != nil || hist.Repository.Object == nil {
+			log.WithFields(f).WithError(err).Error("failed to fetch commit history via GraphQL")
 			return GetPullRequestCommitAuthorsREST(ctx, usersService, installationID, pullRequestID, owner, repo, withCoAuthors)
 		}
 
-		c := page.Repository.PullRequest.Commits
-		if !totalLogged {
-			log.WithFields(f).Debugf("found %d commits (totalCount) for pull request: %d", c.TotalCount, pullRequestID)
-			totalLogged = true
-			userCommitSummary = make([]*UserCommitSummary, 0, c.TotalCount)
+		for _, n := range hist.Repository.Object.History.Nodes {
+			if n.OID == mergeBaseSHA {
+				foundMergeBase = true
+				break
+			}
+			enqueue(n.OID, n.Message, n.Author.Name, n.Author.Email, n.Author.User)
 		}
 
-		// Launch per-commit workers for this page
-		for _, node := range c.Nodes {
-			n := node // capture
-			wg.Add(1)
-			sem <- struct{}{} // acquire slot
-			go func() {
-				defer wg.Done()
-				defer func() { <-sem }() // release slot
-
-				sha := n.Commit.OID
-				msg := n.Commit.Message
-				a := n.Commit.Author
-				u := a.User
-
-				// Legacy precedence: user.* preferred, else commit author fields
-				var (
-					id64  *int64
-					login *string
-					name  *string
-					email *string
-				)
-				if u.DatabaseID != 0 {
-					tmp := int64(u.DatabaseID)
-					id64 = &tmp
-				}
-				if u.Login != "" {
-					tmp := u.Login
-					login = &tmp
-				}
-				if u.Name != "" {
-					tmp := u.Name
-					name = &tmp
-				} else if a.Name != "" {
-					tmp := a.Name
-					name = &tmp
-				}
-				if u.Email != "" {
-					tmp := u.Email
-					email = &tmp
-				} else if a.Email != "" {
-					tmp := a.Email
-					email = &tmp
-				}
-
-				// Minimal go-github objects to keep ExpandWithCoAuthors working
-				ghUser := &github.User{
-					ID:    id64,
-					Login: login,
-					Name:  name,
-					Email: email,
-				}
-				rc := &github.RepositoryCommit{
-					SHA: &sha,
-					Commit: &github.Commit{
-						Message: github.String(msg),
-						Author: &github.CommitAuthor{
-							Name:  github.String(a.Name),
-							Email: github.String(a.Email),
-						},
-					},
-					Author: ghUser,
-				}
-
-				// Append main author summary
-				mu.Lock()
-				userCommitSummary = append(userCommitSummary, &UserCommitSummary{
-					SHA:          sha,
-					CommitAuthor: ghUser,
-					Affiliated:   false,
-					Authorized:   false,
-				})
-				mu.Unlock()
-
-				if withCoAuthors {
-					if ExpandWithCoAuthors(ctx, client, usersService, rc, pullRequestID, installationID, &userCommitSummary, &mu) {
-						anyMissing.Store(true)
-					}
-				}
-			}()
-		}
-
-		if !c.PageInfo.HasNextPage {
+		if foundMergeBase {
 			break
 		}
-		cur := c.PageInfo.EndCursor
-		cursor = &cur
+		if !hist.Repository.Object.History.PageInfo.HasNextPage {
+			return GetPullRequestCommitAuthorsREST(ctx, usersService, installationID, pullRequestID, owner, repo, withCoAuthors)
+		}
+		cur := hist.Repository.Object.History.PageInfo.EndCursor
+		after = &cur
+
+		safetyPages++
+		if safetyPages > 2000 {
+			return GetPullRequestCommitAuthorsREST(ctx, usersService, installationID, pullRequestID, owner, repo, withCoAuthors)
+		}
 	}
 
-	// Wait for all workers to finish
+	// wait workers
 	wg.Wait()
 
-	log.WithFields(f).Debugf("total commit author summaries (including co-authors) for PR %d: %d, any missing: %v", pullRequestID, len(userCommitSummary), anyMissing.Load())
+	// ---- Stats log identical to Python version ----
+	// Build distinct sets
+	distinctSHAs := make(map[string]struct{})
+	distinctIDs := make(map[int64]struct{})
+	distinctLogins := make(map[string]struct{})
+	distinctEmails := make(map[string]struct{})
+	distinctNames := make(map[string]struct{})
+
+	for _, s := range userCommitSummary {
+		if s == nil {
+			continue
+		}
+		if s.SHA != "" {
+			distinctSHAs[s.SHA] = struct{}{}
+		}
+		if s.CommitAuthor != nil {
+			if s.CommitAuthor.ID != nil {
+				distinctIDs[*s.CommitAuthor.ID] = struct{}{}
+			}
+			if s.CommitAuthor.Login != nil && *s.CommitAuthor.Login != "" {
+				distinctLogins[*s.CommitAuthor.Login] = struct{}{}
+			}
+			if s.CommitAuthor.Email != nil && *s.CommitAuthor.Email != "" {
+				distinctEmails[*s.CommitAuthor.Email] = struct{}{}
+			}
+			if s.CommitAuthor.Name != nil && *s.CommitAuthor.Name != "" {
+				distinctNames[*s.CommitAuthor.Name] = struct{}{}
+			}
+		}
+	}
+
+	log.WithFields(f).Debugf(
+		"%s - PR: %d, total commit authors summaries found: %d, any missing: %v, distinct SHAs: %d, distinct author IDs: %d, logins: %d, emails: %d, names: %d",
+		fn, pullRequestID, len(userCommitSummary), anyMissing.Load(),
+		len(distinctSHAs), len(distinctIDs), len(distinctLogins), len(distinctEmails), len(distinctNames),
+	)
+
 	return userCommitSummary, anyMissing.Load(), nil
 }
 
@@ -1519,17 +1656,17 @@ func EditIssueCommentIfChanged(ctx context.Context, client *github.Client, owner
 	return true, nil
 }
 
-// Head SHA for a PR (authoritative "last commit")
-func GetPRHeadSHA(ctx context.Context, gh *github.Client, owner, repo string, prNumber int) (string, error) {
+// Commit SHA for a PR (authoritative "last commit")
+func GetPRCommitSHA(ctx context.Context, gh *github.Client, owner, repo string, prNumber int) (string, error) {
 	pr, _, err := gh.PullRequests.Get(ctx, owner, repo, prNumber)
 	if err != nil {
 		f := logrus.Fields{
-			"functionName":  "github.github_repository.GetPRHeadSHA",
+			"functionName":  "github.github_repository.GetPRCommitSHA",
 			"owner":         owner,
 			"repo":          repo,
 			"pullRequestID": prNumber,
 		}
-		log.WithFields(f).WithError(err).Warn("cannot get PR head SHA using PullRequests.Get, trying PullRequests.ListCommits")
+		log.WithFields(f).WithError(err).Warn("cannot get PR commit SHA using PullRequests.Get, trying PullRequests.ListCommits")
 		opts := &github.ListOptions{PerPage: 1}
 		commits, resp, comErr := gh.PullRequests.ListCommits(ctx, owner, repo, prNumber, opts)
 		if comErr != nil {
@@ -1545,16 +1682,16 @@ func GetPRHeadSHA(ctx context.Context, gh *github.Client, owner, repo string, pr
 			}
 		}
 		if len(commits) == 0 || commits[0].SHA == nil {
-			return "", fmt.Errorf("missing head SHA for %s/%s PR #%d (via ListCommits)", owner, repo, prNumber)
+			return "", fmt.Errorf("missing commit SHA for %s/%s PR #%d (via ListCommits)", owner, repo, prNumber)
 		}
 		return *commits[0].SHA, nil
 	}
 	sha := ""
-	if pr.Head != nil && pr.Head.SHA != nil {
+	if pr != nil && pr.Head != nil && pr.Head.SHA != nil {
 		sha = *pr.Head.SHA
 	}
 	if sha == "" {
-		return "", fmt.Errorf("missing head SHA for %s/%s PR #%d", owner, repo, prNumber)
+		return "", fmt.Errorf("missing commit SHA for %s/%s PR #%d", owner, repo, prNumber)
 	}
 	return sha, nil
 }
@@ -1677,16 +1814,18 @@ func UpdatePullRequest(ctx context.Context, installationID int64, pullRequestID 
 
 	log.WithFields(f).Debugf("Creating status: %+v", status)
 
-	headSHA, err := GetPRHeadSHA(ctx, client, owner, repo, pullRequestID)
+	commitSHA, err := GetPRCommitSHA(ctx, client, owner, repo, pullRequestID)
+	log.WithFields(f).Debugf("Got commit SHA for %s/%s PR %d: %s", owner, repo, pullRequestID, commitSHA)
 	if err != nil {
 		return err
 	}
 
-	_, _, err = CreateStatus(ctx, client, owner, repo, headSHA, &status)
+	_, _, err = CreateStatus(ctx, client, owner, repo, commitSHA, &status)
 	if err != nil {
-		log.WithFields(f).WithError(err).Debugf("unable to create status on %s", headSHA)
+		log.WithFields(f).WithError(err).Debugf("unable to create status on %s", commitSHA)
 		return err
 	}
+	log.WithFields(f).Debugf("Created '%s' status commit SHA for %s/%s PR %d: %s", *status.State, owner, repo, pullRequestID, commitSHA)
 
 	return nil
 }
@@ -1840,12 +1979,92 @@ func assembleCLAComment(ctx context.Context, installationID, pullRequestID int, 
 		}
 	}
 
-	log.WithFields(f).Debug("Building CLAComment body ")
+	log.WithFields(f).Debug("Building CLAComment body.")
 	signURL := getFullSignURL(repositoryType, strconv.Itoa(installationID), strconv.Itoa(int(*repositoryID)), strconv.Itoa(pullRequestID), apiBaseURL)
 	commentBody := getCommentBody(repositoryType, signURL, signed, missing, anyMissing)
 	allSigned := len(missing) == 0
 	badge := getCommentBadge(allSigned, signURL, missingID, false, CLALandingPage, CLALogoURL)
-	return fmt.Sprintf("%s<br >%s", badge, commentBody)
+	body := fmt.Sprintf("%s<br >%s", badge, commentBody)
+	if len(body) > MaxCommentLength {
+		body = TrimComment(body, 40, 20, 20, "…")
+		log.WithFields(f).Debugf("comment trimmed to (%d): %s", len(body), body)
+	}
+	return body
+}
+
+// TrimComment collapses any "(sha1, sha2, ...)" group where all tokens look like SHAs (7–40 hex).
+// If a group has > maxItems, it keeps the first `head`, then an ellipsis, then the last `tail`.
+func TrimComment(html string, maxItems, head, tail int, ellipsis string) string {
+	if head+tail > maxItems {
+		if maxItems > head {
+			tail = maxItems - head
+		} else {
+			tail = 0
+		}
+	}
+	// Match any parenthesized group without nested parens.
+	re := regexp.MustCompile(`\(([^()]*)\)`)
+	return re.ReplaceAllStringFunc(html, func(group string) string {
+		// Strip the surrounding parentheses.
+		inner := group[1 : len(group)-1]
+		parts := splitAndTrimByComma(inner)
+		if len(parts) == 0 {
+			return group
+		}
+		// Ensure every token looks like a SHA.
+		for _, p := range parts {
+			if !isSHA(p) {
+				return group
+			}
+		}
+		// Collapse if too many.
+		if len(parts) > maxItems {
+			var out []string
+			if head > 0 && head < len(parts) {
+				out = append(out, parts[:head]...)
+			}
+			out = append(out, ellipsis)
+			if tail > 0 && tail < len(parts) {
+				out = append(out, parts[len(parts)-tail:]...)
+			}
+			return "(" + strings.Join(out, ", ") + ")"
+		}
+		return group
+	})
+}
+
+func splitAndTrimByComma(s string) []string {
+	if s == "" {
+		return nil
+	}
+	raw := strings.Split(s, ",")
+	out := make([]string, 0, len(raw))
+	for _, r := range raw {
+		t := strings.TrimSpace(r)
+		if t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+func isSHA(s string) bool {
+	// 7..40 hex chars
+	if n := len(s); n < 7 || n > 40 {
+		return false
+	}
+	for _, r := range s {
+		if !isHex(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func isHex(r rune) bool {
+	return (r >= '0' && r <= '9') ||
+		(r >= 'a' && r <= 'f') ||
+		(r >= 'A' && r <= 'F')
 }
 
 // getCommentBody mirrors the Python get_comment_body behavior.

--- a/cla-backend/cla/models/github_models.py
+++ b/cla-backend/cla/models/github_models.py
@@ -2173,77 +2173,118 @@ def pygithub_graphql(g, query: str, variables: dict | None = None):
         return None
 
 def iter_pr_commits_full(g, owner: str, repo_name: str, number: int, page_size: int = 100):
+    """
+    Yield every commit in a PR (base..head) using GraphQL in ~ceil(N/100) requests.
+    Strategy:
+      1) Get head/base OIDs.
+      2) Fetch & yield HEAD (history doesn't include the starting commit).
+      3) Page through Commit.history(first=page_size, after=cursor) from HEAD until we hit the merge-base SHA.
+    """
     page_size = max(1, min(100, page_size))
-    query = """
-    query($owner:String!, $name:String!, $number:Int!, $pageSize:Int!, $cursor:String) {
+
+    # 1) base/head OIDs
+    q_info = """
+    query($owner:String!, $name:String!, $number:Int!) {
       repository(owner:$owner, name:$name) {
-        pullRequest(number:$number) {
-          commits(first:$pageSize, after:$cursor) {
-            pageInfo { hasNextPage endCursor }
-            nodes {
-              commit {
+        pullRequest(number:$number) { baseRefOid headRefOid }
+      }
+    }"""
+    info = pygithub_graphql(g, q_info, {"owner": owner, "name": repo_name, "number": number})
+    if info is None:
+        cla.log.error(f"Failed to fetch base and head OIDs for commits for {owner}/{repo_name} PR #{number}")
+        raise ValueError("failed to fetch base and head OIDs for commits using GraphQL")
+    pr = info["repository"]["pullRequest"]
+    base_oid, head_oid = pr["baseRefOid"], pr["headRefOid"]
+
+    # 2) merge-base via REST (fast and reliable)
+    repo = g.get_repo(f"{owner}/{repo_name}")
+    mb_sha = repo.compare(base_oid, head_oid).merge_base_commit.sha
+
+    # Fetch & yield HEAD commit, because history won't include the starting commit itself
+    q_head = """
+    query($owner:String!, $name:String!, $oid:GitObjectID!) {
+      repository(owner:$owner, name:$name) {
+        object(oid:$oid) {
+          ... on Commit {
+            oid
+            message
+            author { name email user { databaseId login name email } }
+          }
+        }
+      }
+    }"""
+    head = pygithub_graphql(g, q_head, {"owner": owner, "name": repo_name, "oid": head_oid})["repository"]["object"]
+    if head is None:
+        cla.log.error(f"Failed to fetch head commit for {owner}/{repo_name} PR #{number}")
+        raise ValueError("failed to fetch head commit using GraphQL")
+    if head["oid"] != mb_sha:
+        a = head.get("author") or {}; u = a.get("user") or {}
+        yield CommitLite(
+            sha=head["oid"],
+            author_id=u.get("databaseId"),
+            author_login=u.get("login"),
+            author_name=(u.get("name") or a.get("name") or None),
+            author_email=(u.get("email") or a.get("email") or None),
+            message=head.get("message"),
+        )
+
+    # 3) Page through the history from HEAD; stop when we encounter merge-base
+    q_hist = """
+    query($owner:String!, $name:String!, $head:GitObjectID!, $first:Int!, $after:String) {
+      repository(owner:$owner, name:$name) {
+        object(oid:$head) {
+          ... on Commit {
+            history(first:$first, after:$after) {
+              pageInfo { hasNextPage endCursor }
+              nodes {
                 oid
                 message
-                author {
-                  name       # commit metadata author name
-                  email      # commit metadata author email
-                  user {
-                    databaseId   # numeric id (REST-compatible)
-                    login
-                    name         # profile name (preferred)
-                    email        # profile email (often null without extra scopes)
-                  }
-                }
+                author { name email user { databaseId login name email } }
               }
             }
           }
         }
       }
     }"""
-    cursor = None
+
+    after = None
+    safety_pages = 0
     while True:
-        res = pygithub_graphql(
-            g,
-            query,
-            {"owner": owner, "name": repo_name, "number": number,
-             "pageSize": page_size, "cursor": cursor},
+        d = pygithub_graphql(
+            g, q_hist,
+            {"owner": owner, "name": repo_name, "head": head_oid, "first": page_size, "after": after},
         )
-        if res is None:
-            cla.log.error(f"Failed to fetch commits for {owner}/{repo_name} PR #{number}")
-            raise ValueError("failed to fetch commits using GraphQL")
-        commits = res["repository"]["pullRequest"]["commits"]
-        for n in commits["nodes"]:
-            c = n["commit"]
-            a = c.get("author") or {}
-            u = a.get("user") or {}
+        if d is None:
+            cla.log.error(f"Failed to history commits for {owner}/{repo_name} PR #{number}")
+            raise ValueError("failed to fetch history commits using GraphQL")
+        hist = d["repository"]["object"]["history"]
+        nodes = hist["nodes"]
 
-            # id     := commit.author.id
-            # login  := commit.author.login
-            # name   := commit.author.name or commit.commit.author.name
-            # email  := commit.author.email or commit.commit.author.email
-            author_id    = u.get("databaseId")
-            author_login = u.get("login")
-
-            user_name    = (u.get("name") or "").strip() if isinstance(u.get("name"), str) else None
-            commit_name  = (a.get("name") or "").strip() if isinstance(a.get("name"), str) else None
-            author_name  = user_name or commit_name or None
-
-            user_email   = (u.get("email") or "").strip() if isinstance(u.get("email"), str) else None
-            commit_email = (a.get("email") or "").strip() if isinstance(a.get("email"), str) else None
-            author_email = user_email or commit_email or None
-
+        # stream until we hit merge-base
+        for n in nodes:
+            if n["oid"] == mb_sha:
+                # Finished history
+                return
+            a = n.get("author") or {}; u = a.get("user") or {}
             yield CommitLite(
-                sha=c["oid"],
-                author_id=author_id,
-                author_login=author_login,
-                author_name=author_name,
-                author_email=author_email,
-                message=c.get("message"),
+                sha=n["oid"],
+                author_id=u.get("databaseId"),
+                author_login=u.get("login"),
+                author_name=(u.get("name") or a.get("name") or None),
+                author_email=(u.get("email") or a.get("email") or None),
+                message=n.get("message"),
             )
 
-        if not commits["pageInfo"]["hasNextPage"]:
-            break
-        cursor = commits["pageInfo"]["endCursor"]
+        if not hist["pageInfo"]["hasNextPage"]:
+            # merge-base not found — extremely rare (rebases or unusual ancestry).
+            # Fall back to non-GQL old approach (limited to 250 commits but still better that error)
+            raise ValueError("merge-base commit not found in PR commit history")
+
+        after = hist["pageInfo"]["endCursor"]
+        safety_pages += 1
+        if safety_pages > 2000:  # defensive hard stop
+            raise ValueError("Too many pages while scanning history; aborting.")
+
 
 def get_author_summary_gql(commit: CommitLite, pr: int, installation_id, with_co_authors) -> Tuple[List[UserCommitSummary], bool]:
     fn = "cla.models.github_models.get_author_summary_gql"
@@ -2397,6 +2438,16 @@ def get_pull_request_commit_authors(client, org, pull_request, installation_id, 
             cla.log.warning(f"{fn} - PR: {pr_number}, REST processing failed: {exc}")
             raise
 
+    cla.log.debug(
+        f"{fn} - PR: {pr_number}, "
+        f"total commit authors summaries found: {len(commit_authors)}, "
+        f"any missing: {any_missing}, "
+        f"distinct SHAs: {len({a.commit_sha for a in commit_authors})}, "
+        f"distinct author IDs: {len({a.author_id for a in commit_authors if a.author_id})}, "
+        f"logins: {len({a.author_login for a in commit_authors if a.author_login})}, "
+        f"emails: {len({a.author_email for a in commit_authors if a.author_email})}, "
+        f"names: {len({a.author_name for a in commit_authors if a.author_name})}"
+    )
     return (commit_authors, any_missing)
 
 def is_valid_github_username(username: str) -> bool:
@@ -2644,12 +2695,10 @@ def update_pull_request(
     cla.log.debug(f"{fn} - Updating PR {pull_request.number} with notification={notification}, both={both}")
     try:
         last_commit_sha = getattr(getattr(pull_request, "head", None), "sha", None)
-        repo = getattr(getattr(pull_request, "head", None), "repo", None)
-        if repo is None:
-            repo = getattr(getattr(pull_request, "base", None), "repo", None)
+        repo = getattr(getattr(pull_request, "base", None), "repo", None)
         commit_obj = repo.get_commit(last_commit_sha)
     except (GithubException, AttributeError, TypeError) as exc:
-        cla.log.error(f"{fn} - PR {pull_request.number}: exception getting head.sha: {exc}")
+        cla.log.error(f"{fn} - PR {pull_request.number}: exception getting commit sha: {exc}")
         try:
             commit_obj = pull_request.get_commits().reversed[0]
             last_commit_sha = commit_obj.sha

--- a/cla-backend/cla/utils.py
+++ b/cla-backend/cla/utils.py
@@ -1053,8 +1053,35 @@ def assemble_cla_comment(
         project_version=project_version,
         missing_user_id=no_user_id,
     )
-    return badge + "<br />" + comment
+    body = badge + "<br />" + comment
+    if len(body.encode('utf-8')) > 0xFF00:
+        body = trim_comment(body, max_items=40, head=20, tail=20, ellipsis="…")
+    return body
 
+def trim_comment(html: str, max_items: int = 40, head: int = 20, tail: int = 20, ellipsis: str = "…") -> str:
+    """
+    In every (...) group, if the comma-separated tokens all look like SHAs and
+    there are more than `max_items`, keep first `head`, then `ellipsis`, then last `tail`.
+    """
+    # ensure head+tail <= max_items
+    tail = max(0, min(tail, max_items - head))
+
+    sha_token = re.compile(r'^[0-9a-fA-F]{7,40}$')
+
+    def repl(m: re.Match) -> str:
+        inner = m.group(1)
+        parts = [p.strip() for p in inner.split(',')]
+        if parts and all(sha_token.match(p) for p in parts) and len(parts) > max_items:
+            kept = parts[:head]
+            if tail > 0:
+                kept += [ellipsis] + parts[-tail:]
+            else:
+                kept += [ellipsis]
+            return '(' + ', '.join(kept) + ')'
+        return m.group(0)
+
+    # Replace ANY parenthesized group, but only modify if it's a SHA-only list
+    return re.sub(r'\(([^()]*)\)', repl, html, flags=re.S)
 
 def get_comment_body(repository_type, sign_url, signed: List[UserCommitSummary], missing: List[UserCommitSummary], any_missing: bool):
     """


### PR DESCRIPTION
- Handle commend body too big (> 64K characters - can happen if PR has a lot of commits) in both `python` and `golang` backends.
- Handle PRs from forks with > 250 commits with graceful fallack to REST (both `python` and `golang` backends).
- Correctly locate PR head SHA using quick API call and fallback to getting last PR's commit SHA (also both backends).
- Log number of distinct commit SHAs, authors (ids, logins, emails, names) in both backends so we can see how many commit summaries were there and how many actual commits (one commit can have > 1 authors) - both backends.
- Handle private repos and forks correctly in both backends with fallbacks on errors.


cc @mlehotskylf @ahmedomosanya @jarias-lfx - this is for https://github.com/linuxfoundation/easycla/issues/4835.

Signed-off-by: Lukasz Gryglicki <lgryglicki@cncf.io>

Assisted by [OpenAI](https://platform.openai.com/)

Assisted by [GitHub Copilot](https://github.com/features/copilot)