### PR TITLE
fix: validate github return url metadata

### DIFF
--- a/cla-backend-go/github/github_repository.go
+++ b/cla-backend-go/github/github_repository.go
@@ -2597,24 +2597,65 @@ func GetReturnURL(ctx context.Context, installationID, repositoryID int64, pullR
 		"pullRequestID":  pullRequestID,
 	}
 
-	client, err := NewGithubAppClient(installationID)
+	if installationID <= 0 {
+		err := errors.New("invalid installation ID")
+		log.WithFields(f).WithError(err).Warn("invalid installation ID")
+		return "", err
+	}
+	if repositoryID <= 0 {
+		err := errors.New("invalid repository ID")
+		log.WithFields(f).WithError(err).Warn("invalid repository ID")
+		return "", err
+	}
+	if pullRequestID <= 0 {
+		err := errors.New("invalid pull request ID")
+		log.WithFields(f).WithError(err).Warn("invalid pull request ID")
+		return "", err
+	}
 
+	client, err := NewGithubAppClient(installationID)
 	if err != nil {
 		log.WithFields(f).WithError(err).Warn("unable to create Github client")
 		return "", err
 	}
 
 	log.WithFields(f).Debugf("getting github repository by id: %d", repositoryID)
-	repo, _, err := client.Repositories.GetByID(ctx, repositoryID)
+	repo, resp, err := client.Repositories.GetByID(ctx, repositoryID)
 	if err != nil {
+		if ok, wrapped := CheckAndWrapForKnownErrors(resp, err); ok {
+			log.WithFields(f).WithError(wrapped).Warnf("unable to get repository by ID: %d", repositoryID)
+			return "", wrapped
+		}
 		log.WithFields(f).WithError(err).Warnf("unable to get repository by ID: %d", repositoryID)
+		return "", err
+	}
+	if repo == nil || repo.Owner == nil || repo.Owner.Login == nil || repo.Name == nil {
+		err := fmt.Errorf("missing repository owner or name for repository ID %d", repositoryID)
+		log.WithFields(f).WithError(err).Warn("invalid repository metadata")
+		return "", err
+	}
+
+	owner := repo.GetOwner().GetLogin()
+	name := repo.GetName()
+	if owner == "" || name == "" {
+		err := fmt.Errorf("invalid repository owner/name for repository ID %d", repositoryID)
+		log.WithFields(f).WithError(err).Warn("invalid repository metadata")
 		return "", err
 	}
 
 	log.WithFields(f).Debugf("getting pull request by id: %d", pullRequestID)
-	pullRequest, _, err := client.PullRequests.Get(ctx, *repo.Owner.Login, *repo.Name, pullRequestID)
+	pullRequest, resp, err := client.PullRequests.Get(ctx, owner, name, pullRequestID)
 	if err != nil {
+		if ok, wrapped := CheckAndWrapForKnownErrors(resp, err); ok {
+			log.WithFields(f).WithError(wrapped).Warnf("unable to get pull request by ID: %d", pullRequestID)
+			return "", wrapped
+		}
 		log.WithFields(f).WithError(err).Warnf("unable to get pull request by ID: %d", pullRequestID)
+		return "", err
+	}
+	if pullRequest == nil || pullRequest.HTMLURL == nil || *pullRequest.HTMLURL == "" {
+		err := fmt.Errorf("missing html url for pull request %d/%s/%s", pullRequestID, owner, name)
+		log.WithFields(f).WithError(err).Warn("invalid pull request metadata")
 		return "", err
 	}
 

--- a/cla-backend-go/github/github_repository.go
+++ b/cla-backend-go/github/github_repository.go
@@ -2629,8 +2629,8 @@ func GetReturnURL(ctx context.Context, installationID, repositoryID int64, pullR
 		log.WithFields(f).WithError(err).Warnf("unable to get repository by ID: %d", repositoryID)
 		return "", err
 	}
