### PR TITLE
Agents/sss integration review feedback

### DIFF
--- a/cla-backend-go/cmd/s3_upload/main.go
+++ b/cla-backend-go/cmd/s3_upload/main.go
@@ -57,7 +57,7 @@ func init() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	signService = sign.NewService("", "", companyRepo, nil, nil, nil, nil, configFile.DocuSignPrivateKey, nil, nil, nil, nil, githubOrgService, nil, "", "", nil, nil, nil, nil, nil, nil)
+	signService = sign.NewService("", "", companyRepo, nil, nil, nil, nil, configFile.DocuSignPrivateKey, nil, nil, nil, nil, githubOrgService, nil, "", "", nil, nil, nil, nil, nil, nil, configFile.SSS.Required)
 	// projectRepo = repository.NewRepository(awsSession, stage, nil, nil, nil)
 	utils.SetS3Storage(awsSession, configFile.SignatureFilesBucket)
 }

--- a/cla-backend-go/cmd/s3_upload/main.go
+++ b/cla-backend-go/cmd/s3_upload/main.go
@@ -57,7 +57,7 @@ func init() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	signService = sign.NewService("", "", companyRepo, nil, nil, nil, nil, configFile.DocuSignPrivateKey, nil, nil, nil, nil, githubOrgService, nil, "", "", nil, nil, nil, nil, nil)
+	signService = sign.NewService("", "", companyRepo, nil, nil, nil, nil, configFile.DocuSignPrivateKey, nil, nil, nil, nil, githubOrgService, nil, "", "", nil, nil, nil, nil, nil, nil)
 	// projectRepo = repository.NewRepository(awsSession, stage, nil, nil, nil)
 	utils.SetS3Storage(awsSession, configFile.SignatureFilesBucket)
 }

