### PR TITLE
ci: declare contents:read on license + yarn-audit workflows

### DIFF
--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -12,6 +12,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   license-header-check:
     name: License Header Check

--- a/.github/workflows/yarn-scan-backend-go-pr.yml
+++ b/.github/workflows/yarn-scan-backend-go-pr.yml
@@ -15,6 +15,9 @@ on:
       - ".yarn-audit-allowlist.json"
       - ".github/workflows/yarn-scan-backend-go-pr.yml"
 
+permissions:
+  contents: read
+
 jobs:
   yarn-scan-backend-go-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/yarn-scan-backend-pr.yml
+++ b/.github/workflows/yarn-scan-backend-pr.yml
@@ -15,6 +15,9 @@ on:
       - ".yarn-audit-allowlist.json"
       - ".github/workflows/yarn-scan-backend-pr.yml"
 
+permissions:
+  contents: read
+
 jobs:
   yarn-scan-backend-pr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins three workflows to `contents: read` at workflow scope. `license-header-check.yml` runs `./check-headers.sh` against the cla-backend, cla-backend-legacy, cla-backend-go and cla-frontend trees. The two yarn-scan workflows run `yarn install` + `yarn audit` on `cla-backend-go` and `cla-backend` respectively. None of them write to the repo or post comments.

Defense-in-depth motivation is the [CVE-2025-30066](https://github.com/advisories/GHSA-mrrh-fwg8-r2c3) `tj-actions/changed-files` precedent: a compromised third-party action runs inside the existing job context and exfiltrates the workflow `GITHUB_TOKEN` via build logs. The blast radius equals the token's issued scope; the explicit cap bounds it.

Style matches the per-job blocks already in `build-pr.yml`, `go-audit.yml`, `license-compliance-go.yml`, `security-scan-go.yml`, and the rest of the hardened set. YAML validated locally with `yaml.safe_load`.