### PR TITLE
Unicron cla stats from logs prod

### DIFF
--- a/utils/calculate_api_stats.sh
+++ b/utils/calculate_api_stats.sh
@@ -13,7 +13,8 @@ then
   exit 1
 fi
 export DTFROM="${1}"
-REGION=us-east-1 NO_ECHO=1 DTTO='1 second ago' OUT="api-logs-${STAGE}-1.json" ./utils/search_aws_logs.sh 'LG:api-request-path'
-REGION=us-east-2 NO_ECHO=1 DTTO='1 second ago' OUT="api-logs-${STAGE}-2.json" ./utils/search_aws_logs.sh 'LG:api-request-path'
+INCL_LOGS='githubactivity,githubinstall,apiv1,apiv2,api-v3-lambda' REGION=us-east-1 NO_ECHO=1 DTTO='1 second ago' OUT="api-logs-${STAGE}-1.json" ./utils/search_aws_logs.sh 'LG:api-request-path'
+INCL_LOGS='api-v4-lambda' REGION=us-east-2 NO_ECHO=1 DTTO='1 second ago' OUT="api-logs-${STAGE}-2.json" ./utils/search_aws_logs.sh 'LG:api-request-path'
 jq -s 'add' "api-logs-${STAGE}-1.json" "api-logs-${STAGE}-2.json" > "api-logs-${STAGE}.json" && rm -f "api-logs-${STAGE}-1.json" "api-logs-${STAGE}-2.json"
 ./utils/count_apis.sh "api-logs-${STAGE}.json" > "api-logs-${STAGE}.log" && cat "api-logs-${STAGE}.log"
+cat "api-logs-${STAGE}.json" | grep '"logGroupName": "' | sort | uniq

--- a/utils/find_1st_log_entry.sh
+++ b/utils/find_1st_log_entry.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+if [ -z "${STAGE}" ]
+then
+  export STAGE=dev
+fi
+# Array of log group configurations: "region log_group_name"
+log_groups=(
+  "us-east-1 /aws/lambda/cla-backend-${STAGE}-api-v3-lambda"
+  "us-east-1 /aws/lambda/cla-backend-${STAGE}-apiv1"
+  "us-east-1 /aws/lambda/cla-backend-${STAGE}-apiv2"
+  "us-east-1 /aws/lambda/cla-backend-${STAGE}-githubactivity"
+  "us-east-1 /aws/lambda/cla-backend-${STAGE}-githubinstall"
+  "us-east-2 /aws/lambda/cla-backend-go-api-v4-lambda"
+)
+
+for entry in "${log_groups[@]}"; do
+  region=$(echo "$entry" | awk '{print $1}')
+  log_group=$(echo "$entry" | cut -d' ' -f2-)
+  aws --region "$region" --profile "lfproduct-${STAGE}" logs filter-log-events \
+    --log-group-name "$log_group" \
+    --start-time 0 --limit 1 --filter-pattern "\"LG:api-request-path\"" \
+    | jq -r '.events.[0].timestamp' \
+    | awk '{print strftime("%Y-%m-%d %H:%M:%S", $1/1000)}'
+done


### PR DESCRIPTION
Update logs grepping scripts and add a script to find the first API log entry in AWS logs

`prod` version of https://github.com/linuxfoundation/easycla/pull/4880

cc @mlehotskylf @ahmedomosanya 

Signed-off-by: Lukasz Gryglicki <lgryglicki@cncf.io>

Assisted by [OpenAI](https://platform.openai.com/)

Assisted by [GitHub Copilot](https://github.com/features/copilot)