--- a/cla-backend-go/cmd/server.go
+++ b/cla-backend-go/cmd/server.go
@@ -448,7 +448,7 @@ func server(localMode bool) http.Handler {
 	v2GithubActivityService := v2GithubActivity.NewService(gitV1Repository, githubOrganizationsRepo, eventsService, autoEnableService, emailService)
 
 	v2ClaGroupService := cla_groups.NewService(v1ProjectService, templateService, v1ProjectClaGroupRepo, v1ClaManagerService, v1SignaturesService, metricsRepo, gerritService, v1RepositoriesService, eventsService)
-	v2SignService := sign.NewService(configFile.ClaAPIV4Base, configFile.ClaV1ApiURL, v1CompanyRepo, v1CLAGroupRepo, v1ProjectClaGroupRepo, v1CompanyService, v2ClaGroupService, configFile.DocuSignPrivateKey, usersService, v1SignaturesService, storeRepository, v1RepositoriesService, githubOrganizationsService, gitlabOrganizationsService, configFile.CLALandingPage, configFile.CLALogoURL, emailService, eventsService, gitlabActivityService, gitlabApp, gerritService)
+	v2SignService := sign.NewService(configFile.ClaAPIV4Base, configFile.ClaV1ApiURL, v1CompanyRepo, v1CLAGroupRepo, v1ProjectClaGroupRepo, v1CompanyService, v2ClaGroupService, configFile.DocuSignPrivateKey, usersService, v1SignaturesService, storeRepository, v1RepositoriesService, githubOrganizationsService, gitlabOrganizationsService, configFile.CLALandingPage, configFile.CLALogoURL, emailService, eventsService, gitlabActivityService, gitlabApp, gerritService, nil)
 
 	sessionStore, err := dynastore.New(dynastore.Path("/"), dynastore.HTTPOnly(), dynastore.TableName(configFile.SessionStoreTableName), dynastore.DynamoDB(dynamodb.New(awsSession)))
 	if err != nil {

--- a/cla-backend-go/cmd/server.go
+++ b/cla-backend-go/cmd/server.go
@@ -83,6 +83,7 @@ import (
 
 	"github.com/linuxfoundation/easycla/cla-backend-go/api_logs"
 	"github.com/linuxfoundation/easycla/cla-backend-go/signatures"
+	"github.com/linuxfoundation/easycla/cla-backend-go/sss"
 	"github.com/linuxfoundation/easycla/cla-backend-go/telemetry"
 	v2Signatures "github.com/linuxfoundation/easycla/cla-backend-go/v2/signatures"
 
@@ -448,7 +449,31 @@ func server(localMode bool) http.Handler {
 	v2GithubActivityService := v2GithubActivity.NewService(gitV1Repository, githubOrganizationsRepo, eventsService, autoEnableService, emailService)
 
 	v2ClaGroupService := cla_groups.NewService(v1ProjectService, templateService, v1ProjectClaGroupRepo, v1ClaManagerService, v1SignaturesService, metricsRepo, gerritService, v1RepositoriesService, eventsService)
-	v2SignService := sign.NewService(configFile.ClaAPIV4Base, configFile.ClaV1ApiURL, v1CompanyRepo, v1CLAGroupRepo, v1ProjectClaGroupRepo, v1CompanyService, v2ClaGroupService, configFile.DocuSignPrivateKey, usersService, v1SignaturesService, storeRepository, v1RepositoriesService, githubOrganizationsService, gitlabOrganizationsService, configFile.CLALandingPage, configFile.CLALogoURL, emailService, eventsService, gitlabActivityService, gitlabApp, gerritService, nil)
+
+	// Initialize SSS (Sanctions Screening Service) client if configured
+	var sssClient *sss.Client
+	if configFile.SSS.BaseURL != "" && configFile.SSS.Auth0Domain != "" && configFile.SSS.Auth0ClientID != "" && configFile.SSS.Auth0ClientSecret != "" && configFile.SSS.Auth0Audience != "" {
+		sssTimeout := time.Duration(configFile.SSS.RequestTimeoutSec) * time.Second
+		if sssTimeout <= 0 {
+			sssTimeout = 30 * time.Second // default timeout
+		}
+		sssConfig := sss.SSSConfig{
+			BaseURL:           configFile.SSS.BaseURL,
+			Auth0Domain:       configFile.SSS.Auth0Domain,
+			Auth0ClientID:     configFile.SSS.Auth0ClientID,
+			Auth0ClientSecret: configFile.SSS.Auth0ClientSecret,
+			Auth0Audience:     configFile.SSS.Auth0Audience,
+			Timeout:           sssTimeout,
+		}
+		var sssErr error
+		sssClient, sssErr = sss.NewClient(sssConfig)
+		if sssErr != nil {
+			log.WithFields(f).WithError(sssErr).Warnf("failed to initialize SSS client, screening will be unavailable: %v", sssErr)
+			sssClient = nil
+		}
+	}
+
+	v2SignService := sign.NewService(configFile.ClaAPIV4Base, configFile.ClaV1ApiURL, v1CompanyRepo, v1CLAGroupRepo, v1ProjectClaGroupRepo, v1CompanyService, v2ClaGroupService, configFile.DocuSignPrivateKey, usersService, v1SignaturesService, storeRepository, v1RepositoriesService, githubOrganizationsService, gitlabOrganizationsService, configFile.CLALandingPage, configFile.CLALogoURL, emailService, eventsService, gitlabActivityService, gitlabApp, gerritService, sssClient, configFile.SSS.Required)
 
 	sessionStore, err := dynastore.New(dynastore.Path("/"), dynastore.HTTPOnly(), dynastore.TableName(configFile.SessionStoreTableName), dynastore.DynamoDB(dynamodb.New(awsSession)))
 	if err != nil {

--- a/cla-backend-go/company/repository.go
+++ b/cla-backend-go/company/repository.go
@@ -53,6 +53,7 @@ type IRepository interface { //nolint
 	ApproveCompanyAccessRequest(ctx context.Context, companyInviteID string) error
 	RejectCompanyAccessRequest(ctx context.Context, companyInviteID string) error
 	UpdateCompanyAccessList(ctx context.Context, companyID string, companyACL []string) error
+	UpdateCompanySanctionStatus(ctx context.Context, companyID string, sanctioned bool) error
 	IsCCLAEnabledForCompany(ctx context.Context, companyID string) (bool, error)
 }
 
@@ -1276,7 +1277,67 @@ func (repo repository) UpdateCompanyAccessList(ctx context.Context, companyID st
 	return nil
 }
 
-// CreateCompany creates a new company record
+// UpdateCompanySanctionStatus updates the is_sanctioned flag for a company.
+// It only performs the update if the value has changed to avoid unnecessary DynamoDB writes.
+func (repo repository) UpdateCompanySanctionStatus(ctx context.Context, companyID string, sanctioned bool) error {
+	f := logrus.Fields{
+		"functionName":   "company.repository.UpdateCompanySanctionStatus",
+		utils.XREQUESTID: ctx.Value(utils.XREQUESTID),
+		"companyID":      companyID,
+		"sanctioned":     sanctioned,
+	}
+
+	// Fetch current company to check if value has changed
+	currentCompany, err := repo.GetCompany(ctx, companyID)
+	if err != nil {
+		log.WithFields(f).Warnf("unable to fetch current company record to check sanction status, error: %v", err)
+		return err
+	}
+	if currentCompany == nil {
+		return fmt.Errorf("company not found: %s", companyID)
+	}
+
+	// Avoid unnecessary writes - only update if value has changed
+	if currentCompany.IsSanctioned == sanctioned {
+		log.WithFields(f).Debugf("sanction status unchanged (current=%v, new=%v), skipping update", currentCompany.IsSanctioned, sanctioned)
+		return nil
+	}
+
+	log.WithFields(f).Debugf("updating sanction status from %v to %v", currentCompany.IsSanctioned, sanctioned)
+
+	_, now := utils.CurrentTime()
+
+	input := &dynamodb.UpdateItemInput{
+		ExpressionAttributeNames: map[string]*string{
+			"#S": aws.String("is_sanctioned"),
+			"#M": aws.String("date_modified"),
+		},
+		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
+			":s": {
+				BOOL: aws.Bool(sanctioned),
+			},
+			":m": {
+				S: aws.String(now),
+			},
+		},
+		TableName: aws.String(repo.companyTableName),
+		Key: map[string]*dynamodb.AttributeValue{
+			"company_id": {
+				S: aws.String(companyID),
+			},
+		},
+		UpdateExpression: aws.String("SET #S = :s, #M = :m"),
+	}
+
+	_, err = repo.dynamoDBClient.UpdateItem(input)
+	if err != nil {
+		log.WithFields(f).Warnf("error updating company sanction status, error: %v", err)
+		return err
+	}
+
+	return nil
+}
+
 func (repo repository) CreateCompany(ctx context.Context, in *models.Company) (*models.Company, error) {
 	f := logrus.Fields{
 		"functionName":      "company.repository.CreateCompany",

--- a/cla-backend-go/config/config.go
+++ b/cla-backend-go/config/config.go
@@ -98,6 +98,20 @@ type Config struct {
 
 	// DocuSignPrivateKey is the private key for the DocuSign API
 	DocuSignPrivateKey string `json:"docuSignPrivateKey"`
+
+	// SSS (Sanctions Screening Service) configuration
+	SSS SSS `json:"sss"`
+}
+
+// SSS model for Sanctions Screening Service configuration
+type SSS struct {
+	BaseURL           string `json:"base_url"`
+	Auth0Domain       string `json:"auth0_domain"`
+	Auth0ClientID     string `json:"auth0_client_id"`
+	Auth0ClientSecret string `json:"auth0_client_secret"`
+	Auth0Audience     string `json:"auth0_audience"`
+	RequestTimeoutSec int    `json:"request_timeout_sec"`
+	Required          bool   `json:"required"`
 }
 
 // Auth0 model

--- a/cla-backend-go/config/local.go
+++ b/cla-backend-go/config/local.go
@@ -23,6 +23,7 @@ func loadLocalConfig(configFilePath string) (Config, error) {
 	}
 
 	localConfig := Config{}
+	localConfig.SSS.Required = true
 	err = json.Unmarshal(content, &localConfig)
 	if err != nil {
 		return Config{}, err

--- a/cla-backend-go/config/ssm.go
+++ b/cla-backend-go/config/ssm.go
@@ -45,6 +45,7 @@ func loadSSMConfig(awsSession *session.Session, stage string) Config { //nolint
 	}
 	config := Config{}
 	config.SignatureQueryDefaultValue = "all"
+	config.SSS.Required = true
 
 	ssmClient := ssm.New(awsSession)
 
@@ -266,6 +267,15 @@ func loadSSMConfig(awsSession *session.Session, stage string) Config { //nolint
 		case fmt.Sprintf("cla-docusign-private-key-%s", stage):
 			config.DocuSignPrivateKey = resp.value
 		}
+	}
+
+	sssRequiredKey := fmt.Sprintf("cla-sss-required-%s", stage)
+	if value, err := getSSMString(ssmClient, sssRequiredKey); err != nil {
+		log.WithFields(f).WithError(err).Warnf("unable to read optional SSS required flag %s - defaulting to true", sssRequiredKey)
+	} else if boolVal, err := strconv.ParseBool(value); err != nil {
+		log.WithFields(f).WithError(err).Warnf("unable to convert %s value to a boolean - defaulting to true", sssRequiredKey)
+	} else {
+		config.SSS.Required = boolVal
 	}
 
 	return config

--- a/cla-backend-go/v2/sign/helpers.go
+++ b/cla-backend-go/v2/sign/helpers.go
@@ -145,6 +145,23 @@ func (s service) hasUserSigned(ctx context.Context, user *models.User, projectID
 			log.WithFields(f).WithError(compModelErr).Warnf("problem looking up company: %s", companyID)
 			return &hasSigned, &companyAffiliation, compModelErr
 		}
+		if companyModel == nil {
+			compModelErr = fmt.Errorf("company not found: %s", companyID)
+			log.WithFields(f).WithError(compModelErr).Warnf("company record is nil for company: %s", companyID)
+			return &hasSigned, &companyAffiliation, compModelErr
+		}
+
+		// Check if company is sanctioned before allowing ECLA acknowledgement
+		sanctioned, sanctionErr := s.checkCompanyCompliance(ctx, companyModel)
+		if sanctionErr != nil {
+			log.WithFields(f).WithError(sanctionErr).Warnf("failed to check company compliance for company: %s", companyID)
+			return &hasSigned, &companyAffiliation, sanctionErr
+		}
+		if sanctioned {
+			sanctionedErr := fmt.Errorf("company %s is sanctioned", companyID)
+			log.WithFields(f).WithError(sanctionedErr).Error("company is sanctioned")
+			return &hasSigned, &companyAffiliation, sanctionedErr
+		}
 
 		// Load the CLA Group - make sure it is valid
 		claGroupModel, claGroupModelErr := s.claGroupService.GetCLAGroup(ctx, projectID)

--- a/cla-backend-go/v2/sign/service.go
+++ b/cla-backend-go/v2/sign/service.go
@@ -28,6 +28,7 @@ import (
 	"github.com/linuxfoundation/easycla/cla-backend-go/projects_cla_groups"
 	"github.com/linuxfoundation/easycla/cla-backend-go/repositories"
 	"github.com/linuxfoundation/easycla/cla-backend-go/signatures"
+	"github.com/linuxfoundation/easycla/cla-backend-go/sss"
 	"github.com/linuxfoundation/easycla/cla-backend-go/users"
 	"github.com/linuxfoundation/easycla/cla-backend-go/v2/cla_groups"
 	gitlab_activity "github.com/linuxfoundation/easycla/cla-backend-go/v2/gitlab-activity"
@@ -117,12 +118,13 @@ type service struct {
 	gitlabActivityService gitlab_activity.Service
 	gitlabApp             *gitlab_api.App
 	gerritService         gerrits.Service
+	sssClient             *sss.Client
 }
 
 // NewService returns an instance of v2 project service
 func NewService(apiURL, v1API string, compRepo company.IRepository, projectRepo ProjectRepo, pcgRepo projects_cla_groups.Repository, compService company.IService, claGroupService cla_groups.Service, docsignPrivateKey string, userService users.Service, signatureService signatures.SignatureService, storeRepository store.Repository,
 	repositoryService repositories.Service, githubOrgService github_organizations.Service, gitlabOrgService gitlab_organizations.ServiceInterface, claLandingPage string, claLogoURL string, emailTemplateService emails.EmailTemplateService, eventsService events.Service, gitlabActivityService gitlab_activity.Service, gitlabApp *gitlab_api.App,
-	gerritService gerrits.Service) Service {
+	gerritService gerrits.Service, sssClient *sss.Client) Service {
 	return &service{
 		ClaV4ApiURL:           apiURL,
 		ClaV1ApiURL:           v1API,
@@ -145,6 +147,7 @@ func NewService(apiURL, v1API string, compRepo company.IRepository, projectRepo 
 		gitlabApp:             gitlabApp,
 		gerritService:         gerritService,
 		eventsService:         eventsService,
+		sssClient:             sssClient,
 	}
 }
 
@@ -243,14 +246,21 @@ func (s *service) RequestCorporateSignature(ctx context.Context, lfUsername stri
 	}
 
 	// 1.5 Check if company is sanctioned
-	if comp != nil && comp.IsSanctioned {
-		if input.CompanySfid != nil {
-			err = fmt.Errorf("company %s is sanctioned", *input.CompanySfid)
-		} else {
-			err = fmt.Errorf("company is sanctioned")
+	if comp != nil {
+		sanctioned, sanctionErr := s.checkCompanyCompliance(ctx, comp)
+		if sanctionErr != nil {
+			log.WithFields(f).WithError(sanctionErr).Error("failed to check company compliance")
+			return nil, sanctionErr
 		}
-		log.WithFields(f).WithError(err).Error("company is sanctioned")
-		return nil, err
+		if sanctioned {
+			if input.CompanySfid != nil {
+				err = fmt.Errorf("company %s is sanctioned", *input.CompanySfid)
+			} else {
+				err = fmt.Errorf("company is sanctioned")
+			}
+			log.WithFields(f).WithError(err).Error("company is sanctioned")
+			return nil, err
+		}
 	}
 
 	// 2. Ensure this is a valid project
@@ -2935,4 +2945,71 @@ func (s *service) GetUserActiveSignature(ctx context.Context, userID string) (*m
 		ReturnURL:      strfmt.URI(returnURL),
 		UserID:         userID,
 	}, nil
+}
+
+// checkCompanyCompliance queries the Sanctions Screening Service for the given company
+// and persists the result. Returns (sanctioned, error). A nil sssClient is a no-op.
+func (s *service) checkCompanyCompliance(ctx context.Context, company *v1Models.Company) (bool, error) {
+	f := logrus.Fields{
+		"functionName":   "sign.checkCompanyCompliance",
+		utils.XREQUESTID: ctx.Value(utils.XREQUESTID),
+		"companyID":      company.CompanyID,
+		"companyName":    company.CompanyName,
+	}
+
+	if s.sssClient == nil {
+		log.WithFields(f).Debug("SSS client not configured, skipping compliance check")
+		return false, nil
+	}
+
+	// Fetch org from organization service to get the website/domain.
+	orgClient := organizationService.GetClient()
+	org, err := orgClient.GetOrganization(ctx, company.CompanyExternalID)
+	if err != nil {
+		return false, fmt.Errorf("checkCompanyCompliance: failed to get organization %s: %w", company.CompanyExternalID, err)
+	}
+	if org == nil {
+		return false, fmt.Errorf("checkCompanyCompliance: organization record is nil for %s", company.CompanyExternalID)
+	}
+
+	if strings.TrimSpace(org.Link) == "" {
+		log.WithFields(f).Warnf("organization %s has no Link/website; skipping SSS check", company.CompanyExternalID)
+		return false, nil
+	}
+
+	// Strip protocol to get bare domain.
+	domain := org.Link
+	if idx := strings.Index(domain, "://"); idx != -1 {
+		domain = domain[idx+3:]
+	}
+	domain = strings.TrimRight(domain, "/")
+
+	req := sss.OrganizationStatusRequest{
+		Domain:  domain,
+		OrgName: company.CompanyName,
+	}
+	if strings.HasPrefix(company.CompanyExternalID, "001") {
+		req.SFDCID = company.CompanyExternalID
+	}
+
+	result, err := s.sssClient.GetOrganizationStatus(ctx, req)
+	if err != nil {
+		return false, fmt.Errorf("checkCompanyCompliance: SSS request failed for company %s: %w", company.CompanyID, err)
+	}
+
+	sanctioned := result.Status == sss.StatusFlagged
+
+	if persistErr := s.companyRepo.UpdateCompanySanctionStatus(
+		ctx,
+		company.CompanyID,
+		sanctioned,
+	); persistErr != nil {
+		return false, fmt.Errorf(
+			"failed to persist sanction status for company %s: %w",
+			company.CompanyID,
+			persistErr,
+		)
+	}
+
+	return sanctioned, nil
 }

--- a/cla-backend-go/v2/sign/service.go
+++ b/cla-backend-go/v2/sign/service.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-openapi/strfmt"
@@ -60,6 +61,7 @@ const (
 	DontLoadRepoDetails = false
 	DocSignFalse        = "false"
 	DocusignCompleted   = "Completed"
+	complianceCacheTTL  = 5 * time.Minute
 )
 
 // errors
@@ -119,12 +121,21 @@ type service struct {
 	gitlabApp             *gitlab_api.App
 	gerritService         gerrits.Service
 	sssClient             *sss.Client
+	sssRequired           bool
+	complianceCache       map[string]complianceCacheEntry
+	complianceCacheMu     sync.Mutex
+}
+
+type complianceCacheEntry struct {
+	sanctioned bool
+	err        error
+	expiresAt  time.Time
 }
 
 // NewService returns an instance of v2 project service
 func NewService(apiURL, v1API string, compRepo company.IRepository, projectRepo ProjectRepo, pcgRepo projects_cla_groups.Repository, compService company.IService, claGroupService cla_groups.Service, docsignPrivateKey string, userService users.Service, signatureService signatures.SignatureService, storeRepository store.Repository,
 	repositoryService repositories.Service, githubOrgService github_organizations.Service, gitlabOrgService gitlab_organizations.ServiceInterface, claLandingPage string, claLogoURL string, emailTemplateService emails.EmailTemplateService, eventsService events.Service, gitlabActivityService gitlab_activity.Service, gitlabApp *gitlab_api.App,
-	gerritService gerrits.Service, sssClient *sss.Client) Service {
+	gerritService gerrits.Service, sssClient *sss.Client, sssRequired bool) Service {
 	return &service{
 		ClaV4ApiURL:           apiURL,
 		ClaV1ApiURL:           v1API,
@@ -148,6 +159,8 @@ func NewService(apiURL, v1API string, compRepo company.IRepository, projectRepo 
 		gerritService:         gerritService,
 		eventsService:         eventsService,
 		sssClient:             sssClient,
+		sssRequired:           sssRequired,
+		complianceCache:       make(map[string]complianceCacheEntry),
 	}
 }
 
@@ -2962,37 +2975,69 @@ func (s *service) checkCompanyCompliance(ctx context.Context, company *v1Models.
 		"companyName":    company.CompanyName,
 	}
 
+	// Check if company is already manually sanctioned - if so, always block
+	if company.IsSanctioned {
+		log.WithFields(f).Warnf("company is manually sanctioned, blocking")
+		return true, nil
+	}
+
+	cacheKey := s.complianceCacheKey(company)
+	if cached, ok := s.getComplianceCache(cacheKey); ok {
+		log.WithFields(f).Debugf("using cached compliance result for organization/company: %s", cacheKey)
+		return cached.sanctioned, cached.err
+	}
+
 	if s.sssClient == nil {
-		log.WithFields(f).Debug("SSS client not configured, skipping compliance check")
+		log.WithFields(f).Debug("SSS client not configured, skipping live compliance check")
+		s.setComplianceCache(cacheKey, false, nil)
 		return false, nil
 	}
 
 	// Fetch org from organization service to get the website/domain.
 	orgClient := organizationService.GetClient()
+	if orgClient == nil {
+		resultErr := fmt.Errorf("checkCompanyCompliance: organization service client is not configured")
+		if !s.sssRequired {
+			log.WithFields(f).WithError(resultErr).Warn("SSS is not required; continuing without live compliance result")
+			s.setComplianceCache(cacheKey, false, nil)
+			return false, nil
+		}
+		s.setComplianceCache(cacheKey, false, resultErr)
+		return false, resultErr
+	}
 	org, err := orgClient.GetOrganization(ctx, company.CompanyExternalID)
 	if err != nil {
-		return false, fmt.Errorf("checkCompanyCompliance: failed to get organization %s: %w", company.CompanyExternalID, err)
+		log.WithFields(f).WithError(err).Warnf("failed to get organization %s for domain resolution", company.CompanyExternalID)
+		resultErr := fmt.Errorf("checkCompanyCompliance: failed to get organization %s: %w", company.CompanyExternalID, err)
+		if !s.sssRequired {
+			log.WithFields(f).WithError(resultErr).Warn("SSS is not required; continuing without live compliance result")
+			s.setComplianceCache(cacheKey, false, nil)
+			return false, nil
+		}
+		s.setComplianceCache(cacheKey, false, resultErr)
+		return false, resultErr
 	}
 	if org == nil {
-		return false, fmt.Errorf("checkCompanyCompliance: organization record is nil for %s", company.CompanyExternalID)
+		log.WithFields(f).Warnf("organization record is nil for %s", company.CompanyExternalID)
+		resultErr := fmt.Errorf("checkCompanyCompliance: organization record is nil for %s", company.CompanyExternalID)
+		if !s.sssRequired {
+			log.WithFields(f).WithError(resultErr).Warn("SSS is not required; continuing without live compliance result")
+			s.setComplianceCache(cacheKey, false, nil)
+			return false, nil
+		}
+		s.setComplianceCache(cacheKey, false, resultErr)
+		return false, resultErr
 	}
 
-	if strings.TrimSpace(org.Link) == "" {
-		log.WithFields(f).Warnf("organization %s has no Link/website; skipping SSS check", company.CompanyExternalID)
+	// Resolve domain: prefer Domains field, fallback to Link field
+	domain := s.resolveDomain(f, org)
+	if domain == "" {
+		log.WithFields(f).Warnf("unable to resolve domain for organization %s; skipping SSS check", company.CompanyExternalID)
+		s.setComplianceCache(cacheKey, false, nil)
 		return false, nil
 	}
 
-	// Parse org.Link to extract bare hostname (strips scheme, path, port, query).
-	domain := strings.TrimSpace(org.Link)
-	if u, parseErr := url.Parse(domain); parseErr == nil && u.Hostname() != "" {
-		domain = u.Hostname()
-	} else {
-		// Fallback: strip scheme and trailing slashes.
-		if idx := strings.Index(domain, "://"); idx != -1 {
-			domain = domain[idx+3:]
-		}
-		domain = strings.TrimRight(domain, "/")
-	}
+	log.WithFields(f).Debugf("resolved domain: %s for SSS check", domain)
 
 	req := sss.OrganizationStatusRequest{
 		Domain:  domain,
@@ -3004,22 +3049,170 @@ func (s *service) checkCompanyCompliance(ctx context.Context, company *v1Models.
 
 	result, err := s.sssClient.GetOrganizationStatus(ctx, req)
 	if err != nil {
-		return false, fmt.Errorf("checkCompanyCompliance: SSS request failed for company %s: %w", company.CompanyID, err)
+		blocked, handledErr := s.handleSSSError(f, company.CompanyID, err)
+		s.setComplianceCache(cacheKey, blocked, handledErr)
+		return blocked, handledErr
 	}
 
 	sanctioned := result.Status == sss.StatusFlagged
 
-	if persistErr := s.companyRepo.UpdateCompanySanctionStatus(
-		ctx,
-		company.CompanyID,
-		sanctioned,
-	); persistErr != nil {
-		return false, fmt.Errorf(
-			"failed to persist sanction status for company %s: %w",
-			company.CompanyID,
-			persistErr,
-		)
+	// Only persist if flagged (never clear a manual sanction via SSS clean result)
+	if sanctioned {
+		log.WithFields(f).Warnf("SSS returned flagged status for company %s, persisting sanction", company.CompanyID)
+		if persistErr := s.companyRepo.UpdateCompanySanctionStatus(ctx, company.CompanyID, true); persistErr != nil {
+			log.WithFields(f).WithError(persistErr).Warnf("failed to persist sanction status for company %s", company.CompanyID)
+			resultErr := fmt.Errorf("failed to persist sanction status for company %s: %w", company.CompanyID, persistErr)
+			s.setComplianceCache(cacheKey, false, resultErr)
+			return false, resultErr
+		}
+	} else {
+		log.WithFields(f).Debugf("SSS returned clean status for company %s", company.CompanyID)
 	}
 
-	return sanctioned, nil
+	// Return combined result: blocked if manually sanctioned OR sss flagged
+	blocked := company.IsSanctioned || sanctioned
+	s.setComplianceCache(cacheKey, blocked, nil)
+	return blocked, nil
+}
+
+func (s *service) complianceCacheKey(company *v1Models.Company) string {
+	if company == nil {
+		return ""
+	}
+	if key := strings.TrimSpace(company.CompanyExternalID); key != "" {
+		return key
+	}
+	return strings.TrimSpace(company.CompanyID)
+}
+
+func (s *service) getComplianceCache(key string) (complianceCacheEntry, bool) {
+	if key == "" || s.complianceCache == nil {
+		return complianceCacheEntry{}, false
+	}
+	s.complianceCacheMu.Lock()
+	defer s.complianceCacheMu.Unlock()
+
+	entry, ok := s.complianceCache[key]
+	if !ok {
+		return complianceCacheEntry{}, false
+	}
+	if time.Now().After(entry.expiresAt) {
+		delete(s.complianceCache, key)
+		return complianceCacheEntry{}, false
+	}
+	return entry, true
+}
+
+func (s *service) setComplianceCache(key string, sanctioned bool, err error) {
+	if key == "" {
+		return
+	}
+	s.complianceCacheMu.Lock()
+	defer s.complianceCacheMu.Unlock()
+	if s.complianceCache == nil {
+		s.complianceCache = make(map[string]complianceCacheEntry)
+	}
+	s.complianceCache[key] = complianceCacheEntry{
+		sanctioned: sanctioned,
+		err:        err,
+		expiresAt:  time.Now().Add(complianceCacheTTL),
+	}
+}
+
+// resolveDomain attempts to resolve the domain for an organization.
+// Priority: 1) Domains field from org (if available), 2) Parse Link field
+func (s *service) resolveDomain(f logrus.Fields, org interface{}) string {
+	if domainStruct, ok := org.(interface{ GetDomains() []string }); ok {
+		domains := domainStruct.GetDomains()
+		if len(domains) > 0 && strings.TrimSpace(domains[0]) != "" {
+			domain := strings.TrimSpace(domains[0])
+			domain = strings.TrimPrefix(domain, "www.")
+			log.WithFields(f).Debugf("resolved domain from Domains field: %s", domain)
+			return domain
+		}
+	}
+
+	if linkStruct, ok := org.(interface{ GetLink() string }); ok {
+		link := strings.TrimSpace(linkStruct.GetLink())
+		if link != "" {
+			domain := s.parseDomain(link)
+			if domain != "" {
+				return domain
+			}
+		}
+	}
+
+	return ""
+}
+
+// parseDomain extracts the hostname from a URL string.
+// If the URL lacks a scheme, it prepends https:// for parsing.
+func (s *service) parseDomain(urlStr string) string {
+	urlStr = strings.TrimSpace(urlStr)
+	if urlStr == "" {
+		return ""
+	}
+
+	// Prepend https:// if no scheme is present
+	if !strings.Contains(urlStr, "://") {
+		urlStr = "https://" + urlStr
+	}
+
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return ""
+	}
+
+	hostname := u.Hostname()
+	if hostname == "" {
+		return ""
+	}
+
+	// Strip leading www.
+	hostname = strings.TrimPrefix(hostname, "www.")
+	return hostname
+}
+
+// handleSSSError differentiates between various SSS error types and logs appropriately.
+// Returns a non-nil error for SSS failures that should block signing.
+func (s *service) handleSSSError(f logrus.Fields, companyID string, err error) (bool, error) {
+	var badReqErr *sss.BadRequestError
+	var authErr *sss.AuthError
+	var retryErr *sss.RetryableError
+	var notFoundErr *sss.NotFoundError
+	var timeoutErr *sss.TimeoutError
+	allowWhenOptional := func(message string) (bool, error) {
+		if s.sssRequired {
+			return false, fmt.Errorf("%s for company %s: %w", message, companyID, err)
+		}
+		log.WithFields(f).WithError(err).Warnf("%s for company %s; SSS is not required, continuing", message, companyID)
+		return false, nil
+	}
+
+	switch {
+	case errors.As(err, &timeoutErr):
+		log.WithFields(f).WithError(err).Warnf("SSS request timed out for company %s", companyID)
+		return allowWhenOptional("SSS screening unavailable (timeout)")
+
+	case errors.As(err, &authErr):
+		log.WithFields(f).WithError(err).Errorf("SSS authentication/configuration error for company %s", companyID)
+		return allowWhenOptional("SSS authentication error (check configuration)")
+
+	case errors.As(err, &retryErr):
+		log.WithFields(f).WithError(err).Warnf("SSS request failed with retryable error for company %s", companyID)
+		return allowWhenOptional("SSS screening unavailable (transient failure)")
+
+	case errors.As(err, &notFoundErr):
+		log.WithFields(f).WithError(err).Warnf("SSS organization not found for company %s", companyID)
+		// Not found is not a blocking error - proceed without SSS result
+		return false, nil
+
+	case errors.As(err, &badReqErr):
+		log.WithFields(f).WithError(err).Warnf("SSS bad request for company %s", companyID)
+		return false, fmt.Errorf("SSS bad request for company %s: %w", companyID, err)
+
+	default:
+		log.WithFields(f).WithError(err).Warnf("SSS request failed with unexpected error for company %s", companyID)
+		return allowWhenOptional("SSS request failed")
+	}
 }

--- a/cla-backend-go/v2/sign/service.go
+++ b/cla-backend-go/v2/sign/service.go
@@ -246,21 +246,26 @@ func (s *service) RequestCorporateSignature(ctx context.Context, lfUsername stri
 	}
 
 	// 1.5 Check if company is sanctioned
-	if comp != nil {
-		sanctioned, sanctionErr := s.checkCompanyCompliance(ctx, comp)
-		if sanctionErr != nil {
-			log.WithFields(f).WithError(sanctionErr).Error("failed to check company compliance")
-			return nil, sanctionErr
+	if comp == nil {
+		if input.CompanySfid != nil {
+			return nil, fmt.Errorf("company not found for SFID %s", *input.CompanySfid)
 		}
-		if sanctioned {
-			if input.CompanySfid != nil {
-				err = fmt.Errorf("company %s is sanctioned", *input.CompanySfid)
-			} else {
-				err = fmt.Errorf("company is sanctioned")
-			}
-			log.WithFields(f).WithError(err).Error("company is sanctioned")
-			return nil, err
+		return nil, fmt.Errorf("company not found")
+	}
+
+	sanctioned, sanctionErr := s.checkCompanyCompliance(ctx, comp)
+	if sanctionErr != nil {
+		log.WithFields(f).WithError(sanctionErr).Error("failed to check company compliance")
+		return nil, sanctionErr
+	}
+	if sanctioned {
+		if input.CompanySfid != nil {
+			err = fmt.Errorf("company %s is sanctioned", *input.CompanySfid)
+		} else {
+			err = fmt.Errorf("company is sanctioned")
 		}
+		log.WithFields(f).WithError(err).Error("company is sanctioned")
+		return nil, err
 	}
 
 	// 2. Ensure this is a valid project
@@ -2977,12 +2982,17 @@ func (s *service) checkCompanyCompliance(ctx context.Context, company *v1Models.
 		return false, nil
 	}
 
-	// Strip protocol to get bare domain.
-	domain := org.Link
-	if idx := strings.Index(domain, "://"); idx != -1 {
-		domain = domain[idx+3:]
+	// Parse org.Link to extract bare hostname (strips scheme, path, port, query).
+	domain := strings.TrimSpace(org.Link)
+	if u, parseErr := url.Parse(domain); parseErr == nil && u.Hostname() != "" {
+		domain = u.Hostname()
+	} else {
+		// Fallback: strip scheme and trailing slashes.
+		if idx := strings.Index(domain, "://"); idx != -1 {
+			domain = domain[idx+3:]
+		}
+		domain = strings.TrimRight(domain, "/")
 	}
-	domain = strings.TrimRight(domain, "/")
 
 	req := sss.OrganizationStatusRequest{
 		Domain:  domain,

--- a/cla-backend-go/v2/sign/service_sss_test.go
+++ b/cla-backend-go/v2/sign/service_sss_test.go
@@ -1,0 +1,102 @@
+// Copyright The Linux Foundation and each contributor to CommunityBridge.
+// SPDX-License-Identifier: MIT
+
+package sign
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/linuxfoundation/easycla/cla-backend-go/gen/v1/models"
+	"github.com/linuxfoundation/easycla/cla-backend-go/sss"
+	"github.com/sirupsen/logrus"
+)
+
+type testOrg struct {
+	domains []string
+	link    string
+}
+
+func (o testOrg) GetDomains() []string {
+	return o.domains
+}
+
+func (o testOrg) GetLink() string {
+	return o.link
+}
+
+func TestResolveDomainPrefersDomains(t *testing.T) {
+	svc := &service{}
+
+	got := svc.resolveDomain(logrus.Fields{}, testOrg{
+		domains: []string{"www.example.com"},
+		link:    "https://fallback.example.org/path",
+	})
+
+	if got != "example.com" {
+		t.Fatalf("expected domain from Domains field, got %q", got)
+	}
+}
+
+func TestResolveDomainFallsBackToParsedLink(t *testing.T) {
+	svc := &service{}
+
+	got := svc.resolveDomain(logrus.Fields{}, testOrg{
+		link: "www.example.org/path?query=1",
+	})
+
+	if got != "example.org" {
+		t.Fatalf("expected parsed Link hostname, got %q", got)
+	}
+}
+
+func TestHandleSSSErrorRequiredBlocksAvailabilityErrors(t *testing.T) {
+	svc := &service{sssRequired: true}
+
+	_, err := svc.handleSSSError(logrus.Fields{}, "company-id", &sss.RetryableError{Message: "unavailable"})
+	if err == nil {
+		t.Fatal("expected required SSS retryable error to block")
+	}
+}
+
+func TestHandleSSSErrorOptionalAllowsAvailabilityErrors(t *testing.T) {
+	svc := &service{sssRequired: false}
+
+	blocked, err := svc.handleSSSError(logrus.Fields{}, "company-id", &sss.AuthError{Message: "auth failed"})
+	if err != nil {
+		t.Fatalf("expected optional SSS auth error to continue, got %v", err)
+	}
+	if blocked {
+		t.Fatal("expected optional SSS auth error not to block")
+	}
+}
+
+func TestComplianceCacheKeyPrefersExternalID(t *testing.T) {
+	svc := &service{}
+
+	got := svc.complianceCacheKey(&models.Company{
+		CompanyID:         "internal-id",
+		CompanyExternalID: "external-id",
+	})
+
+	if got != "external-id" {
+		t.Fatalf("expected external id cache key, got %q", got)
+	}
+}
+
+func TestComplianceCacheExpires(t *testing.T) {
+	svc := &service{
+		complianceCache: map[string]complianceCacheEntry{
+			"company-id": {
+				sanctioned: true,
+				err:        errors.New("cached"),
+				expiresAt:  time.Now().Add(-time.Second),
+			},
+		},
+	}
+
+	if _, ok := svc.getComplianceCache("company-id"); ok {
+		t.Fatal("expected expired cache entry to be ignored")
+	}
+}


### PR DESCRIPTION
## Summary

Add SSS (Sanctions Screening Service) enforcement to signing flows and address review feedback around sanction handling, rollout safety, and performance.

## Changes

### SSS compliance checks

* Added SSS compliance checks to signing flows in `cla-backend-go`.
* Preserve existing manual sanction behavior:

  * `is_sanctioned` remains an independent/manual block.
  * SSS can set `is_sanctioned=true`.
  * A clean SSS result never clears an existing sanction flag.
* Added explicit handling for SSS timeout, auth, retryable, and not-found errors.

### Configurable rollout

* Added `cla-sss-required-<stage>` configuration support.
* When `Required=true`, SSS availability errors fail closed.
* When `Required=false`, SSS availability errors are logged and signing proceeds.
* Definitive sanctioned results always block regardless of configuration.

### Domain resolution

* Resolve domains using:

  1. Organization `Domains`
  2. Organization `Link` as fallback
* Normalize parsed domains and strip `www.` prefixes.
* Removed unreachable code from `resolveDomain()`.

### Persistence

* Added `UpdateCompanySanctionStatus`.
* Avoid unnecessary DynamoDB writes when the value has not changed.

### Performance

* Added a small in-memory compliance cache (5 minute TTL) to avoid repeated org-service and SSS lookups for the same organization during a single execution window.

## Notes

`cla-backend-legacy` does not currently have an SSS client integration. The live SSS checks added in this change are in `cla-backend-go`.

The legacy ECLA endpoints continue to enforce the persisted `is_sanctioned` flag. Adding live SSS checks directly to the legacy ECLA flow would require separate work in `cla-backend-legacy`.

## Validation

* `gofmt` completed
* `git diff --check` passed
* Added tests covering SSS-required behavior and caching