-	if repo == nil || repo.Owner == nil || repo.Owner.Login == nil || repo.Name == nil {
-		err := fmt.Errorf("missing repository owner or name for repository ID %d", repositoryID)
+	if repo == nil {
+		err := fmt.Errorf("missing repository for repository ID %d", repositoryID)
 		log.WithFields(f).WithError(err).Warn("invalid repository metadata")
 		return "", err
 	}
@@ -2653,13 +2653,20 @@ func GetReturnURL(ctx context.Context, installationID, repositoryID int64, pullR
 		log.WithFields(f).WithError(err).Warnf("unable to get pull request by ID: %d", pullRequestID)
 		return "", err
 	}
-	if pullRequest == nil || pullRequest.HTMLURL == nil || *pullRequest.HTMLURL == "" {
+	if pullRequest == nil {
+		err := fmt.Errorf("missing pull request %d/%s/%s", pullRequestID, owner, name)
+		log.WithFields(f).WithError(err).Warn("invalid pull request metadata")
+		return "", err
+	}
+
+	htmlURL := pullRequest.GetHTMLURL()
+	if htmlURL == "" {
 		err := fmt.Errorf("missing html url for pull request %d/%s/%s", pullRequestID, owner, name)
 		log.WithFields(f).WithError(err).Warn("invalid pull request metadata")
 		return "", err
 	}
 
-	log.WithFields(f).Debugf("returning pull request html url: %s", *pullRequest.HTMLURL)
+	log.WithFields(f).Debugf("returning pull request html url: %s", htmlURL)
 
-	return *pullRequest.HTMLURL, nil
+	return htmlURL, nil
 }

--- a/cla-backend-go/v2/sign/service.go
+++ b/cla-backend-go/v2/sign/service.go
@@ -1572,6 +1572,7 @@ func (s *service) getIndividualSignatureCallbackURLGitlab(ctx context.Context, u
 	if found, ok := metadata["repository_id"].(string); ok {
 		repositoryID = found
 	} else {
+		err = errors.New("missing repository_id in metadata")
 		log.WithFields(f).WithError(err).Warnf("unable to get repository ID for user: %s", userID)
 		return "", err
 	}
@@ -1579,6 +1580,7 @@ func (s *service) getIndividualSignatureCallbackURLGitlab(ctx context.Context, u
 	if found, ok := metadata["merge_request_id"].(string); ok {
 		mergeRequestID = found
 	} else {
+		err = errors.New("missing merge_request_id in metadata")
 		log.WithFields(f).WithError(err).Warnf("unable to get merge request ID for user: %s", userID)
 		return "", err
 	}
@@ -1599,6 +1601,7 @@ func (s *service) getIndividualSignatureCallbackURLGitlab(ctx context.Context, u
 	}
 
 	if gitlabOrg.OrganizationID == "" {
+		err = errors.New("missing organization ID for GitLab repository")
 		log.WithFields(f).WithError(err).Warnf("unable to get organization ID for repository ID: %s", repositoryID)
 		return "", err
 	}
@@ -1631,6 +1634,7 @@ func (s *service) getIndividualSignatureCallbackURL(ctx context.Context, userID 
 	if found, ok := metadata["repository_id"].(string); ok {
 		repositoryID = found
 	} else {
+		err = errors.New("missing repository_id in metadata")
 		log.WithFields(f).WithError(err).Warnf("unable to get repository ID for user: %s", userID)
 		return "", err
 	}
@@ -1640,6 +1644,7 @@ func (s *service) getIndividualSignatureCallbackURL(ctx context.Context, userID 
 	if found, ok := metadata["pull_request_id"].(string); ok {
 		pullRequestID = found
 	} else {
+		err = errors.New("missing pull_request_id in metadata")
 		log.WithFields(f).WithError(err).Warnf("unable to get pull request ID for user: %s", userID)
 		return "", err
 	}

--- a/cla-backend-go/v2/sign/service.go
+++ b/cla-backend-go/v2/sign/service.go
@@ -1585,18 +1585,14 @@ func (s *service) getIndividualSignatureCallbackURLGitlab(ctx context.Context, u
 		}
 	}
 
-	if found, ok := metadata["repository_id"].(string); ok {
-		repositoryID = found
-	} else {
-		err = errors.New("missing repository_id in metadata")
+	repositoryID, err = metadataStringValue(metadata, "repository_id")
+	if err != nil {
 		log.WithFields(f).WithError(err).Warnf("unable to get repository ID for user: %s", userID)
 		return "", err
 	}
 
-	if found, ok := metadata["merge_request_id"].(string); ok {
-		mergeRequestID = found
-	} else {
-		err = errors.New("missing merge_request_id in metadata")
+	mergeRequestID, err = metadataStringValue(metadata, "merge_request_id")
+	if err != nil {
 		log.WithFields(f).WithError(err).Warnf("unable to get merge request ID for user: %s", userID)
 		return "", err
 	}
@@ -1647,20 +1643,16 @@ func (s *service) getIndividualSignatureCallbackURL(ctx context.Context, userID 
 		}
 	}
 
-	if found, ok := metadata["repository_id"].(string); ok {
-		repositoryID = found
-	} else {
-		err = errors.New("missing repository_id in metadata")
+	repositoryID, err = metadataStringValue(metadata, "repository_id")
+	if err != nil {
 		log.WithFields(f).WithError(err).Warnf("unable to get repository ID for user: %s", userID)
 		return "", err
 	}
 
 	log.WithFields(f).Debugf("found repository ID: %s", repositoryID)
 
-	if found, ok := metadata["pull_request_id"].(string); ok {
-		pullRequestID = found
-	} else {
-		err = errors.New("missing pull_request_id in metadata")
+	pullRequestID, err = metadataStringValue(metadata, "pull_request_id")
+	if err != nil {
 		log.WithFields(f).WithError(err).Warnf("unable to get pull request ID for user: %s", userID)
 		return "", err
 	}
@@ -1703,7 +1695,7 @@ func (s *service) getInstallationIDFromRepositoryID(ctx context.Context, reposit
 
 	installationId = githubOrg.OrganizationInstallationID
 	if installationId == 0 {
-		err = fmt.Errorf("missing installation ID for repository ID in metadata: %s", repositoryID)
+		err = fmt.Errorf("installation ID missing for repository ID: %s", repositoryID)
 		log.WithFields(f).WithError(err).Warnf("unable to get installation ID for repository ID: %s", repositoryID)
 		return 0, err
 	}

--- a/cla-backend-go/v2/sign/service.go
+++ b/cla-backend-go/v2/sign/service.go
@@ -1550,6 +1550,22 @@ func getUserName(user *v1Models.User) string {
 	return ""
 }
 
+// metadataStringValue extracts a string value from metadata and validates it.
+func metadataStringValue(metadata map[string]interface{}, key string) (string, error) {
+	if metadata == nil {
+		return "", fmt.Errorf("missing %s in metadata", key)
+	}
+	v, ok := metadata[key]
+	if !ok || v == nil {
+		return "", fmt.Errorf("missing %s in metadata", key)
+	}
+	s := strings.TrimSpace(fmt.Sprintf("%v", v))
+	if s == "" || s == "<nil>" {
+		return "", fmt.Errorf("missing %s in metadata", key)
+	}
+	return s, nil
+}
+
 func (s *service) getIndividualSignatureCallbackURLGitlab(ctx context.Context, userID string, metadata map[string]interface{}) (string, error) {
 	f := logrus.Fields{
 		"functionName": "sign.getIndividualSignatureCallbackURLGitlab",
@@ -1687,7 +1703,7 @@ func (s *service) getInstallationIDFromRepositoryID(ctx context.Context, reposit
 
 	installationId = githubOrg.OrganizationInstallationID
 	if installationId == 0 {
-		err = fmt.Errorf("installation ID missing for repository ID: %s", repositoryID)
+		err = fmt.Errorf("missing installation ID for repository ID in metadata: %s", repositoryID)
 		log.WithFields(f).WithError(err).Warnf("unable to get installation ID for repository ID: %s", repositoryID)
 		return 0, err
 	}


### PR DESCRIPTION
## Summary

Adds defensive validation for GitHub and GitLab return URL generation in the sign flow.

## Changes

* validate installation, repository, pull request, and merge request metadata
* validate GitHub repository metadata before PR lookup
* validate pull request HTML URL before returning redirect target
* improve error handling around callback URL generation
* prevent invalid or empty redirect URLs from propagating through callback flows

## Why

The sign/auth redirect flow could continue with incomplete or malformed metadata, potentially resulting in invalid or empty redirect URLs and blank browser pages after authentication flows.

This patch improves robustness and error visibility around redirect URL generation.

Fixes #5052
